### PR TITLE
feat(webhooks): initial gql queries & mutations

### DIFF
--- a/packages/server/modules/webhooks/graph/resolvers/webhooks.js
+++ b/packages/server/modules/webhooks/graph/resolvers/webhooks.js
@@ -28,6 +28,7 @@ module.exports = {
     },
     async webhookDelete( parent, args, context, info ) {
       let deleted = await deleteWebhook( { id: args.id } )
+
       return !!deleted
     }
   }

--- a/packages/server/modules/webhooks/graph/resolvers/webhooks.js
+++ b/packages/server/modules/webhooks/graph/resolvers/webhooks.js
@@ -1,4 +1,4 @@
-const { createWebhook, getWebhook, updateWebhook, deleteWebhook, getStreamWebhooks, getLastWebhookEvents } = require( '../../services/webhooks' )
+const { createWebhook, getWebhook, updateWebhook, deleteWebhook, getStreamWebhooks, getLastWebhookEvents, getWebhookEventsCount } = require( '../../services/webhooks' )
 
 
 module.exports = {
@@ -12,6 +12,15 @@ module.exports = {
 
       let items = await getStreamWebhooks( { streamId: parent.id } )
       return { items, totalCount: items.length }
+    }
+  },
+
+  Webhook: {
+    async history( parent, args, context, info ) {
+      let items = await getLastWebhookEvents( { webhookId: parent.id, limit: args.limit } )
+      let totalCount = await getWebhookEventsCount( { webhookId: parent.id } )
+
+      return { items, totalCount }
     }
   },
 

--- a/packages/server/modules/webhooks/graph/resolvers/webhooks.js
+++ b/packages/server/modules/webhooks/graph/resolvers/webhooks.js
@@ -1,0 +1,34 @@
+const { createWebhook, getWebhook, updateWebhook, deleteWebhook, getStreamWebhooks, getLastWebhookEvents } = require( '../../services/webhooks' )
+
+
+module.exports = {
+  Stream: {
+    async webhooks( parent, args, context, info ) {
+      if ( args.id ) {
+        let wh = await getWebhook( { id: args.id } )
+        let items = wh ? [ wh ] : []
+        return { items, totalCount: items.length }
+      }
+
+      let items = await getStreamWebhooks( { streamId: parent.id } )
+      return { items, totalCount: items.length }
+    }
+  },
+
+  Mutation: {
+    async webhookCreate( parent, args, context, info ) {
+      let id = await createWebhook( { streamId: args.webhook.streamId, url: args.webhook.url, description: args.webhook.description, secret: args.webhook.secret, enabled: args.webhook.enabled !== false, events: args.webhook.events } )
+
+      return id
+    },
+    async webhookUpdate( parent, args, context, info ) {
+      let updated = await updateWebhook( { id: args.webhook.id, url: args.webhook.url, description: args.webhook.description, secret: args.webhook.secret, enabled: args.webhook.enabled !== false, events: args.webhook.events } )
+
+      return !!updated
+    },
+    async webhookDelete( parent, args, context, info ) {
+      let deleted = await deleteWebhook( { id: args.id } )
+      return !!deleted
+    }
+  }
+}

--- a/packages/server/modules/webhooks/graph/schemas/webhooks.graphql
+++ b/packages/server/modules/webhooks/graph/schemas/webhooks.graphql
@@ -40,6 +40,7 @@ type Webhook {
   description: String
   events: JSONObject!
   enabled: Boolean
+  history(limit: Int! = 25): WebhookEventCollection
 }
 
 input WebhookCreateInput {
@@ -58,4 +59,20 @@ input WebhookUpdateInput {
   secret: String
   enabled: Boolean
   events: JSONObject
+}
+
+type WebhookEventCollection{
+  totalCount: Int
+  cursor: String
+  items: [WebhookEvent]
+}
+
+type WebhookEvent {
+  id: String!
+  webhookId: String!
+  status: Int!
+  statusInfo: String!
+  retryCount: Int!
+  lastUpdate: DateTime!
+  payload: String!
 }

--- a/packages/server/modules/webhooks/graph/schemas/webhooks.graphql
+++ b/packages/server/modules/webhooks/graph/schemas/webhooks.graphql
@@ -39,7 +39,6 @@ type Webhook {
   url: String!
   description: String
   events: JSONObject!
-  secret: String
   enabled: Boolean
 }
 

--- a/packages/server/modules/webhooks/graph/schemas/webhooks.graphql
+++ b/packages/server/modules/webhooks/graph/schemas/webhooks.graphql
@@ -1,0 +1,62 @@
+extend type Stream {
+  webhooks(id: String): WebhookCollection
+    @hasRole(role: "stream:owner")
+    @hasScope(scope: "streams:write")
+}
+
+extend type Mutation {
+  """
+  Creates a new webhook on a stream
+  """
+  webhookCreate(webhook: WebhookCreateInput!): String!
+    @hasRole(role: "stream:owner")
+    @hasScope(scope: "streams:write")
+
+  """
+  Updates an existing webhook
+  """
+  webhookUpdate(webhook: WebhookUpdateInput!): String!
+    @hasRole(role: "stream:owner")
+    @hasScope(scope: "streams:write")
+
+  """
+  Deletes an existing webhook
+  """
+  webhookDelete(id: String!): String!
+    @hasRole(role: "stream:owner")
+    @hasScope(scope: "streams:write")
+}
+
+type WebhookCollection {
+  totalCount: Int
+  cursor: String
+  items: [Webhook]
+}
+
+type Webhook {
+  id: String!
+  streamId: String!
+  url: String!
+  description: String
+  events: JSONObject!
+  secret: String
+  enabled: Boolean
+}
+
+input WebhookCreateInput {
+  streamId: String!
+  url: String!
+  description: String
+  events: JSONObject!
+  secret: String
+  enabled: Boolean
+}
+
+input WebhookUpdateInput {
+  id: String!
+  url: String
+  description: String
+  secret: String
+  enabled: Boolean
+  events: JSONObject
+}

--- a/packages/server/modules/webhooks/services/webhooks.js
+++ b/packages/server/modules/webhooks/services/webhooks.js
@@ -64,4 +64,10 @@ module.exports = {
 
     return await WebhooksEvents( ).select( '*' ).where( { webhookId } ).orderBy( 'lastUpdate', 'desc' ).limit( limit )
   },
+
+  async getWebhookEventsCount( { webhookId } ) {
+    let [ res ] = await WebhooksEvents().count().where( { webhookId } )
+
+    return parseInt( res.count )
+  }
 }

--- a/packages/server/modules/webhooks/services/webhooks.js
+++ b/packages/server/modules/webhooks/services/webhooks.js
@@ -11,7 +11,7 @@ module.exports = {
 
   async createWebhook( { streamId, url, description, secret, enabled, events } ) {
     // TODO: limit max number of webhooks for a stream to 100 (github has a 20 limit per event)
-    
+
     let [ id ] = await WebhooksConfig( ).returning( 'id' ).insert( {
       id: crs( { length: 10 } ),
       streamId,
@@ -23,7 +23,7 @@ module.exports = {
     } )
     return id
   },
-  
+
   async getWebhook( { id } ) {
     // TODO: get webhook object + summary of event history (last event status, etc)
     return await WebhooksConfig().select( '*' ).where( { id } ).first()
@@ -61,6 +61,7 @@ module.exports = {
     if ( !limit ) {
       limit = 100
     }
+
     return await WebhooksEvents( ).select( '*' ).where( { webhookId } ).orderBy( 'lastUpdate', 'desc' ).limit( limit )
   },
 }


### PR DESCRIPTION
started implementing a `webhooks` query (extension on `stream`) and the basic create, update, delete mutations. opening a pr for the purpose of discussion!

some questions:
1. should we change the name of the `events` column in `webhooks_config` to something else (triggers, actions, etc)? 

imo it's a bit confusing bc of the `webhooks_events` table. my intuition is that `events` on a webhook should return the history, not the actions that the webhook will be notified for. the services are also named as `dispatchStreamEvent` and `getLastWebhookEvents` for getting the history

2.  is there a reason for the `events` column beaing a json object? 

it seems simpler for it to be a list of strings eg `["branch_create", "commit_create", "stream_update"]`. this would also make it consistent with other conceptually similar mutations which require lists of strings for roles and scopes