### PR TITLE
Viewer: Fixed issue with n-gon trianguation of quad/n-gon only meshes leading to corrupted geometry in the viewer

### DIFF
--- a/packages/viewer/src/modules/converter/Converter.js
+++ b/packages/viewer/src/modules/converter/Converter.js
@@ -113,7 +113,7 @@ export default class Coverter {
           await Promise.all( childrenConversionPromisses )
           this.activePromises -= childrenConversionPromisses.length
         }
-        
+
         return
       }
     }
@@ -318,23 +318,21 @@ export default class Coverter {
         let n = faces[ k ]
         if ( n <= 3 ) n += 3 // 0 -> 3, 1 -> 4
 
-        if ( n === 3 ) { // TRIANGLE FACE
+        if ( n === 3 ) { // Triangle face
           indices.push( faces[ k + 1 ], faces[ k + 2 ], faces[ k + 3 ] )
-        } else { //Quad or N-GON FACE
-          if( n === 4) { // Handle quads the old way
-            indices.push( faces[ k + 1 ], faces[ k + 2 ], faces[ k + 3 ] )
-            indices.push( faces[ k + 1 ], faces[ k + 3 ], faces[ k + 4 ] )          
-          } else { // Anything else goes through the magic box
-            const triangulation = MeshTriangulationHelper.triangulateFace( k, faces, vertices )
-            for( let t = 0; t < triangulation.length; t += 3 ) {
-              indices.push( triangulation[ t ], triangulation[ t + 1 ], triangulation[ t + 2 ] )
-            }
-          }
+        } else { // Quad or N-gon face
+          const triangulation = MeshTriangulationHelper.triangulateFace( k, faces, vertices )
+          indices.push( ...triangulation )
         }
 
         k += n + 1
       }
-      buffer.setIndex( indices )
+
+      if ( vertices.length >= 65535 || indices.length >= 65535 ) {
+        buffer.setIndex( new THREE.Uint32BufferAttribute( indices, 1 ) )
+      } else {
+        buffer.setIndex( new THREE.Uint16BufferAttribute ( indices, 1 ) )
+      }
 
       buffer.setAttribute(
         'position',

--- a/packages/viewer/src/modules/converter/MeshTriangulationHelper.js
+++ b/packages/viewer/src/modules/converter/MeshTriangulationHelper.js
@@ -14,7 +14,7 @@ export default class MeshTriangulationHelper {
    */
   static triangulateFace( faceIndex, faces, vertices ) {
     let n = faces[faceIndex]
-    if ( n <= 3 ) n += 3 // 0 -> 3, 1 -> 4
+    if ( n < 3 ) n += 3 // 0 -> 3, 1 -> 4
 
     //Converts from relative to absolute index (returns index in mesh.vertices list)
     function asIndex( v ) {
@@ -145,7 +145,8 @@ export default class MeshTriangulationHelper {
    */
   static triangleIsCCW( referenceNormal, a, b, c )
   {
-    const triangleNormal = c.sub( a ).cross( b.sub( a ) ).getNormal()
+    let triangleNormal = c.sub( a ).cross( b.sub( a ) )
+    triangleNormal.normalize()
     return referenceNormal.dot( triangleNormal ) > 0.0
   }
 
@@ -162,42 +163,26 @@ class Vector3 {
     this.z = z
   }
 
-
-  getNormal( )
-  {
-    const scale = 1.0 / Math.sqrt( this.squareSum() )
-    return new Vector3( this.x * scale, this.y * scale, this.z * scale )
-  }
-
   add( v ) {
-    this.x += v.x
-    this.y += v.y
-    this.z += v.z
-    return this
+    return new Vector3( this.x + v.x, this.y + v.y, this.z + v.z )
   }
 
   sub( v ) {
-    this.x -= v.x
-    this.y -= v.y
-    this.z -= v.z
-    return this
+    return new Vector3( this.x - v.x, this.y - v.y, this.z - v.z )
   }
 
   mul( n ) {
-    this.x *= n
-    this.y *= n
-    this.z *= n
-    return this
+    return new Vector3( this.x - n, this.y - n, this.z - n )
   }
 
   dot( v ) { return this.x * v.x + this.y * v.y + this.z * v.z }
 
   cross( v ) {
-    this.x = this.y * v.z - this.z * v.y
-    this.y = this.z * v.x - this.x * v.z
-    this.z = this.x * v.y - this.y * v.x
+    const nx = this.y * v.z - this.z * v.y
+    const ny = this.z * v.x - this.x * v.z
+    const nz = this.x * v.y - this.y * v.x
 
-    return this
+    return new Vector3( nx,ny,nz )
   }
 
   squareSum( ) {
@@ -206,7 +191,9 @@ class Vector3 {
 
   normalize() {
     const scale = 1.0 / Math.sqrt( this.squareSum() )
-    return this.mul( scale )
+    this.x *= scale
+    this.y *= scale
+    this.z *= scale
   }
 
 


### PR DESCRIPTION
- Fixes issue with quad/n-gon only geometry (with a vertices or face count over `UInt16.MaxValue = 65535`) being displayed incorrectly in the viewer.
   - The hotfix for this issue #551 fixed only Quad only geometry.
   - This fix should also fix n-gon only geometry.
   - Re-adds proper triangulation of concave quads (regressed in the hotfix)
   - This fix works by Ensures that a `Uint32BufferAttribute` will be used (if needed) for face index buffer.

    See discussion https://speckle.community/t/color-mesh-visualization-breaking-with-new-web-viewer-update/2282

- Also Fixes a somewhat unrelated issue with n-gon triangulation that would cause ear clipping to sometimes clip an external ear. This was caused by some wonky vector maths.


