### PR TITLE
CI/lernaPublish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,7 @@ workflows:
               # only: &filters-tag /^[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               only:
-                # - main
-                - CI/lernaPublish
+                - main
 
       - docker-build-and-publish-server:
           filters: *filters-build
@@ -225,6 +224,7 @@ jobs:
           command: |
             git config --global user.email "devops+circleci@speckle.systems"
             git config --global user.name "CI"
+            git config --global push.default current
       - run:
           name: publish to npm
           command: npx lerna publish $IMAGE_VERSION_TAG -y --dist-tag next

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.0.1
+  github-cli: circleci/github-cli@2.1.0
 
 workflows:
   version: 2
@@ -12,10 +13,12 @@ workflows:
       - get-version:
           filters: &filters-build
             tags:
-              only: &filters-tag /^[0-9]+\.[0-9]+\.[0-9]+$/
+              only: &filters-tag /^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$/
+              # only: &filters-tag /^[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               only:
-                - main
+                # - main
+                - CI/lernaPublish
 
       - docker-build-and-publish-server:
           filters: *filters-build
@@ -83,16 +86,6 @@ workflows:
             - get-version
 
 jobs:
-  lint:
-    docker: &docker-image
-      - image: cimg/python:3.9-node
-    steps:
-      - checkout
-      - run: npm ci
-      - run: npx lerna bootstrap
-      - run: pip install pre-commit
-      - run: pre-commit run --all-files
-
   get-version:
     docker:
       - image: cimg/python:3.9
@@ -151,7 +144,8 @@ jobs:
           destination: package/server/coverage
 
   docker-build-and-publish: &docker-job
-    docker: *docker-image
+    docker: &docker-image
+      - image: cimg/python:3.9-node
     working_directory: *work-dir
     steps:
       - checkout
@@ -199,11 +193,18 @@ jobs:
     docker: *docker-image
     working_directory: *work-dir
     steps:
-      - checkout
+      - run:
+          # WARNING this assumes that this job is only being run with a git tag trigger
+          # do not run this job with a branch filter
+          # this checks out the tag to a new branch so that we can create
+          # a PR from the lerna changes at the end
+          name: checkout tag to a new branch
+          command: git checkout ${CIRCLE_TAG} -b release/${CIRCLE_TAG}
       - attach_workspace:
           at: /tmp/ci/workspace
       - run: cat workspace/env-vars >> $BASH_ENV
       - run: npx lerna bootstrap
+
       # this has to be after lerna bootstrap
       # otherwise the auth workflow of lerna is borked...
       - run:
@@ -223,7 +224,12 @@ jobs:
           command: |
             git config --global user.email "devops+circleci@speckle.systems"
             git config --global user.name "CI"
-      - run: npx lerna publish $IMAGE_VERSION_TAG -y
+      - run:
+          name: publish to npm
+          command: npx lerna publish $IMAGE_VERSION_TAG -y --dist-tag next
+      - run:
+          name: create PR
+          command: gh pr create --title Lerna publish ${CIRCLE_TAG} --body lerna bumping stuff
 
   publish-helm-chart:
     docker: *docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
           command: npx lerna publish $IMAGE_VERSION_TAG -y --dist-tag next
       - run:
           name: create PR
-          command: gh pr create --title `Lerna publish ${CIRCLE_TAG}` --body `lerna bumping stuff`
+          command: gh pr create --title 'Lerna publish ${CIRCLE_TAG}' --body 'lerna bumping stuff'
 
   publish-helm-chart:
     docker: *docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,7 @@ jobs:
             git config --global user.email "devops+circleci@speckle.systems"
             git config --global user.name "CI"
             git config --global push.default current
+            git push
       - run:
           name: publish to npm
           command: npx lerna publish $IMAGE_VERSION_TAG -y --dist-tag next

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
           command: npx lerna publish $IMAGE_VERSION_TAG -y --dist-tag next
       - run:
           name: create PR
-          command: gh pr create --title Lerna publish ${CIRCLE_TAG} --body lerna bumping stuff
+          command: gh pr create --title `Lerna publish ${CIRCLE_TAG}` --body `lerna bumping stuff`
 
   publish-helm-chart:
     docker: *docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
     docker: *docker-image
     working_directory: *work-dir
     steps:
-      - gh/install
+      - github-cli/install
       - checkout
       - run:
           # WARNING this assumes that this job is only being run with a git tag trigger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,7 @@ jobs:
     docker: *docker-image
     working_directory: *work-dir
     steps:
+      - gh/install
       - checkout
       - run:
           # WARNING this assumes that this job is only being run with a git tag trigger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,9 @@ jobs:
       - run: cat workspace/env-vars >> $BASH_ENV
       - run:
           name: restore packages
-          command: npx lerna bootstrap
+          command: |
+            npm i
+            npx lerna bootstrap
       # this has to be after lerna bootstrap
       # otherwise the auth workflow of lerna is borked...
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,7 @@ jobs:
     docker: *docker-image
     working_directory: *work-dir
     steps:
+      - checkout
       - run:
           # WARNING this assumes that this job is only being run with a git tag trigger
           # do not run this job with a branch filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,11 @@ jobs:
       - attach_workspace:
           at: /tmp/ci/workspace
       - run: cat workspace/env-vars >> $BASH_ENV
-      - run: npx lerna bootstrap
+      - run:
+          name: restore packages
+          command: |
+            npm i
+            npx lerna bootstrap
 
       # this has to be after lerna bootstrap
       # otherwise the auth workflow of lerna is borked...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.0.1
-  github-cli: circleci/github-cli@2.1.0
 
 workflows:
   version: 2
@@ -192,24 +191,13 @@ jobs:
     docker: *docker-image
     working_directory: *work-dir
     steps:
-      - github-cli/install
       - checkout
-      - run:
-          # WARNING this assumes that this job is only being run with a git tag trigger
-          # do not run this job with a branch filter
-          # this checks out the tag to a new branch so that we can create
-          # a PR from the lerna changes at the end
-          name: checkout tag to a new branch
-          command: git checkout ${CIRCLE_TAG} -b release/${CIRCLE_TAG}
       - attach_workspace:
           at: /tmp/ci/workspace
       - run: cat workspace/env-vars >> $BASH_ENV
       - run:
           name: restore packages
-          command: |
-            npm i
-            npx lerna bootstrap
-
+          command: npx lerna bootstrap
       # this has to be after lerna bootstrap
       # otherwise the auth workflow of lerna is borked...
       - run:
@@ -221,22 +209,9 @@ jobs:
       - run:
           name: try login to npm
           command: npm whoami
-      - add_ssh_keys:
-          fingerprints:
-            - 'e4:47:eb:29:a7:0b:56:a7:9b:d3:a9:e0:05:5c:13:e3'
-      - run:
-          name: setup git user
-          command: |
-            git config --global user.email "devops+circleci@speckle.systems"
-            git config --global user.name "CI"
-            git config --global push.default current
-            git push
       - run:
           name: publish to npm
-          command: npx lerna publish $IMAGE_VERSION_TAG -y --dist-tag next
-      - run:
-          name: create PR
-          command: gh pr create --title 'Lerna publish ${CIRCLE_TAG}' --body 'lerna bumping stuff'
+          command: npx lerna publish $IMAGE_VERSION_TAG -y next --no-git-tag-version --no-push --dist-tag
 
   publish-helm-chart:
     docker: *docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
           command: npm whoami
       - run:
           name: publish to npm
-          command: npx lerna publish $IMAGE_VERSION_TAG -y next --no-git-tag-version --no-push --dist-tag
+          command: npx lerna publish $IMAGE_VERSION_TAG -y --no-git-tag-version --no-push --dist-tag next
 
   publish-helm-chart:
     docker: *docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,18 @@ workflows:
 
   test-build:
     jobs:
-      - test-server
+      - test-server:
+          filters:
+            tags:
+              # run tests for all tags
+              only: /.*/
       - get-version:
           filters: &filters-build
             tags:
-              only: &filters-tag /^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$/
-              # only: &filters-tag /^[0-9]+\.[0-9]+\.[0-9]+$/
+              only: &filters-tag /^[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               only:
                 - main
-
       - docker-build-and-publish-server:
           filters: *filters-build
           context: &docker-hub-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,7 @@ jobs:
           command: npm whoami
       - run:
           name: publish to npm
-          command: npx lerna publish $IMAGE_VERSION_TAG -y --no-git-tag-version --no-push --dist-tag next
+          command: npx lerna publish $IMAGE_VERSION_TAG -y --no-git-tag-version --no-push
 
   publish-helm-chart:
     docker: *docker-image

--- a/.circleci/get_version.sh
+++ b/.circleci/get_version.sh
@@ -5,8 +5,7 @@ set -e
 LAST_RELEASE=$(git describe --always --tags `git rev-list --tags` | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
 NEXT_RELEASE=$(echo ${LAST_RELEASE} | python -c "parts = input().split('.'); parts[-1] = str(int(parts[-1])+1); print('.'.join(parts))")
 
-if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
-# if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo $CIRCLE_TAG
     exit 0
 fi

--- a/.circleci/get_version.sh
+++ b/.circleci/get_version.sh
@@ -5,7 +5,8 @@ set -e
 LAST_RELEASE=$(git describe --always --tags `git rev-list --tags` | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
 NEXT_RELEASE=$(echo ${LAST_RELEASE} | python -c "parts = input().split('.'); parts[-1] = str(int(parts[-1])+1); print('.'.join(parts))")
 
-if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
+# if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo $CIRCLE_TAG
     exit 0
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged


### PR DESCRIPTION
- ci(circle ci): test lerna publish with git tag
- ci(circle ci): checkout the repo first
- ci(circle ci): auto set upstream to the current branch
- ci(circle ci): actually push the branch
- ci(husky): ignore husky hooks if running in CI
- ci(circle ci): install root level npm packages in npm publish step
- ci(circle ci): install gh cli for npm publish
- ci(circle ci): fix orb reference
- ci(circle): fix gh pr create text values
- ci(circle): fix gh pr create args again
- ci(circle): gave up on the whole lerna push updates to the repo  stuff
- ci(circle): fix dist tag next
- ci(circle): turns out you do need husky for this to work
