### PR TITLE
chore(frontend): fixing three.js imports & getting rid of some duplicate packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
     "lint-staged": "^12.3.7",
     "prettier": "^2.5.1"
   },
+  "resolutions": {
+    "tslib": "^2.3.1",
+    "core-js": "3.22.4",
+    "vue-cli-plugin-apollo/graphql": "^15"
+  },
   "config": {
     "commitizen": {
       "path": "cz-conventional-changelog"

--- a/packages/frontend/src/main/components/viewer/CommentAddOverlay.vue
+++ b/packages/frontend/src/main/components/viewer/CommentAddOverlay.vue
@@ -201,8 +201,7 @@
   </div>
 </template>
 <script>
-// TODO: Need to fix the viewer package build process to be able to properly reference THREE.js
-/* global THREE */
+import * as THREE from 'three'
 import gql from 'graphql-tag'
 import debounce from 'lodash/debounce'
 

--- a/packages/frontend/src/main/components/viewer/CommentsOverlay.vue
+++ b/packages/frontend/src/main/components/viewer/CommentsOverlay.vue
@@ -168,8 +168,7 @@
   </div>
 </template>
 <script>
-// TODO: Need to fix the viewer package build process to be able to properly reference THREE.js
-/* global THREE */
+import * as THREE from 'three'
 import debounce from 'lodash/debounce'
 import gql from 'graphql-tag'
 

--- a/packages/frontend/src/main/components/viewer/ViewerBubbles.vue
+++ b/packages/frontend/src/main/components/viewer/ViewerBubbles.vue
@@ -87,8 +87,7 @@
   </div>
 </template>
 <script>
-// TODO: Need to fix the viewer package build process to be able to properly reference THREE.js
-/* global THREE */
+import * as THREE from 'three'
 import gql from 'graphql-tag'
 import { v4 as uuid } from 'uuid'
 import debounce from 'lodash/debounce'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8467,14 +8467,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^2.4.0":
-  version: 2.6.12
-  resolution: "core-js@npm:2.6.12"
-  checksum: 44fa9934a85f8c78d61e0c8b7b22436330471ffe59ec5076fe7f324d6e8cf7f824b14b1c81ca73608b13bdb0fef035bd820989bf059767ad6fa13123bb8bd016
-  languageName: node
-  linkType: hard
-
-"core-js@npm:^3.0.1, core-js@npm:^3.21.1, core-js@npm:^3.6.5":
+"core-js@npm:3.22.4":
   version: 3.22.4
   resolution: "core-js@npm:3.22.4"
   checksum: 1d031597a61d11266343c7f9a788ad620bb8e1a15207c8ff41ee77183789f1d6592d7cbaf4931d74773be08739871c6ae1a59090a7e03f0bc5131d4443cc04d2
@@ -12528,15 +12521,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^14.5.8":
-  version: 14.7.0
-  resolution: "graphql@npm:14.7.0"
-  dependencies:
-    iterall: ^1.2.2
-  checksum: e5f4e60799421a573904f390e1ec0aa76360f751688dbbe62e9c35baa0d3727c8d59a659bfc524f126dffe3518da87fd8ecaa78c94fd5c0fe4e035c670745242
-  languageName: node
-  linkType: hard
-
 "growl@npm:1.10.5":
   version: 1.10.5
   resolution: "growl@npm:1.10.5"
@@ -14418,7 +14402,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iterall@npm:^1.1.1, iterall@npm:^1.1.3, iterall@npm:^1.2.1, iterall@npm:^1.2.2, iterall@npm:^1.3.0":
+"iterall@npm:^1.1.1, iterall@npm:^1.1.3, iterall@npm:^1.2.1, iterall@npm:^1.3.0":
   version: 1.3.0
   resolution: "iterall@npm:1.3.0"
   checksum: c78b99678f8c99be488cca7f33e4acca9b72c1326e050afbaf023f086e55619ee466af0464af94a0cb3f292e60cb5bac53a8fd86bd4249ecad26e09f17bb158b
@@ -22936,24 +22920,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
-  version: 1.14.1
-  resolution: "tslib@npm:1.14.1"
-  checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.1":
+"tslib@npm:^2.3.1":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
-  languageName: node
-  linkType: hard
-
-"tslib@npm:~2.3.0":
-  version: 2.3.1
-  resolution: "tslib@npm:2.3.1"
-  checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. Now that we're on yarn workspaces, we can finally use `three.js` as a normal import in `frontend` without webpack bundling three.js twice locally.
2. I used "resolutions" to get rid of some duplicate dependencies that got bundled twice in the frontend build. Some very small duplicates remain, because I'd rather a few extra kb gets bundled in than we complicate the dependency graph too much using "resolutions"

Regarding testing: I tried building every package locally (through `yarn build` from root) and it seemed to go through just fine.