### PR TITLE
Feature/isomorphic object loader

### DIFF
--- a/packages/objectloader/examples/node/script.js
+++ b/packages/objectloader/examples/node/script.js
@@ -1,1 +1,24 @@
-// NOTE: This lib is not working in node, because node-fetch returns node-native readable streams - we need a workaround first. 
+// Since Node v<18 does not provide fetch, we need to pass it in the options object. Note that fetch must return a WHATWG compliant stream, so cross-fetch won't work, but node/undici's implementation will.
+
+import { fetch } from 'undici'
+import ObjectLoader from '../../index.js'
+
+let loader = new ObjectLoader({
+  serverUrl:"https://latest.speckle.dev",
+  streamId:"3ed8357f29",
+  objectId:"0408ab9caaa2ebefb2dd7f1f671e7555",
+  options:{ enableCaching: false, excludeProps:[], fetch }
+})
+
+
+let loadData = async function loadData() {
+
+  let obj = await loader.getAndConstructObject((e) =>{
+    console.log(e) // log progress!
+  })
+
+  console.log('Done!')
+  console.log( obj )
+}
+
+loadData()

--- a/packages/objectloader/index.js
+++ b/packages/objectloader/index.js
@@ -48,7 +48,12 @@ export default class ObjectLoader {
     this.lastAsyncPause = Date.now()
     this.existingAsyncPause = null
 
-    this.fetch = this.options.fetch || window.fetch
+    // we can't simply bind fetch to this.fetch, so instead we have to do some acrobatics: https://stackoverflow.com/questions/69337187/uncaught-in-promise-typeerror-failed-to-execute-fetch-on-workerglobalscope#comment124731316_69337187
+    this.preferredFetch = options.fetch
+    this.fetch = function(...args) {
+      let currentFetch = this.preferredFetch || fetch
+      return currentFetch(...args)
+    }
 
   }
 

--- a/packages/objectloader/index.js
+++ b/packages/objectloader/index.js
@@ -10,7 +10,7 @@ export default class ObjectLoader {
    * Creates a new object loader instance.
    * @param {*} param0
    */
-  constructor( { serverUrl, streamId, token, objectId, options = { enableCaching: true, fullyTraverseArrays: false, excludeProps: [ ] } } ) {
+  constructor( { serverUrl, streamId, token, objectId, options = { enableCaching: true, fullyTraverseArrays: false, excludeProps: [ ], fetch:null } } ) {
     this.INTERVAL_MS = 20
     this.TIMEOUT_MS = 180000 // three mins
 
@@ -47,6 +47,8 @@ export default class ObjectLoader {
 
     this.lastAsyncPause = Date.now()
     this.existingAsyncPause = null
+
+    this.fetch = this.options.fetch || window.fetch
 
   }
 
@@ -329,7 +331,7 @@ export default class ObjectLoader {
       readBuffers.push( '' )
       finishedRequests.push( false )
 
-      fetch(
+      this.fetch(
         this.requestUrlChildren,
         {
           method: 'POST',
@@ -397,7 +399,7 @@ export default class ObjectLoader {
     const cachedRootObject = await this.cacheGetObjects( [ this.objectId ] )
     if ( cachedRootObject[ this.objectId ] )
       return cachedRootObject[ this.objectId ]
-    const response = await fetch( this.requestUrlRootObj, { headers: this.headers } )
+    const response = await this.fetch( this.requestUrlRootObj, { headers: this.headers } )
     const responseText = await response.text()
     this.cacheStoreObjects( [ `${this.objectId}\t${responseText}` ] )
     return responseText

--- a/packages/objectloader/package.json
+++ b/packages/objectloader/package.json
@@ -15,5 +15,8 @@
   },
   "keywords": ["speckle", "aec", "speckle api"],
   "author": "AEC Systems",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "undici": "^4.14.1"
+  }
 }

--- a/packages/objectloader/readme.md
+++ b/packages/objectloader/readme.md
@@ -12,7 +12,9 @@ Comprehensive developer and user documentation can be found in our:
 
 This is a small utility class that helps you stream an object and all its sub-components from the Speckle Server API. It is intended to be used in contexts where you want to "download" the whole object, or iteratively traverse its whole tree.
 
-Here's a sample way on how to use it, pfilfered from the [3d viewer package](../viewer):
+### In the browser
+
+Here's a sample way on how to use it, pilfered from the [3d viewer package](../viewer):
 
 ```js
 
@@ -52,6 +54,19 @@ let loader = new ObjectLoader( {
 
 let obj = await loader.getAndConstructObject( ( e ) => console.log( 'Progress', e ) )
 
+### On the server
+
+Since Node.js does not yet support the [`fetch API`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch), you'll need to provide your own `fetch` function in the options object. Note that `fetch` must return a [Web Stream](https://nodejs.org/api/webstreams.html), so [node-fetch](https://github.com/node-fetch/node-fetch) won't work, but [node/undici's](https://undici.nodejs.org/) implementation will.
+
+```js
+import { fetch } from 'undici'
+
+let loader = new ObjectLoader({
+  serverUrl: 'https://latest.speckle.dev',
+  streamId: '3ed8357f29',
+  objectId: '0408ab9caaa2ebefb2dd7f1f671e7555',
+  options: { enableCaching: false, excludeProps: [], fetch },
+})
 ```
 
 ## Community


### PR DESCRIPTION
Hi! 🙂

This pull request adds the option to provide `ObjectLoader` with a custom `fetch` for server side use. 

@didimitrie @teocomi Do you think this is a viable approach? If so, I'll add tests.

Went with [undici](https://github.com/nodejs/undici) as it will become Node's fetch implementation in v18, even though it is still [considered experimental](https://undici.nodejs.org/#/?id=undicifetchinput-init-promise) at this time.