### PR TITLE
Updated viewer conversion to support 3,4 cardinality faces, and not throw exception when n-gon faces are present

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speckle/viewer",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A 3d viewer for Speckle, based on threejs.",
   "homepage": "https://speckle.systems",
   "repository": {

--- a/packages/viewer/src/modules/converter/Converter.js
+++ b/packages/viewer/src/modules/converter/Converter.js
@@ -313,15 +313,23 @@ export default class Coverter {
 
       let k = 0
       while ( k < faces.length ) {
-        if ( faces[ k ] === 1 ) { // QUAD FACE
+      let n = faces[ k ]
+      if ( n <= 3 ) n += 3 // 0 -> 3, 1 -> 4
+
+        if ( n === 4 ) { // QUAD FACE
           indices.push( faces[ k + 1 ], faces[ k + 2 ], faces[ k + 3 ] )
           indices.push( faces[ k + 1 ], faces[ k + 3 ], faces[ k + 4 ] )
-          k += 5
-        } else if ( faces[ k ] === 0 ) { // TRIANGLE FACE
+        } else if ( n === 3 ) { // TRIANGLE FACE
           indices.push( faces[ k + 1 ], faces[ k + 2 ], faces[ k + 3 ] )
-          k += 4
-        } else throw new Error( `Mesh type not supported. Face topology indicator: ${faces[k]}` )
-      }
+        } else { //N-GON FACE
+          //TODO triangulate n-gon face.
+
+          //There is no need to throw an exception here, unsupported faces will simply be ignored.
+          //throw new Error( `Mesh type not supported. Face topology indicator: ${faces[k]}` )
+        }
+
+      k += n + 1
+    }
       buffer.setIndex( indices )
 
       buffer.setAttribute(


### PR DESCRIPTION
Fixes the P0 part of #444:
 - Mesh faces with 3/4 cardinality indicators will now be converted as triangles/quads respecfully, previosuly they were ignored and only faces with 0/1 indicators would be converted.

- N-gon faces on a mesh will be ignored, previosuly, the entire mesh object would be ignored.

The seccond part of #444, Full N-gon conversion, is still not complete, and will likley require a triangulation function.


Has been tested in the example.html viewer and behaves expectedly.
