### PR TITLE
fix(server): surrounds field names with qoutes in get obj children query

### DIFF
--- a/packages/server/modules/core/services/objects.js
+++ b/packages/server/modules/core/services/objects.js
@@ -223,7 +223,7 @@ module.exports = {
 
     if ( Array.isArray( select ) ) {
       select.forEach( ( field, index ) => {
-        q.select( knex.raw( 'jsonb_path_query(data, :path) as :name:', { path: '$.' + field, name: '' + index } ) )
+        q.select( knex.raw( 'jsonb_path_query(data, :path) as :name:', { path: `$."${field}"`, name: '' + index } ) )
       } )
     } else {
       fullObjectSelect = true
@@ -239,7 +239,7 @@ module.exports = {
       .andWhere( knex.raw( 'id > ?', [ cursor ? cursor : '0' ] ) )
       .orderBy( 'objects.id' )
       .limit( limit )
-
+      
     let rows = await q
 
     if ( rows.length === 0 ) {


### PR DESCRIPTION
so as to allow for the selection of fields with names like "@height" or "super test". should close #405. @cristi8, theoretically these arguments pass through the knex sanitisation filter, but please have a look! 