### PR TITLE
fix(docker): Build viewer with local ObjectLoader

### DIFF
--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -6,6 +6,8 @@ FROM node:14.16-buster-slim as build-stage
 WORKDIR /opt/viewer
 COPY packages/viewer/package*.json ./
 RUN npm install
+COPY packages/objectloader /opt/objectloader
+RUN npm install ../objectloader
 COPY packages/viewer .
 RUN npm run build
 

--- a/packages/objectloader/package-lock.json
+++ b/packages/objectloader/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@speckle/objectloader",
+  "version": "2.1.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@speckle/objectloader",
+      "version": "2.1.1",
+      "license": "Apache-2.0"
+    }
+  }
+}


### PR DESCRIPTION
When building the docker image, the viewer package was pulling the latest `ObjectLoader` from `npm` instead of using the local package.

Modified the Dockerfile in `frontend` to install it from the repo instead.
Special thanks to @cristi8 for the 2 liner quick fix!