### PR TITLE
fix(frontend): branches with / in their names work again now;

### DIFF
--- a/packages/frontend/src/router/index.js
+++ b/packages/frontend/src/router/index.js
@@ -97,7 +97,7 @@ const routes = [
             redirect: 'branches/main',
           },
           {
-            path: 'branches/:branchName',
+            path: 'branches/:branchName*',
             name: 'branch',
             meta: {
               title: 'Branch | Speckle'

--- a/packages/frontend/src/views/stream/Branch.vue
+++ b/packages/frontend/src/views/stream/Branch.vue
@@ -73,7 +73,7 @@
       <no-data-placeholder
         v-if="!$apollo.loading && stream.branch && stream.branch.commits.totalCount === 0"
       >
-        <h2 class="space-grotesk">This branch has no commits.</h2>
+        <h2 class="space-grotesk">Branch "{{stream.branch.name}}" has no commits.</h2>
       </no-data-placeholder>
     </v-row>
     <error-placeholder
@@ -183,6 +183,7 @@ export default {
     }
   },
   mounted() {
+    console.log(this.$route.params)
     if (this.$route.params.branchName === 'globals')
       this.$router.push(`/streams/${this.$route.params.streamId}/globals`)
   }


### PR DESCRIPTION
possibly we need to check the streamwrapper parsing logic (.NET & py) for getting branch names.