### PR TITLE
Fix server container wait for database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ RUN npm run build
 FROM node as runtime
 
 RUN apk add --no-cache tini=0.19.0-r0
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
+RUN chmod +x /wait
 
 # Use a non-root user for increased security.
 USER node
@@ -54,4 +56,4 @@ COPY --chown=node packages/server /home/node/server
 # Init for containers https://github.com/krallin/tini
 ENTRYPOINT [ "/sbin/tini", "--" ]
 
-CMD ["node", "bin/www"]
+CMD /wait && node bin/www

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - "3000:3000"
     environment:
       DEBUG: "speckle:*"
+      WAIT_HOSTS: database:5432, redis:6379
     env_file:
       - .env
     


### PR DESCRIPTION
When starting the server via docker-compose currently the server starts up faster than the postgres
instance. This causes the server app to crash. The fix now adds a wait script that pings the
database and the cache containers unit they properly start up. This delays the server boot until all
deps are started.

this fixes #87

