### PR TITLE
feat(frontend): settings page for webhooks & details

### DIFF
--- a/packages/frontend/src/components/SidebarStream.vue
+++ b/packages/frontend/src/components/SidebarStream.vue
@@ -98,7 +98,7 @@
         class="px-0"
         @click="editStreamDialog = true"
       >
-        <v-icon small class="mr-2 float-left">mdi-cog-outline</v-icon>
+        <v-icon small class="mr-2 float-left">mdi-pencil-outline</v-icon>
         Edit
       </v-btn>
 
@@ -122,6 +122,13 @@
         :to="`/streams/${stream.id}/globals`"
       >
         Globals
+      </v-btn>
+    </v-card-text>
+
+    <v-card-text v-if="userRole === 'owner'">
+      <v-btn block small elevation="0" :to="`/settings/${stream.id}/general`">
+        <v-icon small class="mr-2 float-left">mdi-cog-outline</v-icon>
+        Settings
       </v-btn>
     </v-card-text>
 

--- a/packages/frontend/src/components/admin/AdminCard.vue
+++ b/packages/frontend/src/components/admin/AdminCard.vue
@@ -1,11 +1,19 @@
 <template>
   <v-card class="rounded-lg" v-bind="$attrs">
+    <template slot="progress">
+      <v-progress-linear indeterminate></v-progress-linear>
+    </template>
     <v-card-title class="d-flex justify-space-between">
       <span class="text--secondary">{{ title }}</span>
       <span>
         <slot name="menu"></slot>
       </span>
     </v-card-title>
+    <v-card-subtitle>
+      <span>
+        <slot name="subtitle"></slot>
+      </span>
+    </v-card-subtitle>
     <v-card-text>
       <slot></slot>
     </v-card-text>
@@ -14,9 +22,9 @@
 
 <script>
 export default {
-  name: "AdminCard",
-  props: ["title"]
-};
+  name: 'AdminCard',
+  props: ['title']
+}
 </script>
 
 <style scoped lang="scss"></style>

--- a/packages/frontend/src/components/settings/WebhookForm.vue
+++ b/packages/frontend/src/components/settings/WebhookForm.vue
@@ -1,0 +1,237 @@
+<template>
+  <v-container>
+    <v-form ref="form" v-model="valid" class="px-2" @submit.prevent="sendInvite">
+      <v-text-field
+        v-model="url"
+        :rules="validation.urlRules"
+        label="URL"
+        hint="A POST request will be sent to this URL when this webhook is triggered"
+      />
+
+      <v-text-field
+        v-model="description"
+        :rules="validation.descriptionRules"
+        label="Description"
+        hint="An optional description to help you identify this webhook."
+      />
+      <v-text-field
+        v-model="secret"
+        :rules="validation.secretRules"
+        label="Secret"
+        :hint="
+          webhook == null
+            ? `An optional secret. You'll be able to change this in the future, but you won't be able to retrieve it.`
+            : `Change your secret. Note that anything using your old secret will need to be updated.`
+        "
+      />
+      <v-autocomplete
+        v-model="triggers"
+        :items="allTriggers"
+        :rules="validation.triggersRules"
+        label="Choose what events will trigger this webhook"
+        multiple
+        small-chips
+        deletable-chips
+      />
+      <v-switch
+        v-model="enabled"
+        :label="enabled ? 'Enabled' : 'Disabled'"
+        hint="Get notified when this webhook is triggered"
+        persistent-hint
+      />
+    </v-form>
+
+    <v-divider class="mt-4 mb-3" />
+
+    <v-card-actions v-if="webhook != null">
+      <v-btn outlined color="success" type="submit" :disabled="!valid" @click="saveChanges">
+        Save Changes
+      </v-btn>
+      <v-btn color="error" text @click="showDelete = true">Delete Webhook</v-btn>
+      <v-dialog v-model="showDelete" max-width="500">
+        <v-card>
+          <v-card-title>Are you sure?</v-card-title>
+          <v-card-text>
+            You cannot undo this action. This webhook will be permanently deleted.
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn @click="showDelete = false">Cancel</v-btn>
+            <v-btn color="error" text @click="deleteWebhook">Delete</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </v-card-actions>
+
+    <v-card-actions v-else>
+      <v-btn outlined color="success" type="submit" :disabled="!valid" @click="addWebhook">
+        Add Webhook
+      </v-btn>
+    </v-card-actions>
+  </v-container>
+</template>
+
+<script>
+import gql from 'graphql-tag'
+import webhookQuery from '../../graphql/webhook.gql'
+
+export default {
+  name: 'WebhookForm',
+  props: {
+    webhookId: {
+      type: String,
+      default: null
+    },
+    streamId: {
+      type: String,
+      default: null
+    }
+  },
+  apollo: {
+    webhook: {
+      query: webhookQuery,
+      variables() {
+        return {
+          streamId: this.streamId,
+          webhookId: this.webhookId
+        }
+      },
+      update(data) {
+        let webhook = data.stream.webhooks.items[0]
+        this.secret = null
+        if (webhook)
+          ({
+            url: this.url,
+            description: this.description,
+            triggers: this.triggers,
+            enabled: this.enabled
+          } = webhook)
+
+        return webhook
+      },
+      skip() {
+        return !this.webhookId
+      }
+    }
+  },
+  data: () => ({
+    showDelete: false,
+    valid: false,
+    url: null,
+    description: null,
+    triggers: [],
+    secret: null,
+    enabled: true,
+    allTriggers: [
+      'stream_update',
+      'stream_delete',
+      'branch_create',
+      'branch_update',
+      'branch_delete',
+      'commit_create',
+      'commit_update',
+      'commit_delete',
+      'stream_permissions_add',
+      'stream_permissions_remove'
+    ],
+    validation: {
+      urlRules: [
+        (v) => !!v || 'URL is required',
+        (v) => (/^https?:\/\//.test(v) ? true : `That doesn't look like a valid url`)
+      ],
+      descriptionRules: [
+        (v) => {
+          if (v?.length >= 1024) return 'Description too long!'
+          return true
+        }
+      ],
+      secretRules: [
+        (v) => {
+          if (v?.length >= 100) return 'Secret should be less than 100 characters'
+          return true
+        }
+      ],
+      triggersRules: [
+        (v) => {
+          if (!v || v.length === 0) return 'You must select at least one trigger'
+          return true
+        }
+      ]
+    }
+  }),
+  methods: {
+    async saveChanges() {
+      this.$emit('update:loading', true)
+      this.$matomo && this.$matomo.trackPageView('stream/webhook/update')
+
+      let params = {
+        id: this.webhook.id,
+        url: this.url,
+        description: this.description,
+        triggers: this.triggers,
+        enabled: this.enabled
+      }
+      if (this.secret) params.secret = this.secret
+
+      await this.$apollo.mutate({
+        mutation: gql`
+          mutation webhookUpdate($params: WebhookUpdateInput!) {
+            webhookUpdate(webhook: $params)
+          }
+        `,
+        variables: {
+          params: params
+        }
+      })
+      this.$emit('refetch-webhooks')
+      this.$emit('update:loading', false)
+      this.$router.push({ name: 'webhooks' })
+    },
+    async addWebhook() {
+      this.$emit('update:loading', true)
+      this.$matomo && this.$matomo.trackPageView('stream/webhook/create')
+
+      await this.$apollo.mutate({
+        mutation: gql`
+          mutation webhookCreate($params: WebhookCreateInput!) {
+            webhookCreate(webhook: $params)
+          }
+        `,
+        variables: {
+          params: {
+            streamId: this.streamId,
+            url: this.url,
+            description: this.description,
+            triggers: this.triggers,
+            enabled: this.enabled,
+            secret: this.secret
+          }
+        }
+      })
+
+      this.$emit('refetch-webhooks')
+      this.$emit('update:loading', false)
+      this.$router.push({ name: 'webhooks' })
+    },
+    async deleteWebhook() {
+      this.$emit('update:loading', true)
+      this.$matomo && this.$matomo.trackPageView('stream/webhook/delete')
+
+      await this.$apollo.mutate({
+        mutation: gql`
+          mutation webhookDelete($id: String!) {
+            webhookDelete(id: $id)
+          }
+        `,
+        variables: {
+          id: this.webhookId
+        }
+      })
+
+      this.$emit('refetch-webhooks')
+      this.$emit('update:loading', false)
+      this.$router.push({ name: 'webhooks' })
+    }
+  }
+}
+</script>

--- a/packages/frontend/src/graphql/webhook.gql
+++ b/packages/frontend/src/graphql/webhook.gql
@@ -1,0 +1,21 @@
+query webhook($streamId: String!, $webhookId: String!) {
+  stream(id: $streamId) {
+    id
+    webhooks(id: $webhookId) {
+      items {
+        id
+        streamId
+        url
+        description
+        triggers
+        enabled
+        history(limit: 1) {
+          items {
+            status
+            statusInfo
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/frontend/src/graphql/webhooks.gql
+++ b/packages/frontend/src/graphql/webhooks.gql
@@ -1,0 +1,21 @@
+query webhooks($streamId: String!) {
+  stream(id: $streamId) {
+    id
+    webhooks {
+      items {
+        id
+        streamId
+        url
+        description
+        triggers
+        enabled
+        history(limit: 1) {
+          items {
+            status
+            statusInfo
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/frontend/src/router/index.js
+++ b/packages/frontend/src/router/index.js
@@ -142,6 +142,45 @@ const routes = [
         ]
       },
       {
+        path: 'settings/:streamId/',
+        name: 'settings',
+        props: true,
+        component: () => import('../views/settings/StreamSettings.vue'),
+        children: [
+          {
+            path: 'general/',
+            name: 'general',
+            meta: {
+              title: 'Stream Settings | Speckle'
+            },
+            props: true,
+            component: () => import('../views/settings/SettingsGeneral.vue')
+          },
+          {
+            path: 'webhooks/',
+            name: 'webhooks',
+            meta: {
+              title: 'Webhooks | Speckle'
+            },
+            props: true,
+            component: () => import('../views/settings/SettingsWebhooks.vue'),
+            children: [
+              {
+                path: 'edit/:webhookId/',
+                name: 'edit webhook',
+                props: true
+              }
+            ]
+          },
+          {
+            path: 'webhooks/new/',
+            name: 'add webhook',
+            props: true,
+            component: () => import('../views/settings/SettingsWebhooks.vue')
+          }
+        ]
+      },
+      {
         path: 'profile',
         name: 'profile',
         meta: {
@@ -169,19 +208,18 @@ const routes = [
             component: () => import('../views/admin/AdminOverview.vue')
           },
           {
-            name: "Admin | Users",
-            path: "users",
+            name: 'Admin | Users',
+            path: 'users',
             component: () => import('../views/admin/AdminUsers.vue')
-
           },
           {
-            name: "Admin | Streams",
-            path: "streams",
+            name: 'Admin | Streams',
+            path: 'streams',
             component: () => import('../views/admin/AdminStreams.vue')
           },
           {
-            name: "Admin | Settings",
-            path: "settings",
+            name: 'Admin | Settings',
+            path: 'settings',
             component: () => import('../views/admin/AdminSettings.vue')
           }
         ],

--- a/packages/frontend/src/views/settings/SettingsGeneral.vue
+++ b/packages/frontend/src/views/settings/SettingsGeneral.vue
@@ -1,8 +1,73 @@
 <template>
-  <admin-card title="General"></admin-card>
+  <admin-card :loading="loading" title="General">
+    <v-card-text class="py-0 my-0">
+      <v-form ref="form" v-model="valid" class="px-2" @submit.prevent="save">
+        <v-text-field
+          v-model="name"
+          :rules="validation.nameRules"
+          label="Name"
+          hint="The name of this stream."
+        />
+        <p class="subtitle-1">Description</p>
+        <v-row>
+          <v-col cols="12" sm="12" md="6">
+            <p class="caption">
+              Use Markdown! Tips:
+              <code>#, ##, ###</code>
+              prefix headings, links:
+              <code>[speckle](https://speckle.systems)</code>
+              , images:
+              <code>![image title](image url)</code>
+              , list items are prefixed by
+              <code>-</code>
+              on new lines,
+              <b>bold</b>
+              text by surrounding it with
+              <code>**</code>
+              , etc.
+            </p>
+            <v-textarea
+              v-model="description"
+              auto-grow
+              filled
+              rows="10"
+              style="font-size: 12px; line-height: 10px"
+            ></v-textarea>
+          </v-col>
+          <v-col cols="12" sm="12" md="6">
+            <p class="subtitle">Preview</p>
+            <div class="marked-preview" v-html="compiledMarkdown"></div>
+          </v-col>
+        </v-row>
+        <v-switch
+          v-model="isPublic"
+          :label="isPublic ? 'Public' : 'Private'"
+          :hint="
+            isPublic
+              ? 'Anyone can view this stream. It is also visible on your profile page. Only collaborators can edit it.'
+              : 'Only collaborators can access this stream.'
+          "
+          persistent-hint
+        />
+      </v-form>
+    </v-card-text>
+
+    <v-divider class="mt-4 mb-3" />
+
+    <v-card-actions>
+      <v-btn outlined color="success" type="submit" :disabled="!valid" @click="save">
+        Save Changes
+      </v-btn>
+    </v-card-actions>
+  </admin-card>
 </template>
 
 <script>
+import marked from 'marked'
+import DOMPurify from 'dompurify'
+import gql from 'graphql-tag'
+import streamQuery from '@/graphql/stream.gql'
+
 export default {
   name: 'SettingsGeneral',
   components: {
@@ -12,6 +77,68 @@ export default {
     userRole: {
       type: String,
       default: null
+    }
+  },
+  apollo: {
+    stream: {
+      query: streamQuery,
+      variables() {
+        return {
+          id: this.$attrs.streamId
+        }
+      },
+      update(data) {
+        let stream = data.stream
+        if (stream)
+          ({ name: this.name, description: this.description, isPublic: this.isPublic } = stream)
+
+        return stream
+      }
+    }
+  },
+  data: () => ({
+    loading: false,
+    valid: false,
+    name: null,
+    description: null,
+    isPublic: true,
+    validation: {
+      nameRules: [(v) => !!v || 'A stream must have a name!']
+    }
+  }),
+  computed: {
+    compiledMarkdown() {
+      if (!this.description) return ''
+      let md = marked(this.description)
+      return DOMPurify.sanitize(md)
+    }
+  },
+  methods: {
+    async save() {
+      this.loading = true
+      this.$matomo && this.$matomo.trackPageView('stream/update')
+      try {
+        await this.$apollo.mutate({
+          mutation: gql`
+            mutation editDescription($input: StreamUpdateInput!) {
+              streamUpdate(stream: $input)
+            }
+          `,
+          variables: {
+            input: {
+              id: this.stream.id,
+              name: this.name,
+              description: this.description,
+              isPublic: this.isPublic
+            }
+          }
+        })
+      } catch (e) {
+        console.log(e)
+      }
+
+      this.$apollo.queries.stream.refetch()
+      this.loading = false
     }
   }
 }

--- a/packages/frontend/src/views/settings/SettingsGeneral.vue
+++ b/packages/frontend/src/views/settings/SettingsGeneral.vue
@@ -1,0 +1,18 @@
+<template>
+  <admin-card title="General"></admin-card>
+</template>
+
+<script>
+export default {
+  name: 'SettingsGeneral',
+  components: {
+    AdminCard: () => import('@/components/admin/AdminCard')
+  },
+  props: {
+    userRole: {
+      type: String,
+      default: null
+    }
+  }
+}
+</script>

--- a/packages/frontend/src/views/settings/SettingsWebhooks.vue
+++ b/packages/frontend/src/views/settings/SettingsWebhooks.vue
@@ -27,6 +27,11 @@
       </v-btn>
     </template>
 
+    <v-card-text v-if="webhooks.length == 0">
+      You don't have any webhooks on this stream yet. Click the blue "Add Webhook" button in the top
+      right to add one.
+    </v-card-text>
+
     <v-list subheader two-line>
       <v-list-item
         v-for="wh in webhooks"

--- a/packages/frontend/src/views/settings/SettingsWebhooks.vue
+++ b/packages/frontend/src/views/settings/SettingsWebhooks.vue
@@ -1,0 +1,139 @@
+<template>
+  <admin-card v-if="selectedWebhook != undefined" :loading="loading" title="Edit Webhook">
+    <template #subtitle>
+      <v-icon dense class="text-subtitle-1 pr-1">mdi-webhook</v-icon>
+      <code>{{ selectedWebhook.id }}</code>
+    </template>
+    <webhook-form
+      :loading.sync="loading"
+      :stream-id="$attrs.streamId"
+      :webhook-id="selectedWebhook.id"
+      @refetch-webhooks="refetchWebhooks"
+    />
+  </admin-card>
+
+  <admin-card v-else-if="$route.name === 'add webhook'" :loading="loading" title="Add Webhook">
+    <webhook-form
+      :loading.sync="loading"
+      :stream-id="$attrs.streamId"
+      @refetch-webhooks="refetchWebhooks"
+    />
+  </admin-card>
+
+  <admin-card v-else title="Webhooks">
+    <template #menu>
+      <v-btn small outlined color="primary" :to="`/settings/${$attrs.streamId}/webhooks/new`">
+        Add Webhook
+      </v-btn>
+    </template>
+
+    <v-list subheader two-line>
+      <v-list-item
+        v-for="wh in webhooks"
+        :key="wh.id"
+        :to="`/settings/${$attrs.streamId}/webhooks/edit/${wh.id}`"
+      >
+        <v-list-item-content>
+          <v-list-item-title>
+            <v-tooltip left>
+              <template #activator="{ on }" class="ml-1">
+                <v-icon class="pb-2 pr-1" small :color="wh.statusIcon.color" v-on="on">
+                  {{ wh.statusIcon.icon }}
+                </v-icon>
+              </template>
+              <span>{{ getStatusInfo(wh) }}</span>
+            </v-tooltip>
+            <span id="description">
+              {{ wh.description ? wh.description : `webhook ${wh.id}` }}
+            </span>
+          </v-list-item-title>
+          <v-list-item-subtitle>{{ wh.url }}</v-list-item-subtitle>
+          <v-list-item-subtitle>{{ `( ${wh.triggers.join(', ')} )` }}</v-list-item-subtitle>
+        </v-list-item-content>
+      </v-list-item>
+    </v-list>
+  </admin-card>
+</template>
+
+<script>
+import webhooksQuery from '../../graphql/webhooks.gql'
+export default {
+  name: 'SettingsWebhooks',
+  components: {
+    AdminCard: () => import('@/components/admin/AdminCard'),
+    WebhookForm: () => import('@/components/settings/WebhookForm')
+  },
+  props: {
+    userRole: {
+      type: String,
+      default: null
+    }
+  },
+  apollo: {
+    webhooks: {
+      query: webhooksQuery,
+      variables() {
+        return {
+          streamId: this.$attrs.streamId
+        }
+      },
+      update(data) {
+        let webhooks = data.stream.webhooks.items
+        webhooks.forEach((wh) => {
+          wh.statusIcon = this.getStatusIcon(wh)
+        })
+        return webhooks
+      }
+    }
+  },
+  data() {
+    return {
+      loading: false
+    }
+  },
+  computed: {
+    selectedWebhook() {
+      if (this.$apollo.loading || !this.$attrs.webhookId) return
+
+      return this.webhooks.find(({ id }) => id === this.$attrs.webhookId)
+    }
+  },
+  methods: {
+    getStatusIcon(webhook) {
+      let status = 5 // default 5 if no events
+      if (webhook.history.items.length) status = webhook.history.items[0].status
+      switch (status) {
+        case 0:
+        case 1:
+          return { color: 'amber', icon: 'mdi-alert-outline' }
+        case 2:
+          return { color: 'green', icon: 'mdi-check' }
+        case 3:
+          return { color: 'red', icon: 'mdi-close' }
+
+        default:
+          return { color: 'blue-grey', icon: 'mdi-alert-circle-outline' }
+      }
+    },
+    getStatusInfo(webhook) {
+      if (!webhook.history.items.length) return 'No events yet'
+      let msg = webhook.history.items[0].statusInfo
+
+      return msg
+    },
+    refetchWebhooks() {
+      this.$apollo.queries.webhooks.refetch()
+    }
+  }
+}
+</script>
+
+<style>
+#description {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 300px;
+  display: inline-block;
+}
+</style>

--- a/packages/frontend/src/views/settings/StreamSettings.vue
+++ b/packages/frontend/src/views/settings/StreamSettings.vue
@@ -1,0 +1,125 @@
+<template>
+  <v-container v-if="isOwner">
+    <v-row>
+      <v-col cols="12" sm="12" md="4" lg="3" xl="3" class="pt-md-10">
+        <v-card id="sideMenu" elevation="1" class="rounded-lg overflow-hidden">
+          <v-card-title class="text--secondary font-weight-regular">{{ stream.name }}</v-card-title>
+          <div v-for="child in childRoutes" :key="child.to">
+            <router-link v-slot="{ isActive, navigate }" :to="child.to">
+              <v-hover v-slot="{ hover }">
+                <span
+                  :class="{ 'active-border primary--text': isActive, 'primary--text': hover }"
+                  class="pa-2 pl-6 text-left d-flex menu-item bold"
+                  @click="navigate"
+                >
+                  {{ child.name }}
+                </span>
+              </v-hover>
+            </router-link>
+          </div>
+        </v-card>
+      </v-col>
+
+      <v-col cols="12" sm="12" md="8" lg="9" xl="9" class="pt-md-10">
+        <v-fade-transition mode="out-in">
+          <router-view :user-role="userRole" />
+        </v-fade-transition>
+      </v-col>
+    </v-row>
+  </v-container>
+  <v-container v-else-if="!isOwner && !$apollo.loading">
+    <v-card>
+      <v-card-text class="text-center">
+        <v-icon size="50" color="error">mdi-alert</v-icon>
+        <h3>Sorry...but maybe you shouldn't be here!</h3>
+        <p>
+          Either this stream does not exist or you do not have the required permissions to edit this
+          stream's settings.
+        </p>
+        <v-btn @click="$router.back()">Go back</v-btn>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import streamQuery from '../../graphql/stream.gql'
+
+export default {
+  name: 'Settings',
+  components: {},
+  apollo: {
+    stream: {
+      query: streamQuery,
+      variables() {
+        return {
+          id: this.$attrs.streamId
+        }
+      },
+      error(err) {
+        if (err.message) this.error = err.message.replace('GraphQL error: ', '')
+        else this.error = err
+      }
+    }
+  },
+  data() {
+    return {
+      childRoutes: [
+        {
+          name: 'General',
+          to: `/settings/${this.$attrs.streamId}/general`
+        },
+        {
+          name: 'Webhooks',
+          to: `/settings/${this.$attrs.streamId}/webhooks`
+        }
+      ]
+    }
+  },
+  computed: {
+    userRole() {
+      let uuid = localStorage.getItem('uuid')
+      if (!uuid) return null
+      if (this.$apollo.loading) return null
+      if (!this.stream) return null
+      let contrib = this.stream.collaborators.find((u) => u.id === uuid)
+      if (contrib) return contrib.role.split(':')[1]
+      else return null
+    },
+    isOwner() {
+      return this.userRole === 'owner'
+    }
+  },
+  methods: {}
+}
+</script>
+
+<style lang="scss" scoped>
+.gray-border {
+  border-top: 1pt solid var(--v-background-base) !important;
+}
+
+.menu-item {
+  overflow: hidden;
+  position: relative;
+  border-top: 1pt solid var(--v-background-base) !important;
+  cursor: pointer;
+  transition: 0.1s all ease-out, border-top-color 0s;
+
+  &::before {
+    @include speckle-gradient-bg;
+
+    position: absolute;
+    content: '';
+    width: 0;
+    height: 100%;
+    top: 0;
+    left: 0;
+    transition: all 0.1s ease-in-out, border-top-color 0s;
+  }
+
+  &.active-border::before {
+    width: 4pt;
+  }
+}
+</style>

--- a/packages/frontend/src/views/settings/StreamSettings.vue
+++ b/packages/frontend/src/views/settings/StreamSettings.vue
@@ -3,7 +3,13 @@
     <v-row>
       <v-col cols="12" sm="12" md="4" lg="3" xl="3" class="pt-md-10">
         <v-card id="sideMenu" elevation="1" class="rounded-lg overflow-hidden">
-          <v-card-title class="text--secondary font-weight-regular">{{ stream.name }}</v-card-title>
+          <v-card-title class="text--secondary font-weight-regular">
+            {{ stream.name }}
+            <v-btn plain small class="mt-3 pa-0" :to="'/streams/' + stream.id">
+              <v-icon small>mdi-chevron-left</v-icon>
+              back to stream
+            </v-btn>
+          </v-card-title>
           <div v-for="child in childRoutes" :key="child.to">
             <router-link v-slot="{ isActive, navigate }" :to="child.to">
               <v-hover v-slot="{ hover }">

--- a/packages/server/modules/webhooks/graph/schemas/webhooks.graphql
+++ b/packages/server/modules/webhooks/graph/schemas/webhooks.graphql
@@ -29,7 +29,6 @@ extend type Mutation {
 
 type WebhookCollection {
   totalCount: Int
-  cursor: String
   items: [Webhook]
 }
 
@@ -63,7 +62,6 @@ input WebhookUpdateInput {
 
 type WebhookEventCollection{
   totalCount: Int
-  cursor: String
   items: [WebhookEvent]
 }
 

--- a/packages/server/modules/webhooks/services/webhooks.js
+++ b/packages/server/modules/webhooks/services/webhooks.js
@@ -17,7 +17,7 @@ module.exports = {
       throw new Error( `Maximum number of webhooks for a stream reached (${MAX_STREAM_WEBHOOKS})` )
     }
 
-    let triggersObj = Object.assign( {}, ...triggers.map( ( x ) => ( { [x]: true } ) ) )
+    let triggersObj = Object.assign( {}, ...triggers.map( ( x ) => ( { [ x ]: true } ) ) )
 
     let [ id ] = await WebhooksConfig( ).returning( 'id' ).insert( {
       id: crs( { length: 10 } ),
@@ -36,6 +36,7 @@ module.exports = {
     if ( webhook ) {
       webhook.triggers = Object.keys( webhook.triggers )
     }
+
     return webhook
   },
 
@@ -46,7 +47,7 @@ module.exports = {
     if ( secret !== undefined ) fieldsToUpdate.secret = secret
     if ( enabled !== undefined ) fieldsToUpdate.enabled = enabled
     if ( triggers !== undefined ) {
-      let triggersObj = Object.assign( {}, ...triggers.map( ( x ) => ( { [x]: true } ) ) )
+      let triggersObj = Object.assign( {}, ...triggers.map( ( x ) => ( { [ x ]: true } ) ) )
       fieldsToUpdate.triggers = triggersObj
     }
 
@@ -66,6 +67,7 @@ module.exports = {
     for ( let webhook of webhooks ) {
       webhook.triggers = Object.keys( webhook.triggers )
     }
+
     return webhooks
   },
 

--- a/packages/server/modules/webhooks/tests/webhooks.spec.js
+++ b/packages/server/modules/webhooks/tests/webhooks.spec.js
@@ -121,10 +121,7 @@ describe( 'Webhooks @webhooks', () => {
       description: 'test wh no 2',
       secret: 'secret',
       enabled: true,
-      events: {
-        'commit_create': true,
-        'commit_update': true
-      }
+      triggers: [ 'commit_create', 'commit_update' ]
     }
 
     let streamTwo = {
@@ -208,11 +205,13 @@ describe( 'Webhooks @webhooks', () => {
       for ( let i = 0; i < limit - 1; i++ ) {
         await createWebhook( webhookOne )
       }
+
       try {
         await createWebhook( webhookOne )
       } catch ( err ) {
         if ( err.toString().indexOf( 'Maximum' ) > -1 ) return
       }
+
       assert.fail( 'Configured more webhooks than the limit' )
     } )
 
@@ -224,10 +223,11 @@ describe( 'Webhooks @webhooks', () => {
           await deleteWebhook( { id: webhook.id } )
         }
       }
+
       streamWebhooks = await getStreamWebhooks( { streamId: streamOne.id } )
       expect( streamWebhooks ).to.have.lengthOf( 1 )
-      expect( streamWebhooks[0] ).to.have.property( 'id' )
-      expect( streamWebhooks[0].id ).to.equal( webhookOne.id )
+      expect( streamWebhooks[ 0 ] ).to.have.property( 'id' )
+      expect( streamWebhooks[ 0 ].id ).to.equal( webhookOne.id )
     } )
   } )
 } )

--- a/packages/server/modules/webhooks/tests/webhooks.spec.js
+++ b/packages/server/modules/webhooks/tests/webhooks.spec.js
@@ -14,7 +14,8 @@ const { createStream, getStream, grantPermissionsStream } = require( '../../core
 const expect = chai.expect
 chai.use( chaiHttp )
 
-const serverAddress = `http://localhost:${process.env.PORT || 3000}`
+const port = 3420
+const serverAddress = `http://localhost:${port}`
 
 
 describe( 'Webhooks @webhooks', () => {
@@ -45,7 +46,7 @@ describe( 'Webhooks @webhooks', () => {
     await knex.migrate.rollback( )
     await knex.migrate.latest( )
     let { app } = await init()
-    let { server } = await startHttp( app )
+    let { server } = await startHttp( app, port )
     testServer = server
 
     userOne.id = await createUser( userOne )

--- a/packages/server/modules/webhooks/tests/webhooks.spec.js
+++ b/packages/server/modules/webhooks/tests/webhooks.spec.js
@@ -4,18 +4,22 @@ const chaiHttp = require( 'chai-http' )
 const assert = require( 'assert' )
 
 const appRoot = require( 'app-root-path' )
-const { init } = require( `${appRoot}/app` )
+const { init, startHttp } = require( `${appRoot}/app` )
 const knex = require( `${appRoot}/db/knex` )
+const { createPersonalAccessToken } = require( '../../core/services/tokens' )
+const { createWebhook, getStreamWebhooks, getLastWebhookEvents, getWebhook, updateWebhook, deleteWebhook, dispatchStreamEvent } = require( '../services/webhooks' )
+const { createUser } = require( '../../core/services/users' )
+const { createStream, getStream, grantPermissionsStream } = require( '../../core/services/streams' )
 
 const expect = chai.expect
 chai.use( chaiHttp )
 
+const serverAddress = `http://localhost:${process.env.PORT || 3000}`
 
-const { createWebhook, getStreamWebhooks, getLastWebhookEvents, getWebhook, updateWebhook, deleteWebhook, dispatchStreamEvent } = require( '../services/webhooks' )
-const { createUser } = require( '../../core/services/users' )
-const { createStream, getStream } = require( '../../core/services/streams' )
 
-describe( 'Webhooks', ( ) => {
+describe( 'Webhooks @webhooks', () => {
+  let testServer
+
   let userOne = {
     name: 'User',
     email: 'user@gmail.com',
@@ -23,7 +27,7 @@ describe( 'Webhooks', ( ) => {
   }
 
   let streamOne = {
-    name: 'stream',
+    name: 'streamOne',
     description: 'stream',
     isPublic: true
   }
@@ -40,16 +44,20 @@ describe( 'Webhooks', ( ) => {
   before( async ( ) => {
     await knex.migrate.rollback( )
     await knex.migrate.latest( )
-    await init()
+    let { app } = await init()
+    let { server } = await startHttp( app )
+    testServer = server
 
     userOne.id = await createUser( userOne )
     streamOne.ownerId = userOne.id
     streamOne.id = await createStream( streamOne )
+
     webhookOne.streamId = streamOne.id
   } )
 
   after( async ( ) => {
     // await knex.migrate.rollback( )
+    testServer.close( )
   } )
 
   describe( 'Create, Read, Update, Delete Webhooks', ( ) => {
@@ -81,22 +89,118 @@ describe( 'Webhooks', ( ) => {
       expect( webhook ).to.be.undefined
     } )
 
-    it( 'Should get webooks for stream', async ( ) => {
+    it( 'Should get webhooks for stream', async ( ) => {
       let streamWebhooks = await getStreamWebhooks( { streamId: streamOne.id } )
       expect( streamWebhooks ).to.have.lengthOf( 0 )
-      
+
       webhookOne.id = await createWebhook( webhookOne )
       streamWebhooks = await getStreamWebhooks( { streamId: streamOne.id } )
       expect( streamWebhooks ).to.have.lengthOf( 1 )
-      expect( streamWebhooks[0] ).to.have.property( 'url' )
-      expect( streamWebhooks[0].url ).to.equal( webhookOne.url )
+      expect( streamWebhooks[ 0 ] ).to.have.property( 'url' )
+      expect( streamWebhooks[ 0 ].url ).to.equal( webhookOne.url )
     } )
 
-    it( 'Should dispatch and get events', async () => {      
+    it( 'Should dispatch and get events', async () => {
       await dispatchStreamEvent( { streamId: streamOne.id, event: 'commit_create', eventPayload: 'payload123' } )
       let lastEvents = await getLastWebhookEvents( { webhookId: webhookOne.id } )
       expect( lastEvents ).to.have.lengthOf( 1 )
-      expect( lastEvents[0].payload ).to.equal( 'payload123' )
+      expect( lastEvents[ 0 ].payload ).to.equal( 'payload123' )
+    } )
+  } )
+
+  describe( 'GraphQL API Webhooks @webhooks-api', () => {
+    let userTwo = {
+      name: 'User2',
+      email: 'user2@gmail.com',
+      password: 'jdsadjsadasfdsa'
+    }
+
+    let webhookTwo = {
+      streamId: null,
+      url: 'http://localhost:42/non-existent-two',
+      description: 'test wh no 2',
+      secret: 'secret',
+      enabled: true,
+      events: {
+        'commit_create': true,
+        'commit_update': true
+      }
+    }
+
+    let streamTwo = {
+      name: 'streamTwo',
+      description: 'stream',
+      isPublic: true
+    }
+
+    before( async () => {
+      userTwo.id = await createUser( userTwo )
+      streamTwo.ownerId = userOne.id
+      streamTwo.id = await createStream( streamTwo )
+      webhookTwo.streamId = streamTwo.id
+
+
+      userOne.token = `Bearer ${( await createPersonalAccessToken( userOne.id, 'userOne test token', [ 'streams:read', 'streams:write' ] ) )}`
+      userTwo.token = `Bearer ${( await createPersonalAccessToken( userTwo.id, 'userTwo test token', [ 'streams:read', 'streams:write' ] ) )}`
+      await grantPermissionsStream( { streamId: streamTwo.id, userId: userTwo.id, role: 'stream:contributor' } )
+    } )
+
+    it( 'Should create a webhook', async () => {
+      const res = await sendRequest( userOne.token, { query: 'mutation createWebhook($webhook: WebhookCreateInput!) { webhookCreate( webhook: $webhook ) }', variables: { webhook: webhookTwo } } )
+      expect( noErrors( res ) )
+      expect( res.body.data.webhookCreate ).to.not.be.null
+      webhookTwo.id = res.body.data.webhookCreate
+    } )
+
+    it( 'Should get stream webhooks and the previous events', async () => {
+      await dispatchStreamEvent( { streamId: streamTwo.id, event: 'commit_create', eventPayload: 'payload321' } )
+      const res = await sendRequest( userOne.token, { query: `query {
+        stream(id: "${streamTwo.id}") {
+          webhooks { totalCount items { id url enabled
+            history { totalCount items { status statusInfo payload } } }
+          }
+        }
+      }` } )
+      expect( noErrors( res ) )
+      let webhooks = res.body.data.stream.webhooks
+
+      expect( webhooks.totalCount ).to.equal( 1 )
+      expect( webhooks.items[ 0 ].url ).to.equal( webhookTwo.url )
+      expect( webhooks.items[ 0 ].history.totalCount ).to.equal( 1 )
+      expect( webhooks.items[ 0 ].history.items[ 0 ].payload ).to.equal( 'payload321' )
+    } )
+
+    it( 'Should update a webhook', async () => {
+      const res = await sendRequest( userOne.token, { query: `mutation { webhookUpdate(webhook: { id: "${webhookTwo.id}", description: "updated webhook", enabled: false })
+    }` } )
+      let webhook = await getWebhook( { id: webhookTwo.id } )
+      expect( noErrors( res ) )
+      expect( res.body.data.webhookUpdate ).to.equal( 'true' )
+      expect( webhook.description ).to.equal( 'updated webhook' )
+      expect( webhook.enabled ).to.equal( false )
+    } )
+
+    it( 'Should delete a webhook', async () => {
+      const res = await sendRequest( userOne.token, {
+        query: `mutation { webhookDelete(id: "${webhookTwo.id}") }`
+      } )
+      expect( noErrors( res ) )
+      expect( res.body.data.webhookDelete ).to.equal( 'true' )
+    } )
+
+    it( 'Should *not* create a webhook if user is not a stream owner', async () => {
+      delete webhookTwo.id
+      const res = await sendRequest( userTwo.token, { query: 'mutation createWebhook($webhook: WebhookCreateInput!) { webhookCreate( webhook: $webhook ) }', variables: { webhook: webhookTwo } } )
+      expect( res.body.errors ).to.exist
+      expect( res.body.errors[ 0 ].extensions.code ).to.equal( 'FORBIDDEN' )
+    } )
+
+    it( 'Should *not* get a webhook if the user is not a stream owner', async () => {
+      const res = await sendRequest( userTwo.token, { query: `query {
+        stream(id: "${streamTwo.id}") { webhooks { totalCount items { id url enabled } } }
+      }` } )
+      expect( res.body.errors ).to.exist
+      expect( res.body.errors[ 0 ].extensions.code ).to.equal( 'FORBIDDEN' )
     } )
 
     it( 'Should have a webhook limit for streams', async ( ) => {
@@ -127,3 +231,23 @@ describe( 'Webhooks', ( ) => {
     } )
   } )
 } )
+
+
+/**
+ * Sends a graphql request. Convenience wrapper.
+ * @param  {string} auth the user's token
+ * @param  {string} obj  the query/mutation to send
+ * @return {Promise}      the awaitable request
+ */
+function sendRequest( auth, obj, address = serverAddress ) {
+  return chai.request( address ).post( '/graphql' ).set( 'Authorization', auth ).send( obj )
+}
+
+/**
+ * Checks the response body for errors. To be used in expect assertions.
+ * Will throw an error if 'errors' exist.
+ * @param {*} res
+ */
+function noErrors( res ) {
+  if ( 'errors' in res.body ) throw new Error( `Failed GraphQL request: ${res.body.errors[ 0 ].message}` )
+}


### PR DESCRIPTION
![webhooks-ui-demo](https://user-images.githubusercontent.com/7717434/125970247-852251f0-1858-482d-89b9-3ca4f4de0fb2.gif)

- stole sidebar from admin panel
- added settings page visible if you are stream owner
- only verifying webhook urls by starting w http/s - is that cool? wasn't sure how much to enforce 
- blocked if you don't have access or stream doesn't exist
![image](https://user-images.githubusercontent.com/7717434/125970561-1a4770dc-2911-4172-849e-7f587d6bcc93.png)

