### PR TITLE
fix(frontend): globals permisisons

### DIFF
--- a/packages/frontend/src/components/GlobalsBuilder.vue
+++ b/packages/frontend/src/components/GlobalsBuilder.vue
@@ -42,10 +42,9 @@
         reset all
       </v-btn>
       <v-btn
-        v-if="userRole === 'contributor' || userRole === 'owner'"
         v-tooltip="'Save your changes with a message'"
         small
-        :disabled="!globalsAreValid"
+        :disabled="!canSave"
         color="primary"
         @click="
           saveDialog = true
@@ -150,6 +149,9 @@ export default {
     }
   },
   computed: {
+    canSave() {
+      return this.globalsAreValid && (this.userRole === 'contributor' || this.userRole === 'owner')
+    },
     globalsCommit() {
       // eslint-disable-next-line vue/no-side-effects-in-computed-properties
       this.globalsAreValid = true

--- a/packages/frontend/src/views/Globals.vue
+++ b/packages/frontend/src/views/Globals.vue
@@ -6,13 +6,30 @@
           <v-progress-linear indeterminate></v-progress-linear>
         </template>
         <v-card-title>You don't have any globals on this stream!</v-card-title>
-        <v-card-text class="subtitle-1">
+        <v-card-text
+          v-if="$attrs['user-role'] === 'contributor' || $attrs['user-role'] === 'owner'"
+          class="subtitle-1"
+        >
           Globals are useful for storing design values, project requirements, notes, or any info you
           want to keep track of alongside your geometry. Would you like to create some now?
         </v-card-text>
+        <v-card-text
+          v-if="!($attrs['user-role'] === 'contributor') && !($attrs['user-role'] === 'owner')"
+          class="subtitle-1"
+        >
+          Globals are useful for storing design values, project requirements, notes, or any info you
+          want to keep track of alongside your geometry. You don't have permission to create and
+          edit globals on this stream, but you can create your own stream to try them out!
+        </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn color="primary" @click="createClicked">create globals</v-btn>
+          <v-btn
+            v-if="$attrs['user-role'] === 'contributor' || $attrs['user-role'] === 'owner'"
+            color="primary"
+            @click="createClicked"
+          >
+            create globals
+          </v-btn>
         </v-card-actions>
       </v-card>
     </div>

--- a/packages/frontend/src/views/StreamMain.vue
+++ b/packages/frontend/src/views/StreamMain.vue
@@ -90,33 +90,27 @@
             </v-list>
           </v-menu>
           <div
-            v-if="
-              stream &&
-              stream.commit &&
-              selectedBranch.name == 'main' &&
-              stream.commit.branchName != 'main' &&
-              stream.commit.branchName != selectedBranch.name
-            "
+            v-if="commitNotif && selectedBranch.name == 'main' && commitNotif.branchName != 'main'"
             class="pb-2 caption"
           >
             <v-alert color="primary" class="caption" dense text type="info">
-              The last commit of this stream is on the
+              The last commitNotif of this stream is on the
               <v-btn
                 text
                 x-small
                 color="primary darken-1"
-                :to="'/streams/' + $route.params.streamId + '/branches/' + stream.commit.branchName"
+                :to="'/streams/' + $route.params.streamId + '/branches/' + commitNotif.branchName"
               >
-                {{ stream.commit.branchName }}
+                {{ commitNotif.branchName }}
               </v-btn>
               branch, see
               <v-btn
                 x-small
                 text
                 color="primary  darken-1"
-                :to="'/streams/' + $route.params.streamId + '/commits/' + stream.commit.id"
+                :to="'/streams/' + $route.params.streamId + '/commits/' + commitNotif.id"
               >
-                {{ stream.commit.message }}
+                {{ commitNotif.message }}
               </v-btn>
             </v-alert>
           </div>
@@ -315,7 +309,7 @@ export default {
     },
     description: {
       query: gql`
-        query($id: String!) {
+        query ($id: String!) {
           stream(id: $id) {
             id
             description
@@ -329,15 +323,17 @@ export default {
       },
       update: (data) => data.stream.description
     },
-    stream: {
+    commitNotif: {
       query: gql`
-        query($id: String!) {
+        query ($id: String!) {
           stream(id: $id) {
             id
-            commit {
-              branchName
-              id
-              message
+            commits {
+              items {
+                id
+                message
+                branchName
+              }
             }
           }
         }
@@ -346,13 +342,15 @@ export default {
         return {
           id: this.$route.params.streamId
         }
+      },
+      update(data) {
+        return data.stream.commits.items.filter((c) => !c.branchName.startsWith('globals'))[0]
       }
-      //update: (data) => data.stream.description
     },
     $subscribe: {
       branchCreated: {
         query: gql`
-          subscription($streamId: String!) {
+          subscription ($streamId: String!) {
             branchCreated(streamId: $streamId)
           }
         `,
@@ -370,7 +368,7 @@ export default {
       },
       branchDeleted: {
         query: gql`
-          subscription($streamId: String!) {
+          subscription ($streamId: String!) {
             branchDeleted(streamId: $streamId)
           }
         `,


### PR DESCRIPTION
- removes create globals button on stream if you don't have permission + adds some text explaining why you can't create globals
- disables instead of hides the save button on globals page if you don't have permission (just to make it a bit more obvi. there is still text there also that tells you why you can't save. i tried a tooltip on the disabled button but decided against it as it looked v weird as the style is diff from in built button tooltips)
- hides commits to globals branch from the little warning on the main page you get when there's newer commits on a different branch 

![image](https://user-images.githubusercontent.com/7717434/122381340-b8d97080-cf60-11eb-8dae-dbc1a8ac94d8.png)

![image](https://user-images.githubusercontent.com/7717434/122381417-cee73100-cf60-11eb-879d-f4492852c253.png)

closes #296 