### PR TITLE
Frontend: Viewer can now be embedded in iframe.

### DIFF
--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -1,4 +1,4 @@
-<template>
+<template lang="html">
   <router-view></router-view>
 </template>
 <script>

--- a/packages/frontend/src/components/Renderer.vue
+++ b/packages/frontend/src/components/Renderer.vue
@@ -389,7 +389,6 @@ export default {
     load() {
       if (!this.objectUrl) return
       this.hasLoadedModel = true
-      console.log('loading model', this.objectUrl)
       window.__viewer.loadObject(this.objectUrl)
       window.__viewerLastLoadedUrl = this.objectUrl
 
@@ -405,7 +404,7 @@ export default {
       navigator.clipboard.writeText(this.embedUrl).then(() => console.log('Copied embed URL'))
     },
     copyIFrame() {
-      var frameCode = `<iframe src="${this.embedUrl}" title=""></iframe>`
+      var frameCode = `<iframe src="${this.embedUrl}" width=600 height=400></iframe>`
       navigator.clipboard.writeText(frameCode).then(() => console.log('Copied embed URL'))
     }
   }

--- a/packages/frontend/src/components/Renderer.vue
+++ b/packages/frontend/src/components/Renderer.vue
@@ -59,7 +59,23 @@
           Speckle
         </v-btn>
       </div>
-      <div v-if="embeded" class="top-right ma-2">
+
+      <div v-if="embeded" class="top-right ma-2 d-flex">
+        <ApolloQuery :query="streamQuery" :variables="{ id: $route.params.streamId }" class="">
+          <template v-slot="{ result: { loading, error, data } }">
+            <!-- Loading -->
+            <div v-if="loading" class="loading apollo">Loading...</div>
+
+            <!-- Error -->
+            <div v-else-if="error" class="error apollo">An error occurred</div>
+
+            <!-- Result -->
+            <div v-else-if="data" class="result apollo">{{ data.stream.name }}</div>
+
+            <!-- No result -->
+            <div v-else class="no-result apollo">No result :(</div>
+          </template>
+        </ApolloQuery>
         <v-btn color="primary" small :href="url" target="blank">View in Speckle.xyz</v-btn>
       </div>
 
@@ -227,6 +243,7 @@
 import throttle from 'lodash.throttle'
 import { Viewer } from '@speckle/viewer'
 import ObjectSimpleViewer from './ObjectSimpleViewer'
+import StreamQuery from '../graphql/stream.gql'
 
 export default {
   components: { ObjectSimpleViewer },
@@ -250,6 +267,7 @@ export default {
   },
   data() {
     return {
+      streamQuery: StreamQuery,
       hasLoadedModel: false,
       loadProgress: 0,
       fullScreen: false,

--- a/packages/frontend/src/components/Renderer.vue
+++ b/packages/frontend/src/components/Renderer.vue
@@ -288,9 +288,10 @@ export default {
       this.setupEvents()
     }
     if (this.$route.query.embed) {
-      console.warn('EMBED MODE!!')
       this.fullScreen = true
       this.embeded = true
+      //TODO: Remove overflow from window
+      document.body.classList.add('no-scrollbar')
     }
   },
   beforeDestroy() {
@@ -377,6 +378,10 @@ export default {
 }
 </script>
 <style>
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 #rendererparent {
   position: relative;
   display: inline-block;

--- a/packages/frontend/src/components/Renderer.vue
+++ b/packages/frontend/src/components/Renderer.vue
@@ -69,8 +69,8 @@
         class="pa-0 text-center transparent elevation-0 pb-3"
       >
         <!--  -->
-        <v-btn-toggle class="elevation-0">
-          <v-menu v-if="!embeded" top close-on-click offset-y style="z-index: 100">
+        <v-btn-toggle class="elevation-0" style="z-index: 100">
+          <v-menu v-if="!embeded" top close-on-click offset-y>
             <template #activator="{ on: onMenu, attrs: menuAttrs }">
               <v-tooltip top>
                 <template #activator="{ on: onTooltip, attrs: tooltipAttrs }">

--- a/packages/frontend/src/components/Renderer.vue
+++ b/packages/frontend/src/components/Renderer.vue
@@ -1,4 +1,4 @@
-<template>
+<template lang="html">
   <v-sheet style="height: 100%" class="transparent">
     <v-alert
       v-show="showAlert"
@@ -64,8 +64,22 @@
           <v-menu top close-on-click offset-y style="z-index: 100">
             <template #activator="{ on, attrs }">
               <v-btn :small="!fullScreen" dark text color="primary" v-bind="attrs" v-on="on">
-                <v-icon small class="mr-1">mdi-camera-outline</v-icon>
-                Views
+                Share
+              </v-btn>
+            </template>
+            <v-list dense>
+              <v-list-item @click="copyIFrame">
+                <v-list-item-title>Copy iframe</v-list-item-title>
+              </v-list-item>
+              <v-list-item @click="copyEmbedUrl">
+                <v-list-item-title>Copy URL</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+          <v-menu top close-on-click offset-y style="z-index: 100">
+            <template #activator="{ on, attrs }">
+              <v-btn :small="!fullScreen" dark text color="primary" v-bind="attrs" v-on="on">
+                Set View
               </v-btn>
             </template>
             <v-list dense>
@@ -108,7 +122,7 @@
             </template>
             Show / Hide Section plane
           </v-tooltip>
-          <v-tooltip top>
+          <v-tooltip top v-if="!embeded">
             <template #activator="{ on, attrs }">
               <v-btn
                 :small="!fullScreen"
@@ -206,6 +220,7 @@ export default {
       hasLoadedModel: false,
       loadProgress: 0,
       fullScreen: false,
+      embeded: false,
       showHelp: false,
       alertMessage: null,
       showAlert: false,
@@ -218,6 +233,9 @@ export default {
   computed: {
     darkMode() {
       return this.$vuetify.theme.dark
+    },
+    embedUrl() {
+      return window.location.href + '?embed=true'
     }
   },
   watch: {
@@ -268,6 +286,11 @@ export default {
       this.hasLoadedModel = true
       this.loadProgress = 100
       this.setupEvents()
+    }
+    if (this.$route.query.embed) {
+      console.warn('EMBED MODE!!')
+      this.fullScreen = true
+      this.embeded = true
     }
   },
   beforeDestroy() {
@@ -342,6 +365,13 @@ export default {
       this.hasLoadedModel = false
       this.loadProgress = 0
       this.namedViews.splice(0, this.namedViews.length)
+    },
+    copyEmbedUrl() {
+      navigator.clipboard.writeText(this.embedUrl).then(() => console.log('Copied embed URL'))
+    },
+    copyIFrame() {
+      var frameCode = `<iframe src="${this.embedUrl}" title=""></iframe>`
+      navigator.clipboard.writeText(frameCode).then(() => console.log('Copied embed URL'))
     }
   }
 }

--- a/packages/frontend/src/components/Renderer.vue
+++ b/packages/frontend/src/components/Renderer.vue
@@ -45,40 +45,6 @@
         style="position: absolute; width: 80%; left: 10%; opacity: 0.5"
       ></v-progress-linear>
 
-      <div v-if="embeded" class="top-left ma-2">
-        <v-btn
-          text
-          small
-          color="primary"
-          elevation="0"
-          href="http://speckle.systems"
-          target="blank"
-        >
-          Powered by
-          <img src="@/assets/logo.svg" height="16" />
-          Speckle
-        </v-btn>
-      </div>
-
-      <div v-if="embeded" class="top-right ma-2 d-flex">
-        <ApolloQuery :query="streamQuery" :variables="{ id: $route.params.streamId }" class="">
-          <template v-slot="{ result: { loading, error, data } }">
-            <!-- Loading -->
-            <div v-if="loading" class="loading apollo">Loading...</div>
-
-            <!-- Error -->
-            <div v-else-if="error" class="error apollo">An error occurred</div>
-
-            <!-- Result -->
-            <div v-else-if="data" class="result apollo">{{ data.stream.name }}</div>
-
-            <!-- No result -->
-            <div v-else class="no-result apollo">No result :(</div>
-          </template>
-        </ApolloQuery>
-        <v-btn color="primary" small :href="url" target="blank">View in Speckle.xyz</v-btn>
-      </div>
-
       <v-card
         v-show="hasLoadedModel && loadProgress >= 99"
         style="position: absolute; bottom: 0px; z-index: 2; width: 100%"
@@ -263,6 +229,10 @@ export default {
     showSelectionHelper: {
       type: Boolean,
       default: false
+    },
+    embeded: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -271,7 +241,6 @@ export default {
       hasLoadedModel: false,
       loadProgress: 0,
       fullScreen: false,
-      embeded: false,
       showHelp: false,
       alertMessage: null,
       showAlert: false,
@@ -343,7 +312,6 @@ export default {
     }
     if (this.$route.query.embed) {
       this.fullScreen = true
-      this.embeded = true
       //TODO: Remove overflow from window
       document.body.classList.add('no-scrollbar')
     }
@@ -409,7 +377,7 @@ export default {
     load() {
       if (!this.objectUrl) return
       this.hasLoadedModel = true
-
+      console.log('loading model', this.objectUrl)
       window.__viewer.loadObject(this.objectUrl)
       window.__viewerLastLoadedUrl = this.objectUrl
 
@@ -432,10 +400,6 @@ export default {
 }
 </script>
 <style>
-.no-scrollbar::-webkit-scrollbar {
-  display: none;
-}
-
 .top-left {
   position: absolute;
   top: 0;

--- a/packages/frontend/src/components/Renderer.vue
+++ b/packages/frontend/src/components/Renderer.vue
@@ -255,10 +255,22 @@ export default {
       return this.$vuetify.theme.dark
     },
     url() {
-      return window.location.origin + this.$route.path
+      var stream = this.$route.params.streamId
+      var base = `${window.location.origin}/embed?stream=${stream}`
+
+      var object = this.$route.params.objectId
+      if (object) return base + `&object=${object}`
+
+      var commit = this.$route.params.commitId
+      if (commit) return base + `&commit=${commit}`
+
+      var branch = this.$route.params.branchName
+      if (branch) return base + `&branch=${encodeURI(branch)}`
+
+      return base
     },
     embedUrl() {
-      return this.url + '?embed=true'
+      return this.url
     }
   },
   watch: {

--- a/packages/frontend/src/components/Renderer.vue
+++ b/packages/frontend/src/components/Renderer.vue
@@ -401,11 +401,15 @@ export default {
       this.namedViews.splice(0, this.namedViews.length)
     },
     copyEmbedUrl() {
-      navigator.clipboard.writeText(this.embedUrl).then(() => console.log('Copied embed URL'))
+      navigator.clipboard.writeText(this.embedUrl).then(() => {
+        //TODO: Show vuetify notification
+      })
     },
     copyIFrame() {
       var frameCode = `<iframe src="${this.embedUrl}" width=600 height=400></iframe>`
-      navigator.clipboard.writeText(frameCode).then(() => console.log('Copied embed URL'))
+      navigator.clipboard.writeText(frameCode).then(() => {
+        //TODO: Show vuetify notification
+      })
     }
   }
 }

--- a/packages/frontend/src/components/Renderer.vue
+++ b/packages/frontend/src/components/Renderer.vue
@@ -44,6 +44,25 @@
         class="vertical-center elevation-10"
         style="position: absolute; width: 80%; left: 10%; opacity: 0.5"
       ></v-progress-linear>
+
+      <div v-if="embeded" class="top-left ma-2">
+        <v-btn
+          text
+          small
+          color="primary"
+          elevation="0"
+          href="http://speckle.systems"
+          target="blank"
+        >
+          Powered by
+          <img src="@/assets/logo.svg" height="16" />
+          Speckle
+        </v-btn>
+      </div>
+      <div v-if="embeded" class="top-right ma-2">
+        <v-btn color="primary" small :href="url" target="blank">View in Speckle.xyz</v-btn>
+      </div>
+
       <v-card
         v-show="hasLoadedModel && loadProgress >= 99"
         style="position: absolute; bottom: 0px; z-index: 2; width: 100%"
@@ -51,21 +70,21 @@
       >
         <!--  -->
         <v-btn-toggle class="elevation-0">
-          <v-btn
-            v-show="selectedObjects.length !== 0 && (showSelectionHelper || fullScreen)"
-            :small="!fullScreen"
-            dark
-            text
-            color="primary"
-            @click="showObjectDetails = !showObjectDetails"
-          >
-            Selection Details ({{ selectedObjects.length }})
-          </v-btn>
-          <v-menu top close-on-click offset-y style="z-index: 100">
-            <template #activator="{ on, attrs }">
-              <v-btn :small="!fullScreen" dark text color="primary" v-bind="attrs" v-on="on">
-                Share
-              </v-btn>
+          <v-menu v-if="!embeded" top close-on-click offset-y style="z-index: 100">
+            <template #activator="{ on: onMenu, attrs: menuAttrs }">
+              <v-tooltip top>
+                <template #activator="{ on: onTooltip, attrs: tooltipAttrs }">
+                  <v-btn
+                    small
+                    v-bind="{ ...tooltipAttrs, ...menuAttrs }"
+                    v-on="{ ...onTooltip, ...onMenu }"
+                    @click="zoomEx()"
+                  >
+                    <v-icon small>mdi-share-variant</v-icon>
+                  </v-btn>
+                </template>
+                Embed 3D Viewer
+              </v-tooltip>
             </template>
             <v-list dense>
               <v-list-item @click="copyIFrame">
@@ -76,12 +95,31 @@
               </v-list-item>
             </v-list>
           </v-menu>
+          <v-btn
+            v-show="selectedObjects.length !== 0 && (showSelectionHelper || fullScreen)"
+            small
+            color="primary"
+            @click="showObjectDetails = !showObjectDetails"
+          >
+            Selection Details ({{ selectedObjects.length }})
+          </v-btn>
           <v-menu top close-on-click offset-y style="z-index: 100">
-            <template #activator="{ on, attrs }">
-              <v-btn :small="!fullScreen" dark text color="primary" v-bind="attrs" v-on="on">
-                Set View
-              </v-btn>
+            <template #activator="{ on: onMenu, attrs: menuAttrs }">
+              <v-tooltip top>
+                <template #activator="{ on: onTooltip, attrs: tooltipAttrs }">
+                  <v-btn
+                    small
+                    v-bind="{ ...tooltipAttrs, ...menuAttrs }"
+                    v-on="{ ...onTooltip, ...onMenu }"
+                    @click="zoomEx()"
+                  >
+                    <v-icon small>mdi-camera</v-icon>
+                  </v-btn>
+                </template>
+                Select view
+              </v-tooltip>
             </template>
+
             <v-list dense>
               <v-list-item @click="setView('top')">
                 <v-list-item-title>Top</v-list-item-title>
@@ -108,7 +146,7 @@
 
           <v-tooltip top>
             <template #activator="{ on, attrs }">
-              <v-btn :small="!fullScreen" v-bind="attrs" v-on="on" @click="zoomEx()">
+              <v-btn v-bind="attrs" v-on="on" small @click="zoomEx()">
                 <v-icon small>mdi-cube-scan</v-icon>
               </v-btn>
             </template>
@@ -116,20 +154,15 @@
           </v-tooltip>
           <v-tooltip top>
             <template #activator="{ on, attrs }">
-              <v-btn :small="!fullScreen" v-bind="attrs" @click="sectionToggle()" v-on="on">
+              <v-btn v-bind="attrs" small @click="sectionToggle()" v-on="on">
                 <v-icon small>mdi-scissors-cutting</v-icon>
               </v-btn>
             </template>
             Show / Hide Section plane
           </v-tooltip>
-          <v-tooltip top v-if="!embeded">
+          <v-tooltip v-if="!embeded" top>
             <template #activator="{ on, attrs }">
-              <v-btn
-                :small="!fullScreen"
-                v-bind="attrs"
-                @click="fullScreen = !fullScreen"
-                v-on="on"
-              >
+              <v-btn small v-bind="attrs" @click="fullScreen = !fullScreen" v-on="on">
                 <v-icon small>{{ fullScreen ? 'mdi-fullscreen-exit' : 'mdi-fullscreen' }}</v-icon>
               </v-btn>
             </template>
@@ -137,7 +170,7 @@
           </v-tooltip>
           <v-tooltip top>
             <template #activator="{ on, attrs }">
-              <v-btn :small="!fullScreen" v-bind="attrs" @click="showHelp = !showHelp" v-on="on">
+              <v-btn v-bind="attrs" @click="showHelp = !showHelp" v-on="on" small>
                 <v-icon small>mdi-help</v-icon>
               </v-btn>
             </template>
@@ -234,8 +267,11 @@ export default {
     darkMode() {
       return this.$vuetify.theme.dark
     },
+    url() {
+      return window.location.origin + this.$route.path
+    },
     embedUrl() {
-      return window.location.href + '?embed=true'
+      return this.url + '?embed=true'
     }
   },
   watch: {
@@ -380,6 +416,20 @@ export default {
 <style>
 .no-scrollbar::-webkit-scrollbar {
   display: none;
+}
+
+.top-left {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 3;
+}
+
+.top-right {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
 }
 
 #rendererparent {

--- a/packages/frontend/src/components/SpeckleLoading.vue
+++ b/packages/frontend/src/components/SpeckleLoading.vue
@@ -1,11 +1,24 @@
 <template lang="html">
-  <div class="fixed-overlay">
-    <img src="@/assets/logo.svg" class="overlay-logo tada" />
+  <div class="fixed-overlay" :class="error ? 'primary' : 'white'">
+    <img v-if="!error" src="@/assets/logo.svg" class="overlay-logo tada" />
+    <div v-else>
+      <v-icon size="120" color="white tada">mdi-alert</v-icon>
+      <h1 class="pt-6 pb-3">Ooops! 😅</h1>
+      <h2>{{ error }}</h2>
+    </div>
   </div>
 </template>
 
 <script>
-export default {}
+export default {
+  name: 'SpeckleLoading',
+  props: {
+    error: {
+      type: String,
+      default: null
+    }
+  }
+}
 </script>
 
 <style lang="scss">
@@ -13,7 +26,6 @@ export default {}
   width: 100vw;
   height: 100vh;
   font-family: sans-serif !important;
-  background-color: white;
   z-index: 100;
   position: fixed;
   top: 0;
@@ -24,11 +36,12 @@ export default {}
   text-align: center;
   font-weight: 400;
   font-size: 10px;
+  padding-top: 200px;
 }
 
 .overlay-logo {
   max-width: 50px;
   position: relative;
-  top: 250px;
+  top: 150px;
 }
 </style>

--- a/packages/frontend/src/components/SpeckleLoading.vue
+++ b/packages/frontend/src/components/SpeckleLoading.vue
@@ -1,0 +1,34 @@
+<template lang="html">
+  <div class="fixed-overlay">
+    <img src="@/assets/logo.svg" class="overlay-logo tada" />
+  </div>
+</template>
+
+<script>
+export default {}
+</script>
+
+<style lang="scss">
+.fixed-overlay {
+  width: 100vw;
+  height: 100vh;
+  font-family: sans-serif !important;
+  background-color: white;
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+  text-align: center;
+  font-weight: 400;
+  font-size: 10px;
+}
+
+.overlay-logo {
+  max-width: 50px;
+  position: relative;
+  top: 250px;
+}
+</style>

--- a/packages/frontend/src/router/index.js
+++ b/packages/frontend/src/router/index.js
@@ -160,6 +160,11 @@ const routes = [
     component: () => import('../views/GettingStartedView.vue')
   },
   {
+    path: '/embed',
+    name: 'Embeded Viewer',
+    component: () => import('../views/EmbedViewer.vue')
+  },
+  {
     path: '*',
     name: 'notfound',
     meta: {

--- a/packages/frontend/src/router/index.js
+++ b/packages/frontend/src/router/index.js
@@ -187,6 +187,7 @@ router.beforeEach((to, from, next) => {
   if (
     !uuid &&
     !to.matched.some(({ name }) => name === 'streams') && //allow public streams to be viewed
+    to.name !== 'Embeded Viewer' &&
     to.name !== 'Login' &&
     to.name !== 'Register' &&
     to.name !== 'Error' &&

--- a/packages/frontend/src/views/EmbedViewer.vue
+++ b/packages/frontend/src/views/EmbedViewer.vue
@@ -17,35 +17,41 @@
         </v-btn>
       </div>
 
-      <div class="top-right ma-2 d-flex">
-        <v-btn
-          small
-          class="mr-5"
-          :class="{
-            success: displayType == 'commit',
-            error: displayType == 'branch',
-            warning: displayType == 'stream',
-            teal: displayType == 'object'
-          }"
-        >
-          {{ displayType }}
-        </v-btn>
-        <v-btn
-          v-if="stream && serverInfo"
-          color="primary"
-          small
-          :href="goToServerUrl"
-          target="blank"
-        >
-          View
-          <em class="pl-1 pr-1">
-            <b>
-              {{ stream.name }}
-            </b>
-          </em>
-          in
-          <em>{{ serverInfo.name }}</em>
-        </v-btn>
+      <div class="top-right ma-2 d-flex flex-column justify-end">
+        <div class="d-flex justify-end">
+          <v-btn
+            v-if="stream && serverInfo"
+            color="primary"
+            small
+            :href="goToServerUrl"
+            target="blank"
+          >
+            View
+            <em class="pl-1 pr-1">
+              <b>
+                {{ stream.name | truncate }}
+              </b>
+            </em>
+            in
+            <em>{{ serverInfo.name }}</em>
+          </v-btn>
+        </div>
+        <div class="d-flex">
+          <v-btn-toggle class="pt-2 pr-2 transparent justify-end">
+            <v-btn x-small class="primary">Stream</v-btn>
+            <v-btn x-small>
+              {{ input.stream }}
+            </v-btn>
+          </v-btn-toggle>
+          <v-btn-toggle class="pt-2 transparent justify-end">
+            <v-btn x-small class="success">
+              {{ displayType }}
+            </v-btn>
+            <v-btn x-small>
+              {{ input[displayType] | truncate }}
+            </v-btn>
+          </v-btn-toggle>
+        </div>
       </div>
       <renderer v-if="stream" :object-url="objectUrl" embeded show-selection-helper></renderer>
     </div>
@@ -59,6 +65,11 @@ import SpeckleLoading from '../components/SpeckleLoading.vue'
 export default {
   name: 'EmbedViewer',
   components: { Renderer, SpeckleLoading },
+  filters: {
+    truncate: function (str, n = 20) {
+      return str.length > n ? str.substr(0, n - 3) + '...' : str
+    }
+  },
   data() {
     return {
       error: null,

--- a/packages/frontend/src/views/EmbedViewer.vue
+++ b/packages/frontend/src/views/EmbedViewer.vue
@@ -1,0 +1,159 @@
+<template lang="html">
+  <v-app class="no-scrollbar">
+    <speckle-loading v-if="$apollo.queries.loading || error" :error="error" style="z-index: 101" />
+    <div v-else class="no-scrollbar embed-view">
+      <div class="top-left ma-2">
+        <v-btn
+          small
+          outlined
+          color="primary"
+          elevation="0"
+          href="http://speckle.systems"
+          target="blank"
+        >
+          Powered by
+          <img src="@/assets/logo.svg" height="16" />
+          Speckle
+        </v-btn>
+      </div>
+
+      <div class="top-right ma-2 d-flex">
+        <v-btn
+          v-if="$apollo.data.stream && $apollo.data.serverInfo"
+          color="primary"
+          small
+          href=""
+          target="blank"
+        >
+          View
+          <em class="pl-1 pr-1">
+            <b>
+              {{ $apollo.data.stream.name }}
+            </b>
+            ({{ $apollo.data.stream.id }})
+          </em>
+          in
+          <em>{{ $apollo.data.serverInfo.name }}</em>
+        </v-btn>
+      </div>
+      <renderer
+        v-if="input.stream"
+        :object-url="objectUrl"
+        embeded
+        show-selection-helper
+      ></renderer>
+    </div>
+  </v-app>
+</template>
+
+<script>
+import gql from 'graphql-tag'
+import Renderer from '../components/Renderer.vue'
+import SpeckleLoading from '../components/SpeckleLoading.vue'
+export default {
+  name: 'EmbedViewer',
+  components: { Renderer, SpeckleLoading },
+  data() {
+    return {
+      error: null,
+      input: {
+        stream: this.$route.query.stream,
+        object: this.$route.query.object,
+        branch: this.$route.query.branch || 'main'
+      }
+    }
+  },
+  apollo: {
+    stream: {
+      query: gql`
+        query Stream($id: String!, $branch: String!) {
+          stream(id: $id) {
+            id
+            name
+            description
+            isPublic
+            branch(name: $branch) {
+              commits(limit: 1) {
+                totalCount
+                items {
+                  referencedObject
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables() {
+        return {
+          id: this.input.stream,
+          branch: this.input.branch
+        }
+      },
+      error(err) {
+        console.error(err)
+        this.error = err
+      }
+    },
+    serverInfo: {
+      query: gql`
+        query ServerInfo {
+          serverInfo {
+            name
+          }
+        }
+      `,
+      error(err) {
+        console.error(err)
+        this.error = err
+      }
+    }
+  },
+  computed: {
+    displayType() {
+      if (!this.input.stream) {
+        return 'error'
+      }
+      if (this.input.object) return 'object'
+      if (this.input.branch) return 'branch'
+      return 'stream'
+    },
+
+    objectUrl() {
+      var objId = this.input.object || this.stream?.branch?.commits?.items[0]?.referencedObject
+
+      return `${window.location.protocol}//${window.location.host}/streams/${this.input.stream}/objects/${objId}`
+    }
+  },
+  watch: {
+    displayType(oldVal, newVal) {
+      console.log(oldVal, newVal)
+      if (newVal == 'error') this.error = 'Provided details were invalid'
+      else {
+        this.error = null
+      }
+    }
+  },
+  methods: {}
+}
+</script>
+
+<style lang="scss">
+body::-webkit-scrollbar {
+  display: none;
+}
+.embed-view {
+  height: 100vh !important;
+  width: 100vw !important;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.no-scrollbar {
+  overflow: hidden;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+</style>

--- a/packages/frontend/src/views/EmbedViewer.vue
+++ b/packages/frontend/src/views/EmbedViewer.vue
@@ -108,7 +108,6 @@ export default {
         }
       },
       error(err) {
-        console.log(err.message)
         this.error = err.message
       },
       update(data) {
@@ -146,11 +145,9 @@ export default {
         }
       },
       error(err) {
-        console.log(err.message)
         this.error = err.message
       },
       update(data) {
-        console.log('received specific comit', data, this.input.object)
         var latestCommit = data.stream.commit
         if (this.input.object === undefined) this.objectId = latestCommit.referencedObject
         return data.stream
@@ -168,7 +165,6 @@ export default {
         }
       `,
       error(err) {
-        console.error(err)
         this.error = err.message
       }
     }

--- a/packages/frontend/src/views/Stream.vue
+++ b/packages/frontend/src/views/Stream.vue
@@ -1,6 +1,5 @@
 <template>
   <v-container :fluid="$vuetify.breakpoint.lgAndDown">
-    <speckle-loading v-if="$route.query.embed && !stream" />
     <v-row v-if="stream">
       <v-col cols="12" sm="12" md="4" lg="3" xl="3">
         <sidebar-stream :user-role="userRole"></sidebar-stream>
@@ -51,15 +50,13 @@ import ErrorBlock from '../components/ErrorBlock'
 import streamQuery from '../graphql/stream.gql'
 import gql from 'graphql-tag'
 import StreamInviteDialog from '../components/dialogs/StreamInviteDialog'
-import SpeckleLoading from '../components/SpeckleLoading.vue'
 
 export default {
   name: 'Stream',
   components: {
     SidebarStream,
     ErrorBlock,
-    StreamInviteDialog,
-    SpeckleLoading
+    StreamInviteDialog
   },
   data() {
     return {

--- a/packages/frontend/src/views/Stream.vue
+++ b/packages/frontend/src/views/Stream.vue
@@ -44,6 +44,7 @@
     <stream-invite-dialog v-if="stream" ref="streamInviteDialog" :stream-id="stream.id" />
   </v-container>
 </template>
+
 <script>
 import SidebarStream from '../components/SidebarStream'
 import ErrorBlock from '../components/ErrorBlock'

--- a/packages/frontend/src/views/Stream.vue
+++ b/packages/frontend/src/views/Stream.vue
@@ -1,5 +1,6 @@
 <template>
   <v-container :fluid="$vuetify.breakpoint.lgAndDown">
+    <speckle-loading v-if="$route.query.embed && !stream" />
     <v-row v-if="stream">
       <v-col cols="12" sm="12" md="4" lg="3" xl="3">
         <sidebar-stream :user-role="userRole"></sidebar-stream>
@@ -49,13 +50,15 @@ import ErrorBlock from '../components/ErrorBlock'
 import streamQuery from '../graphql/stream.gql'
 import gql from 'graphql-tag'
 import StreamInviteDialog from '../components/dialogs/StreamInviteDialog'
+import SpeckleLoading from '../components/SpeckleLoading.vue'
 
 export default {
   name: 'Stream',
   components: {
     SidebarStream,
     ErrorBlock,
-    StreamInviteDialog
+    StreamInviteDialog,
+    SpeckleLoading
   },
   data() {
     return {

--- a/packages/frontend/src/views/StreamMain.vue
+++ b/packages/frontend/src/views/StreamMain.vue
@@ -1,7 +1,5 @@
 <template>
   <v-row v-if="!error">
-    <!-- Only show loading component when embeded to prevent showing page -->
-    <speckle-loading v-if="$route.query.embed && $apollo.queries.branches.loading" />
     <v-col sm="12">
       <v-card v-if="$apollo.queries.branches.loading">
         <v-skeleton-loader type="card-heading, card-avatar, article"></v-skeleton-loader>
@@ -195,7 +193,7 @@ import streamBranchesQuery from '../graphql/streamBranches.gql'
 import Renderer from '../components/Renderer'
 import UserAvatar from '../components/UserAvatar'
 import ErrorBlock from '../components/ErrorBlock'
-import SpeckleLoading from '../components/SpeckleLoading.vue'
+
 export default {
   name: 'StreamMain',
   components: {
@@ -204,8 +202,7 @@ export default {
     SourceAppAvatar,
     NoDataPlaceholder,
     Renderer,
-    ErrorBlock,
-    SpeckleLoading
+    ErrorBlock
   },
   props: {
     userRole: {

--- a/packages/frontend/src/views/StreamMain.vue
+++ b/packages/frontend/src/views/StreamMain.vue
@@ -1,5 +1,7 @@
 <template>
   <v-row v-if="!error">
+    <!-- Only show loading component when embeded to prevent showing page -->
+    <speckle-loading v-if="$route.query.embed && $apollo.queries.branches.loading" />
     <v-col sm="12">
       <v-card v-if="$apollo.queries.branches.loading">
         <v-skeleton-loader type="card-heading, card-avatar, article"></v-skeleton-loader>
@@ -193,7 +195,7 @@ import streamBranchesQuery from '../graphql/streamBranches.gql'
 import Renderer from '../components/Renderer'
 import UserAvatar from '../components/UserAvatar'
 import ErrorBlock from '../components/ErrorBlock'
-
+import SpeckleLoading from '../components/SpeckleLoading.vue'
 export default {
   name: 'StreamMain',
   components: {
@@ -202,7 +204,8 @@ export default {
     SourceAppAvatar,
     NoDataPlaceholder,
     Renderer,
-    ErrorBlock
+    ErrorBlock,
+    SpeckleLoading
   },
   props: {
     userRole: {


### PR DESCRIPTION
Viewer can now be embedded!! 🥳 It should work with public streams AND private streams **if** you are already logged in to the server (@didimitrie is this ok or is it bad security practice??)


**How does it work?**

Embed mode lives in it's own route => `YOUR_SERVER_URL/embed`. This route also accepts several query parameters:
- **stream**: The stream ID of the object to display
- **branch (optional)**: The branch to fetch the objects from
- **commit (optional)**: The specific commit id to display
- **object (optional)**: The specific object id to display

**IMPORTANT**: Do note that all optional parameters are mutually exclusive. Object has higher priority than commit and higher than branch

In any stream page, you can get the appropriate embed URL and iframe code from the Viewer toolbar:

<img width="425" alt="Screenshot 2021-05-14 at 09 35 52" src="https://user-images.githubusercontent.com/2316535/118237623-c9955300-b497-11eb-82c1-11f65b2e2e31.png">

Embed mode will also display stream name and branch/object/commit where appropriate.

<img width="622" alt="Screenshot 2021-05-14 at 09 26 59" src="https://user-images.githubusercontent.com/2316535/118236640-98685300-b496-11eb-8c67-f7ae5ad408dd.png">
