### PR TITLE
🛰 feat(telemetry): track actions & remove page track

### DIFF
--- a/packages/frontend/src/components/ListItemPersonalAccessToken.vue
+++ b/packages/frontend/src/components/ListItemPersonalAccessToken.vue
@@ -7,9 +7,9 @@
       </v-list-item-title>
       <v-list-item-subtitle class="caption">
         <b>Created:</b>
-        {{ token.createdAt | dateParse() | dateFormat("DD MMM YYYY") }}
+        {{ token.createdAt | dateParse() | dateFormat('DD MMM YYYY') }}
         <b>Last Used:</b>
-        {{ token.lastUsed | dateParse() | dateFormat("DD MMM YYYY") }}
+        {{ token.lastUsed | dateParse() | dateFormat('DD MMM YYYY') }}
         <b>Scopes:</b>
         {{ token.scopes }}
       </v-list-item-subtitle>
@@ -37,7 +37,7 @@
   </v-list-item>
 </template>
 <script>
-import gql from "graphql-tag"
+import gql from 'graphql-tag'
 
 export default {
   components: {},
@@ -54,6 +54,7 @@ export default {
   },
   methods: {
     async revokeToken() {
+      this.$matomo && this.$matomo.trackPageView('user/token/revoke')
       try {
         await this.$apollo.mutate({
           mutation: gql`
@@ -62,7 +63,7 @@ export default {
             }
           `
         })
-        this.$emit("deleted")
+        this.$emit('deleted')
         this.showRevokeConfirm = false
       } catch (e) {
         console.log(e)

--- a/packages/frontend/src/components/ListItemUserApp.vue
+++ b/packages/frontend/src/components/ListItemUserApp.vue
@@ -65,6 +65,7 @@ export default {
   },
   methods: {
     async revokeApp() {
+      this.$matomo && this.$matomo.trackPageView('user/app/revoke')
       try {
         await this.$apollo.mutate({
           mutation: gql`

--- a/packages/frontend/src/components/ServerInfoCard.vue
+++ b/packages/frontend/src/components/ServerInfoCard.vue
@@ -51,6 +51,7 @@ export default {
       this.$refs.editServerDialog.open(this.serverInfo).then((dialog) => {
         if (!dialog.result) return
         console.log(dialog)
+        this.$matomo && this.$matomo.trackPageView('server/update')
         this.$apollo
           .mutate({
             mutation: gql`

--- a/packages/frontend/src/components/UserAuthorisedApps.vue
+++ b/packages/frontend/src/components/UserAuthorisedApps.vue
@@ -112,6 +112,7 @@ export default {
     },
     async revokeAccess() {
       this.showRevokeDialog = false
+      this.$matomo && this.$matomo.trackPageView('user/app/revoke')
       await this.$apollo.mutate({
         mutation: gql`
           mutation{ appRevokeAccess(appId: "${this.appToRevoke.id}")}

--- a/packages/frontend/src/components/dialogs/BranchEditDialog.vue
+++ b/packages/frontend/src/components/dialogs/BranchEditDialog.vue
@@ -75,7 +75,7 @@ export default {
           (v && this.allBranchNames.findIndex((e) => e === v) === -1) ||
           'A branch with this name already exists',
         (v) => (v && v.length <= 25) || 'Name must be less than 25 characters',
-        (v) => (v && v.length >= 3) || 'Name must be at least 3 characters',
+        (v) => (v && v.length >= 3) || 'Name must be at least 3 characters'
       ],
       description: this.branch.description,
       isEdit: false,
@@ -113,6 +113,7 @@ export default {
   methods: {
     async deleteBranch() {
       this.loading = true
+      this.$matomo && this.$matomo.trackPageView('branch/delete')
       try {
         await this.$apollo.mutate({
           mutation: gql`
@@ -135,6 +136,7 @@ export default {
     },
     async updateBranch() {
       this.loading = true
+      this.$matomo && this.$matomo.trackPageView('branch/update')
       await this.$apollo.mutate({
         mutation: gql`
           mutation branchUpdate($params: BranchUpdateInput!) {

--- a/packages/frontend/src/components/dialogs/BranchNewDialog.vue
+++ b/packages/frontend/src/components/dialogs/BranchNewDialog.vue
@@ -58,6 +58,7 @@ export default {
   methods: {
     async createBranch() {
       this.loading = true
+      this.$matomo && this.$matomo.trackPageView('branch/create')
       await this.$apollo.mutate({
         mutation: gql`
           mutation branchCreate($params: BranchCreateInput!) {

--- a/packages/frontend/src/components/dialogs/EditStreamDialog.vue
+++ b/packages/frontend/src/components/dialogs/EditStreamDialog.vue
@@ -99,6 +99,7 @@ export default {
   methods: {
     async deleteStream() {
       this.isLoading = true
+      this.$matomo && this.$matomo.trackPageView('stream/delete')
       try {
         await this.$apollo.mutate({
           mutation: gql`
@@ -121,6 +122,7 @@ export default {
         return
       }
       this.isLoading = true
+      this.$matomo && this.$matomo.trackPageView('stream/update')
       try {
         await this.$apollo.mutate({
           mutation: gql`

--- a/packages/frontend/src/components/dialogs/NewAppDialog.vue
+++ b/packages/frontend/src/components/dialogs/NewAppDialog.vue
@@ -167,6 +167,7 @@ export default {
       this.$emit('close')
     },
     async createApp() {
+      this.$matomo && this.$matomo.trackPageView('user/app/create')
       try {
         let res = await this.$apollo.mutate({
           mutation: gql`

--- a/packages/frontend/src/components/dialogs/NewStreamDialog.vue
+++ b/packages/frontend/src/components/dialogs/NewStreamDialog.vue
@@ -153,6 +153,7 @@ export default {
         return
       }
       this.isLoading = true
+      this.$matomo && this.$matomo.trackPageView('stream/create')
       try {
         let res = await this.$apollo.mutate({
           mutation: gql`

--- a/packages/frontend/src/components/dialogs/StreamDescriptionDialog.vue
+++ b/packages/frontend/src/components/dialogs/StreamDescriptionDialog.vue
@@ -73,6 +73,7 @@ export default {
   methods: {
     async save() {
       this.loading = true
+      this.$matomo && this.$matomo.trackPageView('stream/update')
       try {
         await this.$apollo.mutate({
           mutation: gql`

--- a/packages/frontend/src/components/dialogs/StreamShareDialog.vue
+++ b/packages/frontend/src/components/dialogs/StreamShareDialog.vue
@@ -160,6 +160,7 @@ export default {
   methods: {
     async removeUser(user) {
       this.loading = true
+      this.$matomo && this.$matomo.trackPageView('stream/remove-collaborator')
       try {
         await this.$apollo.mutate({
           mutation: gql`
@@ -201,6 +202,7 @@ export default {
       this.$apollo.queries.stream.refetch()
     },
     async grantPermissionUser(user) {
+      this.$matomo && this.$matomo.trackPageView('stream/add-collaborator')
       try {
         await this.$apollo.mutate({
           mutation: gql`

--- a/packages/frontend/src/components/dialogs/TokenDialog.vue
+++ b/packages/frontend/src/components/dialogs/TokenDialog.vue
@@ -113,6 +113,7 @@ export default {
       this.$emit('close')
     },
     async createToken() {
+      this.$matomo && this.$matomo.trackPageView('user/token/create')
       try {
         let res = await this.$apollo.mutate({
           mutation: gql`

--- a/packages/frontend/src/components/dialogs/UserDialog.vue
+++ b/packages/frontend/src/components/dialogs/UserDialog.vue
@@ -65,6 +65,7 @@ export default {
   watch: {},
   methods: {
     async updateUser() {
+      this.$matomo && this.$matomo.trackPageView('user/update')
       try {
         this.isLoading = true
         await this.$apollo.mutate({

--- a/packages/frontend/src/views/Branch.vue
+++ b/packages/frontend/src/views/Branch.vue
@@ -123,6 +123,7 @@ export default {
       this.$refs.commitDialog.open(this.stream.commit, this.stream.id).then((dialog) => {
         if (!dialog.result) return
 
+        this.$matomo && this.$matomo.trackPageView('branch/update')
         this.$apollo
           .mutate({
             mutation: gql`

--- a/packages/frontend/src/views/Commit.vue
+++ b/packages/frontend/src/views/Commit.vue
@@ -137,6 +137,7 @@ export default {
       this.$refs.commitDialog.open(this.stream.commit, this.stream.id).then((dialog) => {
         if (!dialog.result) return
 
+        this.$matomo && this.$matomo.trackPageView('commit/update')
         this.$apollo
           .mutate({
             mutation: gql`

--- a/packages/frontend/src/views/StreamMain.vue
+++ b/packages/frontend/src/views/StreamMain.vue
@@ -209,7 +209,6 @@ export default {
     }
   },
   mounted() {
-    this.$matomo && this.$matomo.trackPageView('streams/single')
     this.$apollo.queries.branches.refetch()
     this.$apollo.queries.description.refetch()
     this.$apollo.queries.commits.refetch()

--- a/packages/frontend/src/views/Streams.vue
+++ b/packages/frontend/src/views/Streams.vue
@@ -64,9 +64,6 @@ export default {
   }),
   computed: {},
   watch: {},
-  mounted() {
-    this.$matomo && this.$matomo.trackPageView('streams')
-  },
   methods: {
     infiniteHandler($state) {
       this.$apollo.queries.streams.fetchMore({
@@ -96,6 +93,7 @@ export default {
     newStream() {
       this.$refs.streamDialog.open().then((dialog) => {
         if (!dialog.result) return
+        this.$matomo && this.$matomo.trackPageView('stream/create')
         this.$apollo
           .mutate({
             mutation: gql`


### PR DESCRIPTION
adds tracking in the frontend for all the stuff you'd expect and removes redundant tracking for pages that don't need it

we're now tracking

- streams: create, update, and delete
- branches: create, update, and delete
- commits: update
- user: update
- apps: create and delete
- tokens: create and delete