### PR TITLE
previews cache control

### DIFF
--- a/packages/server/modules/previews/index.js
+++ b/packages/server/modules/previews/index.js
@@ -78,7 +78,7 @@ exports.init = ( app, options ) => {
     } else {
       res.contentType( 'image/png' )
       // If the preview is a buffer, it comes from the DB and can be cached on clients
-      res.set( 'Cache-Control', 'private, max-age=31536000' )
+      res.set( 'Cache-Control', 'private, max-age=604800' )
       res.send( previewBufferOrFile.buffer )  
     }
   }

--- a/packages/server/modules/previews/index.js
+++ b/packages/server/modules/previews/index.js
@@ -77,6 +77,8 @@ exports.init = ( app, options ) => {
       res.sendFile( previewBufferOrFile.file )
     } else {
       res.contentType( 'image/png' )
+      // If the preview is a buffer, it comes from the DB and can be cached on clients
+      res.set( 'Cache-Control', 'private, max-age=31536000' )
       res.send( previewBufferOrFile.buffer )  
     }
   }


### PR DESCRIPTION
set the cache-control header for preview images, to allow browser cache of max 1 week
