### PR TITLE
unified build number in docker tagging

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -8,7 +8,9 @@ FOLDER="${FOLDER:-packages}"
 
 DOCKER_IMAGE_TAG=speckle/speckle-$SPECKLE_SERVER_PACKAGE
 
-IMAGE_VERSION_TAG=$(./.circleci/get_version.sh)
+# IMAGE_VERSION_TAG=$(./.circleci/get_version.sh)
+IMAGE_VERSION_TAG="${IMAGE_VERSION_TAG:-0}"
+echo $IMAGE_VERSION_TAG
 
 docker build --build-arg SPECKLE_SERVER_VERSION=$IMAGE_VERSION_TAG -t $DOCKER_IMAGE_TAG:latest . -f $FOLDER/$SPECKLE_SERVER_PACKAGE/Dockerfile
 
@@ -19,5 +21,4 @@ if [[ "$IMAGE_VERSION_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 echo "$DOCKER_REG_PASS" | docker login -u "$DOCKER_REG_USER" --password-stdin $DOCKER_REG_URL
-docker image ls
 docker push -a $DOCKER_IMAGE_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       # - run: echo "$BAZ"
       # - run: echo "export FOO=foo.`date +%Y%m%d.%H%M%S`" >>workspace/new-env-vars
       # - run: echo "export BOB=$BAZ" >> workspace/new-env-vars
-      - run: cat workspace/env-vars >> $BASH_ENV
+      # - run: cat workspace/env-vars >> $BASH_ENV
       # - run: echo ${FOO:-NULL}
       # - run: echo ${BAZ:-NULL}
       # - run: echo ${BOB:-NULL}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,10 @@ jobs:
       - run: mkdir -p workspace
       - run:
           name: set version
-          command: echo $(./.circleci/get_version.sh)
+          command: |
+            echo $(./.circleci/get_version.sh)
+            SPECKLE_VERSION=$(./.circleci/get_version.sh)
+            echo $SPECKLE_VERSION
       # - run:
       #     name: set var
       #     command: echo "export BAZ=baz.`date +%Y%m%d.%H%M`" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
       - run: mkdir -p workspace
       - run:
           name: set version
-          command: echo ./.circleci/get_version.sh
+          command: echo $(./.circleci/get_version.sh)
       # - run:
       #     name: set var
       #     command: echo "export BAZ=baz.`date +%Y%m%d.%H%M`" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ orbs:
 workflows:
   version: 2
 
-defaults: &defaults
-  working_directory: /tmp/ci
-
   test-build:
     jobs:
       - test-server
@@ -105,7 +102,7 @@ jobs:
 
   get-version:
     docker: *docker-image
-    <<: *defaults
+    working_directory: /tmp/ci
     steps:
       - checkout
       - run: pwd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,22 +116,22 @@ jobs:
       - run: mkdir -p workspace
       - run:
           name: set version
-          command: SPECKLE_VERSION=./.circleci/get_version.sh
+          command: echo "export SPECKLE_VERSION=./.circleci/get_version.sh" >> workspace/env-vars
       # - run:
       #     name: set var
       #     command: echo "export BAZ=baz.`date +%Y%m%d.%H%M`" >> $BASH_ENV
       # - run: echo "$BAZ"
       # - run: echo "export FOO=foo.`date +%Y%m%d.%H%M%S`" >>workspace/new-env-vars
       # - run: echo "export BOB=$BAZ" >> workspace/new-env-vars
-      # - run: cat workspace/new-env-vars >> $BASH_ENV
+      - run: cat workspace/env-vars >> $BASH_ENV
       # - run: echo ${FOO:-NULL}
       # - run: echo ${BAZ:-NULL}
       # - run: echo ${BOB:-NULL}
       - run: echo $SPECKLE_VERSION
-      # - persist_to_workspace:
-      #     root: workspace
-      #     paths:
-      #         - new-env-vars
+      - persist_to_workspace:
+          root: workspace
+          paths:
+              - env-vars
 
 
   test-server:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,14 @@ orbs:
 workflows:
   version: 2
 
+defaults: &defaults
+  working_directory: /tmp/ci
+
   test-build:
     jobs:
       - test-server
       - lint
+      - get-version
 
       # - build-viewer:
       #     # built the npm package
@@ -35,6 +39,7 @@ workflows:
             branches:
               only:
                 - main
+                - gergo/CIRewrite
           requires:
             - lint
             - test-server
@@ -97,6 +102,33 @@ jobs:
     steps:
       - checkout
       - run: node --version
+
+  get-version:
+    docker: *docker-image
+    <<: *defaults
+    steps:
+      - checkout
+      - run: pwd
+      - run: mkdir -p workspace
+      - run:
+          name: set version
+          command: SPECKLE_VERSION = ./.circleci/get_version.sh
+      # - run:
+      #     name: set var
+      #     command: echo "export BAZ=baz.`date +%Y%m%d.%H%M`" >> $BASH_ENV
+      # - run: echo "$BAZ"
+      # - run: echo "export FOO=foo.`date +%Y%m%d.%H%M%S`" >>workspace/new-env-vars
+      # - run: echo "export BOB=$BAZ" >> workspace/new-env-vars
+      # - run: cat workspace/new-env-vars >> $BASH_ENV
+      # - run: echo ${FOO:-NULL}
+      # - run: echo ${BAZ:-NULL}
+      # - run: echo ${BOB:-NULL}
+      - run: echo $SPECKLE_VERSION
+      # - persist_to_workspace:
+      #     root: workspace
+      #     paths:
+      #         - new-env-vars
+
 
   test-server:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
       - run: mkdir -p workspace
       - run:
           name: set version
-          command: echo "export SPECKLE_VERSION=./.circleci/get_version.sh" >> workspace/env-vars
+          command: SPECKLE_VERSION=$(./.circleci/get_version.sh)
       # - run:
       #     name: set var
       #     command: echo "export BAZ=baz.`date +%Y%m%d.%H%M`" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
 
   get-version:
     docker: *docker-image
-    working_directory: /tmp/ci
+    working_directory: &work-dir /tmp/ci
     steps:
       - checkout
       - run: pwd
@@ -117,14 +117,13 @@ jobs:
       - run:
           name: set version
           command: |
-            echo "export SPECKLE_VERSION=$(./.circleci/get_version.sh)" >> workspace/env-vars
+            echo "export IMAGE_VERSION_TAG=$(circleci/get_version.sh)" >> workspace/env-vars
       - run: cat workspace/env-vars >> $BASH_ENV
-      - run: echo $SPECKLE_VERSION
+      - run: echo $IMAGE_VERSION_TAG
       - persist_to_workspace:
           root: workspace
           paths:
               - env-vars
-
 
   test-server:
     docker:
@@ -179,8 +178,12 @@ jobs:
 
   docker-build-and-publish: &docker-job
     docker: *docker-image
+    working_directory: *work-dir
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/ci/workspace
+      - run: cat workspace/env-vars >> $BASH_ENV
       - setup_remote_docker:
           docker_layer_caching: true
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,18 +40,21 @@ workflows:
           requires:
             - lint
             - test-server
+            - get-version
 
       - docker-build-and-publish-frontend:
           context: *docker-hub-context
           filters: *filters-build
           requires:
             - lint
+            - get-version
 
       - docker-build-and-publish-webhooks:
           context: *docker-hub-context
           filters: *filters-build
           requires:
             - lint
+            - get-version
             - test-server
 
       - docker-build-and-publish-file-imports:
@@ -59,6 +62,7 @@ workflows:
           filters: *filters-build
           requires:
             - lint
+            - get-version
             - test-server
 
       - docker-build-and-publish-previews:
@@ -66,6 +70,7 @@ workflows:
           filters: *filters-build
           requires:
             - lint
+            - get-version
             - test-server
 
       - docker-build-and-publish-test-container:
@@ -73,6 +78,7 @@ workflows:
           filters: *filters-build
           requires:
             - lint
+            - get-version
             - test-server
 
       - publish-helm-chart:
@@ -80,6 +86,7 @@ workflows:
           requires:
             - lint
             - test-server
+            - get-version
             - docker-build-and-publish-server
             - docker-build-and-publish-frontend
             - docker-build-and-publish-webhooks
@@ -109,7 +116,7 @@ jobs:
       - run: mkdir -p workspace
       - run:
           name: set version
-          command: SPECKLE_VERSION = ./.circleci/get_version.sh
+          command: SPECKLE_VERSION=./.circleci/get_version.sh
       # - run:
       #     name: set var
       #     command: echo "export BAZ=baz.`date +%Y%m%d.%H%M`" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,18 +117,8 @@ jobs:
       - run:
           name: set version
           command: |
-            SPECKLE_VERSION=$(./.circleci/get_version.sh)
-            echo "export SPECKLE_VERSION=$SPECKLE_VERSION" >> workspace/env-vars
-      # - run:
-      #     name: set var
-      #     command: echo "export BAZ=baz.`date +%Y%m%d.%H%M`" >> $BASH_ENV
-      # - run: echo "$BAZ"
-      # - run: echo "export FOO=foo.`date +%Y%m%d.%H%M%S`" >>workspace/new-env-vars
-      # - run: echo "export BOB=$BAZ" >> workspace/new-env-vars
+            echo "export SPECKLE_VERSION=$(./.circleci/get_version.sh)" >> workspace/env-vars
       - run: cat workspace/env-vars >> $BASH_ENV
-      # - run: echo ${FOO:-NULL}
-      # - run: echo ${BAZ:-NULL}
-      # - run: echo ${BOB:-NULL}
       - run: echo $SPECKLE_VERSION
       - persist_to_workspace:
           root: workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,8 +231,12 @@ jobs:
 
   publish-helm-chart:
     docker: *docker-image
+    working_directory: *work-dir
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/ci/workspace
+      - run: cat workspace/env-vars >> $BASH_ENV
       - add_ssh_keys:
           fingerprints:
             - '18:74:c4:b9:dc:66:b2:66:1d:81:56:0d:0a:87:9b:b1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,9 +117,8 @@ jobs:
       - run:
           name: set version
           command: |
-            echo $(./.circleci/get_version.sh)
             SPECKLE_VERSION=$(./.circleci/get_version.sh)
-            echo $SPECKLE_VERSION
+            echo "export SPECKLE_VERSION=$SPECKLE_VERSION" >> workspace/env-vars
       # - run:
       #     name: set var
       #     command: echo "export BAZ=baz.`date +%Y%m%d.%H%M`" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ workflows:
             branches:
               only:
                 - main
-                - gergo/CIRewrite
           requires:
             - lint
             - test-server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
       # - run: echo "$BAZ"
       # - run: echo "export FOO=foo.`date +%Y%m%d.%H%M%S`" >>workspace/new-env-vars
       # - run: echo "export BOB=$BAZ" >> workspace/new-env-vars
-      # - run: cat workspace/env-vars >> $BASH_ENV
+      - run: cat workspace/env-vars >> $BASH_ENV
       # - run: echo ${FOO:-NULL}
       # - run: echo ${BAZ:-NULL}
       # - run: echo ${BOB:-NULL}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
       - run: mkdir -p workspace
       - run:
           name: set version
-          command: SPECKLE_VERSION=$(./.circleci/get_version.sh)
+          command: echo ./.circleci/get_version.sh
       # - run:
       #     name: set var
       #     command: echo "export BAZ=baz.`date +%Y%m%d.%H%M`" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - run:
           name: set version
           command: |
-            echo "export IMAGE_VERSION_TAG=$(circleci/get_version.sh)" >> workspace/env-vars
+            echo "export IMAGE_VERSION_TAG=$(.circleci/get_version.sh)" >> workspace/env-vars
       - run: cat workspace/env-vars >> $BASH_ENV
       - run: echo $IMAGE_VERSION_TAG
       - persist_to_workspace:

--- a/.circleci/publish_helm_chart.sh
+++ b/.circleci/publish_helm_chart.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-RELEASE_VERSION=$(./.circleci/get_version.sh)
+RELEASE_VERSION=${IMAGE_VERSION_TAG}
 
 echo "Releasing Helm Chart version $RELEASE_VERSION"
 


### PR DESCRIPTION
- ci: add get version job
- fix workspace folder
- version dependecies
- persist envvars to workspace
- set speckle version
- disable file based env var
- echo
- command
- echo speckle version
- save to workspace
- add to bash_env
- cleanup
- add workspace envvar persistence
- dot dot
- add image version to helm chart build
