### PR TITLE
Adds webhook events for comment actions

### DIFF
--- a/packages/frontend/src/main/components/stream/WebhookForm.vue
+++ b/packages/frontend/src/main/components/stream/WebhookForm.vue
@@ -135,7 +135,11 @@ export default {
       'commit_receive',
       'commit_delete',
       'stream_permissions_add',
-      'stream_permissions_remove'
+      'stream_permissions_remove',
+      'comment_created',
+      'comment_updated',
+      'comment_archived',
+      'comment_replied',
     ],
     validation: {
       urlRules: [

--- a/packages/frontend/src/main/components/stream/WebhookForm.vue
+++ b/packages/frontend/src/main/components/stream/WebhookForm.vue
@@ -139,7 +139,7 @@ export default {
       'comment_created',
       'comment_updated',
       'comment_archived',
-      'comment_replied',
+      'comment_replied'
     ],
     validation: {
       urlRules: [


### PR DESCRIPTION
- Adopting the pattern for the graphql resolvers from core services, saveActivity() is called on: create, reply, edit and archive of comments.
- The webhook payload is pretty straightforward for each. 
- Edit comment doesn't return anything, so this webhook will fire immediately after edit is called.

Addresses #740