### PR TITLE
fix: throwing error if running tests without .env.test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,10 @@ jobs:
       - run: 'dockerize -wait tcp://localhost:5432 -timeout 1m'
 
       - run:
+          command: touch .env.test
+          working_directory: 'packages/server'
+
+      - run:
           command: npm run test:report
           working_directory: 'packages/server'
 

--- a/packages/server/bootstrap.js
+++ b/packages/server/bootstrap.js
@@ -14,7 +14,14 @@ const appRoot = require('app-root-path')
 // If running in test env, load .env.test first
 // (appRoot necessary, cause env files aren't loaded through require() calls)
 if (isTestEnv()) {
-  dotenv.config({ path: `${appRoot}/.env.test` })
+  const { error } = dotenv.config({ path: `${appRoot}/.env.test` })
+  if (error) {
+    const e = new Error(
+      'Attempting to run tests without an .env.test file properly set up! Check readme!'
+    )
+    console.error(e)
+    process.exit(1)
+  }
 }
 
 dotenv.config({ path: `${appRoot}/.env` })


### PR DESCRIPTION
closes #731 