### PR TITLE
feat(frontend): globals editor explicit drag handles

### DIFF
--- a/packages/frontend/src/main/components/stream/globals/GlobalsEntry.vue
+++ b/packages/frontend/src/main/components/stream/globals/GlobalsEntry.vue
@@ -6,6 +6,7 @@
       tag="ul"
       group="globals"
       v-bind="dragOptions"
+      handle=".drag-handle"
       @start="drag = true"
       @end="drag = false"
     >
@@ -13,6 +14,9 @@
         <transition type="transition" :name="!drag ? 'flip-list' : null">
           <div v-if="!entry.globals">
             <div class="d-flex align-center">
+              <v-icon color="grey darken-1" class="mb-2 mr-2 drag-handle">
+                mdi-menu
+              </v-icon>
               <v-text-field
                 ref="keyInput"
                 v-model="entry.key"

--- a/packages/frontend/src/main/pages/stream/TheGlobals.vue
+++ b/packages/frontend/src/main/pages/stream/TheGlobals.vue
@@ -108,7 +108,7 @@
           </section-card>
         </v-col>
         <!-- History -->
-        <v-col cols="12" md="4">
+        <v-col v-if="branch" cols="12" md="4">
           <section-card v-if="branch.commits" expandable>
             <template slot="header">
               Globals History ({{ branch.commits.totalCount }})


### PR DESCRIPTION
closes #463 

tested it out locally on Edge & Firefox

<img width="927" alt="image" src="https://user-images.githubusercontent.com/938316/165911155-0678871f-ec28-4cba-bbe3-2a1134958e0c.png">
