### PR TITLE
IFC Service: Reshaping of properties + pset extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ packages/frontend/schema.graphql
 packages/server/reports*
 
 **/venv/**
+**/start/

--- a/packages/fileimport-service/ifc/parser.js
+++ b/packages/fileimport-service/ifc/parser.js
@@ -126,6 +126,14 @@ module.exports = class IFCParser {
     // Find children and populate element
     const childrenIds = this.getAllRelatedItemsOfType( element.expressID, WebIFC.IFCRELCONTAINEDINSPATIALSTRUCTURE, 'RelatingStructure', 'RelatedElements' )
     if( childrenIds.length > 0 )  element.rawChildren = childrenIds.map( ( childId ) => this.api.GetLine( this.modelId, childId, true ) )
+    
+    // Find related property sets
+    const psetsIds = this.getAllRelatedItemsOfType( element.expressID, WebIFC.IFCRELDEFINESBYPROPERTIES, 'RelatingPropertyDefinition', 'RelatedObjects' )
+    if( psetsIds.length > 0 )  element.rawPsets = psetsIds.map( ( childId ) => this.api.GetLine( this.modelId, childId, true ) )
+
+    // Find related type properties
+    const typePropsId = this.getAllRelatedItemsOfType( element.expressID, WebIFC.IFCRELDEFINESBYTYPE, 'RelatingType', 'RelatedObjects' )
+    if( typePropsId.length > 0 )  element.rawTypeProps = typePropsId.map( ( childId ) => this.api.GetLine( this.modelId, childId, true ) )
 
     // Lookup geometry in generated geometries object
     if( this.productGeo[element.expressID] ) {
@@ -139,63 +147,13 @@ module.exports = class IFCParser {
     const isSpecial = specialTypes.find( t => t.type === element.speckle_type )
     // Recurse all children
     if ( recursive ) {
+      await this.processSubElements( element, 'rawSpatialChildren', 'spatialChildren', isSpecial, recursive, depth, specialTypes )
+      await this.processSubElements( element, 'rawChildren', 'children', isSpecial, recursive, depth, specialTypes )
+      await this.processSubElements( element, 'rawPsets', 'propertySets', false, recursive, depth, specialTypes )
+      await this.processSubElements( element, 'rawTypeProps', 'typeProps', false, recursive, depth, specialTypes )
 
-      if( element.rawSpatialChildren ) {
-        if( !isSpecial )
-          element.spatialChildren = []
-        let childCount = {
-
-        }
-        for( let child of element.rawSpatialChildren ) {
-          let res = await this.traverse( child, recursive, depth + 1, specialTypes )
-          if( res.referencedId ) {
-            if( isSpecial ) {
-              let name = child[isSpecial.key]
-              if ( !name || name.length === 0 )
-                name = 'Undefined'
-              if( !childCount[name] )
-                childCount[name] = 0
-              if( childCount[name] > 0 )
-                name += '-' + childCount[name]++
-              element[name] = res
-            } else
-              element.spatialChildren.push( res )
-            this.project.__closure[res.referencedId.toString()] = depth 
-            element.__closure[res.referencedId.toString()] = 1
-            
-            // adds to parent (this element) the child's closure tree.
-            if( this.closureCache[child.expressID.toString()] ) {
-              for( let key of Object.keys( this.closureCache[child.expressID.toString()] ) ) {
-                element.__closure[key] = this.closureCache[child.expressID.toString()][key] + 1
-              }
-            }
-          }
-        }
-        delete element.rawSpatialChildren
-      }
-      
-      if ( element.rawChildren ) { 
-        element.children = []
-        for( let child of element.rawChildren ) {
-          let res = await this.traverse( child, recursive, depth + 1 ) 
-          if( res.referencedId ) {
-            element.children.push( res )
-            this.project.__closure[res.referencedId.toString()] = depth 
-            element.__closure[res.referencedId.toString()] = 1
-
-            // adds to parent (this element) the child's closure tree.
-            if( this.closureCache[child.expressID.toString()] ) {
-              for( let key of Object.keys( this.closureCache[child.expressID.toString()] ) ) {
-                element.__closure[key] = this.closureCache[child.expressID.toString()][key] + 1
-              }
-            }
-          }
-        }
-        delete element.rawChildren
-      }
-
-      if( element.children || element.spatialChildren ) {
-        console.log( `${element.constructor.name} ${element.GlobalId}: children count: ${ element.children ? element.children.length : '0'}; spatial children count: ${element.spatialChildren ? element.spatialChildren.length : '0'} ` )
+      if( element.children || element.spatialChildren || element.propertySets || element.typeProps ) {
+        console.log( `${element.constructor.name} ${element.GlobalId}:\n\tchildren count: ${ element.children ? element.children.length : '0'};\n\tspatial children count: ${element.spatialChildren ? element.spatialChildren.length : '0'};\n\tproperty sets count: ${element.propertySets ? element.propertySets.length : 0};\n\ttype properties: ${element.typeProps ? element.typeProps.length : 0}` )
       }
 
     }
@@ -213,6 +171,41 @@ module.exports = class IFCParser {
     }
   }
 
+
+  async processSubElements( element, key, newKey, isSpecial, recursive, depth, specialTypes ) {
+    if ( element[key] ) {
+      if ( !isSpecial )
+        element[newKey] = []
+      let childCount = {}
+      for ( let child of element[key] ) {
+        let res = await this.traverse( child, recursive, depth + 1, specialTypes )
+        if ( res.referencedId ) {
+          if ( isSpecial ) {
+            let name = child[isSpecial.key]
+            if ( !name || name.length === 0 )
+              name = 'Undefined'
+            if ( !childCount[name] )
+              childCount[name] = 0
+            if ( childCount[name] > 0 )
+              name += '-' + childCount[name]++
+            element[name] = res
+          }
+          else
+            element[newKey].push( res )
+          this.project.__closure[res.referencedId.toString()] = depth
+          element.__closure[res.referencedId.toString()] = 1
+
+          // adds to parent (this element) the child's closure tree.
+          if ( this.closureCache[child.expressID.toString()] ) {
+            for ( let key of Object.keys( this.closureCache[child.expressID.toString()] ) ) {
+              element.__closure[key] = this.closureCache[child.expressID.toString()][key] + 1
+            }
+          }
+        }
+      }
+      delete element[key]
+    }
+  }
 
   // (c) https://github.com/agviegas/web-ifc-three
   extractVertexData( vertexData ) {

--- a/packages/fileimport-service/ifc/parser.js
+++ b/packages/fileimport-service/ifc/parser.js
@@ -24,7 +24,7 @@ module.exports = class IFCParser {
     // Steps: create and store in speckle all the geometries (meshes) from this project and store them 
     // as reference objects in this.productGeo
     this.productGeo = {}
-    await this.createGeometries()    
+    await this.createGeometries()
     console.log( `Geometries created: ${Object.keys( this.productGeo ).length} meshes.` )
     
     // Lastly, traverse the ifc project object and parse it into something friendly; as well as 
@@ -98,12 +98,12 @@ module.exports = class IFCParser {
     
     // If array, traverse all items in it.
     if( Array.isArray( element ) ) {
-      return element.map( async el => await this.traverse( el,recursive, depth + 1 ) )
+      return await Promise.all( element.map( async el => await this.traverse( el,recursive, depth + 1 ) ) )
     }
 
     // If it has no expressID, its either a simple type or a { type, value } object. 
     if( !element.expressID ) {
-      return element.value !== null && element.value !== undefined ? element.value : element
+      return await Promise.resolve( element.value !== null && element.value !== undefined ? element.value : element )
     }
 
     if( this.cache[element.expressID.toString()] ) return this.cache[element.expressID.toString()]

--- a/packages/fileimport-service/src/daemon.js
+++ b/packages/fileimport-service/src/daemon.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const crypto = require( 'crypto' )
 const knex = require( '../knex' )
 
 const { getFileStream } = require( './filesApi' )


### PR DESCRIPTION
# Description

Fixes #454 

Changes the resulting structure of an imported IFC file:


- First 3 levels of the IFC file (Project, Site, Building) will have their `children` and `spatialChildren` extracted directly as properties of their parent, as opposed to having them in as items in an array.
- The child name will be used as the `key`. If two or more children have the same name, a suffix will be added to any subsequent element with that name.
- This behaviour can be customised in the `specialTypes` input of the `traverse` function.

Refactored the processing of `rawChildren` and `rawSpatialChildren` into a new function -> `processSubElements` that is also used now to extract the `propertySets` of any object.

Finally, I modified the detaching process so that things like `IfcOwnerHistory` will also be detached and shared by all objects that use it (every ifc object basically...)

