### PR TITLE
Embed: Adds matomo tracking under 'embed/view'

### DIFF
--- a/packages/frontend/src/embed/EmbedApp.vue
+++ b/packages/frontend/src/embed/EmbedApp.vue
@@ -3,6 +3,9 @@
 </template>
 <script>
 export default {
-  components: {}
+  components: {},
+  mounted() {
+    this.$matomo.trackPageView('embed/view')
+  }
 }
 </script>

--- a/packages/frontend/src/embed/embedApp.js
+++ b/packages/frontend/src/embed/embedApp.js
@@ -4,6 +4,14 @@ import vuetify from './embedVuetify'
 import router from './embedRouter'
 Vue.config.productionTip = false
 
+import VueMatomo from 'vue-matomo'
+
+Vue.use(VueMatomo, {
+  host: 'https://speckle.matomo.cloud',
+  siteId: 4,
+  router: router
+})
+
 new Vue({
   router,
   vuetify,


### PR DESCRIPTION
Pretty much self explanatory. We should now get stats for all embed views.