### PR TITLE
fix(viewer): Adds box conversion to buffer geometry

### DIFF
--- a/packages/viewer/src/modules/Converter.js
+++ b/packages/viewer/src/modules/Converter.js
@@ -91,6 +91,7 @@ export default class Coverter {
     // Last attempt: iterate through all object keys and see if we can display anything!
     // traverses the object in case there's any sub-objects we can convert.
     for ( let prop in target ) {
+      if ( prop === 'bbox' ) continue
       if ( typeof target[prop] !== 'object' ) continue
       let childPromise = this.traverseAndConvert( target[prop], callback, scale )
       childrenConversionPromisses.push( childPromise )

--- a/packages/viewer/src/modules/Converter.js
+++ b/packages/viewer/src/modules/Converter.js
@@ -363,6 +363,20 @@ export default class Coverter {
     return new ObjectWrapper( geometry, obj, 'line' )
   }
 
+  async BoxToBufferGeometry( object, scale = true ){
+    let conversionFactor = scale ? getConversionFactor( object.units ) : 1
+
+    var move = this.PointToVector3( object.basePlane.origin )
+    var width = ( object.xSize.end - object.xSize.start ) * conversionFactor
+    var depth = ( object.ySize.end - object.ySize.start ) * conversionFactor
+    var height = ( object.zSize.end - object.zSize.start ) * conversionFactor
+
+    var box = new THREE.BoxBufferGeometry( width,height,depth,1,1,1 )
+    box.applyMatrix4( new THREE.Matrix4().setPosition( move ) )
+    
+    return new ObjectWrapper( box, object )
+  }
+
   async PolycurveToBufferGeometry( object, scale = true ) {
     let obj = {}
     Object.assign( obj, object )


### PR DESCRIPTION
Fixes #270

Added `BoxToBufferGeometry` method in `converter.js`

Tested with several boxes of various units and positons.

Also opened some pre-existing complex streams to ensure no bboxes were being rendered as a side effect of this.