### PR TITLE
gergo/streamInviteFix

### DIFF
--- a/packages/server/modules/auth/strategies/local.js
+++ b/packages/server/modules/auth/strategies/local.js
@@ -44,22 +44,27 @@ module.exports = async ( app, session, sessionAppId, finalizeAuth ) => {
 
       let user = req.body
 
-      let userId
-      // go ahead with register
-      if ( !serverInfo.inviteOnly ){
-        userId = await createUser( user )
-      } else {
-        if ( !req.session.inviteId )
-          throw new Error( 'This server is invite only. Please provide an invite id.' )
-        
-        if ( !await validateInvite( { id: req.session.inviteId, email: user.email } ) )
-          throw new Error( 'Invite email mismatch. Please use the original email the invite was sent to register.' )
+      // 1. if the server is invite only you must have an invite
+      if ( serverInfo.inviteOnly && !req.session.inviteId )
+        throw new Error( 'This server is invite only. Please provide an invite id.' )
 
-        userId = await createUser( user )
-        await useInvite( { id: req.session.inviteId, email: user.email } )
+      // 2. if you have an invite it must be valid, both for invite only and public servers
+      if ( req.session.inviteId ) {
+        const isInviteValid = await validateInvite( { id: req.session.inviteId, email: user.email } ) 
+        if ( !isInviteValid )
+          throw new Error( 'Invite email mismatch. Please use the original email the invite was sent to register.' )
       }
 
+      // 3. at this point we know, that we have one of these cases:
+      //    * the server is invite only and the user has a valid invite
+      //    * the server public and the user has a valid invite
+      //    * the server public and the user doesn't have an invite
+      // so we go ahead and register the user
+      let userId = await createUser( user )
       req.user = { id: userId, email: user.email }
+
+      // 4. if the user had an invite, its used up
+      if ( req.session.inviteId ) await useInvite( { id: req.session.inviteId, email: user.email } )
 
       return next( )
     } catch ( err ) {

--- a/packages/server/modules/core/services/generic.js
+++ b/packages/server/modules/core/services/generic.js
@@ -15,36 +15,26 @@ module.exports = {
   },
 
   async getAllScopes( ) {
-
     return await Scopes( ).select( '*' )
-
   },
 
   async getPublicScopes() {
-
     return await Scopes( ).select( '*' ).where( { public: true } )
-
   },
 
   async getAllRoles( ) {
-
     return await Roles( ).select( '*' )
-
   },
 
   async getPublicRoles() {
-
     return await Roles( ).select( '*' ).where( { public: true } )
-
   },
 
   async updateServerInfo( { name, company, description, adminContact, termsOfService, inviteOnly } ) {
-
     let serverInfo = await Info( ).select( '*' ).first( )
     if ( !serverInfo )
       return await Info( ).insert( { name, company, description, adminContact, termsOfService, inviteOnly, completed: true } )
     else
       return await Info( ).where( { id: 0 } ).update( { name, company, description, adminContact, termsOfService, inviteOnly, completed: true } )
-
   }
 }


### PR DESCRIPTION
- fix(server local auth): user is created before the invite is used, so stream permissions can be set
- fix(server local auth): re-rework the local auth workflow, prev, there was a gap
- test(server auth): add test for server invite with stream sharing
