### PR TITLE
gergo/properEmailCasing

### DIFF
--- a/packages/server/modules/auth/strategies/local.js
+++ b/packages/server/modules/auth/strategies/local.js
@@ -17,11 +17,12 @@ module.exports = async ( app, session, sessionAppId, finalizeAuth ) => {
 
   app.post( '/auth/local/login', session, sessionAppId, async ( req, res, next ) => {
     try {
-      let valid = await validatePasssword( { email: req.body.email, password: req.body.password } )
+      const lowercaseEmail = req.body.email.toLowerCase()
+      let valid = await validatePasssword( { email: lowercaseEmail, password: req.body.password } )
 
       if ( !valid ) throw new Error( 'Invalid credentials' )
 
-      let user = await getUserByEmail( { email: req.body.email } )
+      let user = await getUserByEmail( { email: lowercaseEmail } )
       if ( !user ) throw new Error( 'Invalid credentials' )
 
       if ( req.body.suuid && user.suuid !== req.body.suuid ) {
@@ -43,6 +44,7 @@ module.exports = async ( app, session, sessionAppId, finalizeAuth ) => {
         throw new Error( 'Password missing' )
 
       let user = req.body
+      user.email = user.email.toLowerCase()
 
       if ( serverInfo.inviteOnly && !req.session.inviteId ) {
         throw new Error( 'This server is invite only. Please provide an invite id.' )

--- a/packages/server/modules/auth/strategies/local.js
+++ b/packages/server/modules/auth/strategies/local.js
@@ -17,12 +17,11 @@ module.exports = async ( app, session, sessionAppId, finalizeAuth ) => {
 
   app.post( '/auth/local/login', session, sessionAppId, async ( req, res, next ) => {
     try {
-      const lowercaseEmail = req.body.email.toLowerCase()
-      let valid = await validatePasssword( { email: lowercaseEmail, password: req.body.password } )
+      let valid = await validatePasssword( { email: req.body.email, password: req.body.password } )
 
       if ( !valid ) throw new Error( 'Invalid credentials' )
 
-      let user = await getUserByEmail( { email: lowercaseEmail } )
+      let user = await getUserByEmail( { email: req.body.email } )
       if ( !user ) throw new Error( 'Invalid credentials' )
 
       if ( req.body.suuid && user.suuid !== req.body.suuid ) {
@@ -44,7 +43,6 @@ module.exports = async ( app, session, sessionAppId, finalizeAuth ) => {
         throw new Error( 'Password missing' )
 
       let user = req.body
-      user.email = user.email.toLowerCase()
 
       if ( serverInfo.inviteOnly && !req.session.inviteId ) {
         throw new Error( 'This server is invite only. Please provide an invite id.' )

--- a/packages/server/modules/core/services/users.js
+++ b/packages/server/modules/core/services/users.js
@@ -27,7 +27,7 @@ const _ensureAtleastOneAdminRemains = async ( userId ) => {
   }
 }
 
-const userByEmailQuery = email => Users( ).where( 'email', 'ilike', `%${email}` )
+const userByEmailQuery = email => Users( ).whereRaw( 'lower(email) = lower(?)',[ email ] )
 
 
 module.exports = {

--- a/packages/server/modules/core/services/users.js
+++ b/packages/server/modules/core/services/users.js
@@ -38,7 +38,6 @@ module.exports = {
 
   async createUser( user ) {
     user.id = crs( { length: 10 } )
-    user.email = user.email.toLowerCase()
 
     if ( user.password ) {
       if ( user.password.length < 8 ) throw new Error( 'Password to short; needs to be 8 characters or longer.' )

--- a/packages/server/modules/core/tests/users.spec.js
+++ b/packages/server/modules/core/tests/users.spec.js
@@ -1,4 +1,6 @@
 /* istanbul ignore file */
+const bcrypt = require( 'bcrypt' )
+const crs = require( 'crypto-random-string' )
 const chai = require( 'chai' )
 const chaiHttp = require( 'chai-http' )
 const assert = require( 'assert' )
@@ -93,6 +95,30 @@ describe( 'Actors & Tokens @user-services', () => {
         return
       }
       assert.fail( 'short pwd' )
+    } )
+
+    it ( 'Should still find previously stored non lowercase emails', async ( ) => {
+      const email = 'Dim@gMail.cOm'
+      const user =  { name: 'Dim Sum', email, password: '1234567' } 
+      user.id = crs( { length: 10 } )
+      user.passwordDigest = await bcrypt.hash( user.password, 10 )
+      delete user.password
+
+      const [ userId ] = await knex( 'users' ).returning( 'id' ).insert( user )
+
+      const userByEmail = await getUserByEmail( { email } )
+      expect( userByEmail ).to.not.be.null
+      expect( userByEmail.email ).to.equal( email )
+      expect( userByEmail.id ).to.equal( userId )
+
+      const userByLowerEmail = await getUserByEmail( { email: email.toLowerCase() } )
+      expect( userByLowerEmail ).to.not.be.null
+      expect( userByLowerEmail.email ).to.equal( email )
+      expect( user.id ).to.equal( userId )
+
+      user.email = user.email.toLowerCase()
+      const foundNotCreatedUser = await findOrCreateUser( { user } )
+      expect( foundNotCreatedUser.id ).to.equal( userId )
     } )
 
     it( 'Should not create an user with the same email', async () => {


### PR DESCRIPTION
- Only use lowercase names for local auth strategy
- fix(core users): handle case insensitive email comparison in a backwards compatible way
