### PR TITLE
Only use lowercase names for local auth strategy

### DIFF
--- a/packages/server/modules/auth/strategies/local.js
+++ b/packages/server/modules/auth/strategies/local.js
@@ -17,11 +17,12 @@ module.exports = async ( app, session, sessionAppId, finalizeAuth ) => {
 
   app.post( '/auth/local/login', session, sessionAppId, async ( req, res, next ) => {
     try {
-      let valid = await validatePasssword( { email: req.body.email, password: req.body.password } )
+      const lowercaseEmail = req.body.email.toLowerCase()
+      let valid = await validatePasssword( { email: lowercaseEmail, password: req.body.password } )
 
       if ( !valid ) throw new Error( 'Invalid credentials' )
 
-      let user = await getUserByEmail( { email: req.body.email } )
+      let user = await getUserByEmail( { email: lowercaseEmail } )
       if ( !user ) throw new Error( 'Invalid credentials' )
 
       if ( req.body.suuid && user.suuid !== req.body.suuid ) {
@@ -43,6 +44,7 @@ module.exports = async ( app, session, sessionAppId, finalizeAuth ) => {
         throw new Error( 'Password missing' )
 
       let user = req.body
+      user.email = user.email.toLowerCase()
 
       if ( serverInfo.inviteOnly && !req.session.inviteId ) {
         throw new Error( 'This server is invite only. Please provide an invite id.' )

--- a/packages/server/modules/core/services/users.js
+++ b/packages/server/modules/core/services/users.js
@@ -38,7 +38,6 @@ module.exports = {
 
   async createUser( user ) {
     user.id = crs( { length: 10 } )
-    user.email = user.email.toLowerCase()
 
     if ( user.password ) {
       if ( user.password.length < 8 ) throw new Error( 'Password to short; needs to be 8 characters or longer.' )


### PR DESCRIPTION
As discussed in the speckle community https://speckle.community/t/users-email-stored-in-lowercase-in-the-server-but-lookup-uses-mixed-case/1996

When using federated access email's don't need to be stored in lowercase and currently new users can't log in to the system from Azure AD.