### PR TITLE
feat(frontend): animated preview images

### DIFF
--- a/packages/frontend/src/main/components/common/CommitPreviewCard.vue
+++ b/packages/frontend/src/main/components/common/CommitPreviewCard.vue
@@ -9,6 +9,7 @@
         <preview-image
           :url="`/preview/${streamId}/commits/${commit.id}`"
           :height="previewHeight"
+          rotate
         ></preview-image>
       </router-link>
       <v-toolbar class="transparent elevation-0" dense>

--- a/packages/frontend/src/main/components/common/PreviewImage.vue
+++ b/packages/frontend/src/main/components/common/PreviewImage.vue
@@ -1,18 +1,29 @@
 <template>
-  <div @mouseenter="hovered = true" @mouseleave="hovered = false" @mousemove="setIndex">
+  <div
+    style="position: relative"
+    @mouseenter="hovered = true"
+    @mouseleave="hovered = false"
+    @mousemove="setIndex"
+  >
     <v-img
       ref="cover"
       :height="height"
       cover
       :class="`${color ? '' : 'grasycale-img'} preview-img`"
-      :src="previewImages[imageIndex]"
+      :src="revImg[imageIndex]"
       :gradient="`to top right, ${
         $vuetify.theme.dark
           ? 'rgba(100,115,201,.13), rgba(25,32,72,.2)'
           : 'rgba(100,115,231,.075), rgba(25,32,72,.02)'
       }`"
     />
-    <v-progress-linear v-show="loading" indeterminate height="2" />
+    <v-progress-linear
+      v-show="loading"
+      indeterminate
+      height="4"
+      style="position: absolute; bottom: 0"
+    />
+    <!-- <span class="caption">{{ imageIndex }}</span> -->
   </div>
 </template>
 <script>
@@ -43,10 +54,16 @@ export default {
       currentPreviewImg: '',
       previewImages: [],
       imageIndex: 0,
+      legacyMode: false,
       angles: [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
         22, 23, 0
       ]
+    }
+  },
+  computed: {
+    revImg() {
+      return !this.legacyMode ? this.previewImages : [...this.previewImages].reverse()
     }
   },
   watch: {
@@ -66,7 +83,7 @@ export default {
       const x = e.clientX - rect.left
       const step = rect.width / this.previewImages.length
       let index = Math.round(x / step)
-      if (index >= this.previewImages.length) index = this.previewImages.length - 1
+      if (index >= this.previewImages.length) index = 0
       this.imageIndex = index
     },
     async getPreviewImage(angle = 0) {
@@ -94,7 +111,9 @@ export default {
           const img = await this.getPreviewImage(this.angles[i])
           this.$set(this.previewImages, i, img)
         } catch (err) {
+          console.log(err)
           // on the legacy track!
+          this.legacyMode = true
           this.previewImages.unshift(await this.getPreviewImage(-1))
           this.previewImages.unshift(await this.getPreviewImage(-2))
           // We have the image at 0, skipping

--- a/packages/frontend/src/main/components/common/PreviewImage.vue
+++ b/packages/frontend/src/main/components/common/PreviewImage.vue
@@ -1,16 +1,19 @@
 <template>
-  <v-img
-    ref="cover"
-    :height="height"
-    cover
-    :class="`${color ? '' : 'grasycale-img'} preview-img`"
-    :src="currentPreviewImg"
-    :gradient="`to top right, ${
-      $vuetify.theme.dark
-        ? 'rgba(100,115,201,.33), rgba(25,32,72,.7)'
-        : 'rgba(100,115,231,.1), rgba(25,32,72,.05)'
-    }`"
-  />
+  <div @mouseenter="hovered = true" @mouseleave="hovered = false" @mousemove="setIndex">
+    <v-img
+      ref="cover"
+      :height="height"
+      cover
+      :class="`${color ? '' : 'grasycale-img'} preview-img`"
+      :src="previewImages[imageIndex]"
+      :gradient="`to top right, ${
+        $vuetify.theme.dark
+          ? 'rgba(100,115,201,.13), rgba(25,32,72,.2)'
+          : 'rgba(100,115,231,.075), rgba(25,32,72,.02)'
+      }`"
+    />
+    <v-progress-linear v-show="loading" indeterminate height="2" />
+  </div>
 </template>
 <script>
 export default {
@@ -34,26 +37,74 @@ export default {
   },
   data() {
     return {
-      currentPreviewImg: ''
-      // currentPreviewImg: '/loadingImage.png'
+      loading: false,
+      hovered: false,
+      hasStartedLoadingImages: false,
+      currentPreviewImg: '',
+      previewImages: [],
+      imageIndex: 0,
+      angles: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+        22, 23, 0
+      ]
     }
   },
-  mounted() {
-    this.getPreviewImage().then().catch()
+  watch: {
+    hovered(val) {
+      if (!val || this.hasStartedLoadingImages) return
+      this.getOtherAngles()
+      this.hasStartedLoadingImages = true
+    }
+  },
+  async mounted() {
+    this.previewImages.push(await this.getPreviewImage())
   },
   methods: {
-    async getPreviewImage() {
-      const res = await fetch(this.url, {
+    setIndex(e) {
+      if (this.hasStartedLoadingImages && this.loading) return
+      const rect = e.target.getBoundingClientRect()
+      const x = e.clientX - rect.left
+      const step = rect.width / this.previewImages.length
+      let index = Math.round(x / step)
+      if (index >= this.previewImages.length) index = this.previewImages.length - 1
+      this.imageIndex = index
+    },
+    async getPreviewImage(angle = 0) {
+      const res = await fetch(this.url + `/${angle}`, {
         headers: localStorage.getItem('AuthToken')
           ? { Authorization: `Bearer ${localStorage.getItem('AuthToken')}` }
           : {}
       })
-      try {
-        const blob = await res.blob()
-        this.currentPreviewImg = URL.createObjectURL(blob)
-      } catch (err) {
-        // console.log(err)
+
+      if (res.headers.has('X-Preview-Error')) {
+        throw new Error('Failed getting preview')
       }
+      const blob = await res.blob()
+      return URL.createObjectURL(blob)
+    },
+    async getOtherAngles() {
+      // Note: previously, previews were generated for only 5 angles (-30deg, -15, 0, 15, 30deg), corresponding to
+      // labelled angles (-2, -1, 0, 1, 2). We have now switched to generating full 360deg previews in increments
+      // of 15 deg, going clockwise straight. Eg., 0 = 0deg, 1 = 15deg, 2 = 30 deg, etc.
+      this.loading = true
+      // starting in reverse to quickly figure out if we're on the legacy track!
+      for (let i = this.angles.length - 1; i > 0; i--) {
+        if (this.angles[i] === 0) continue // we already have this one loaded
+        try {
+          const img = await this.getPreviewImage(this.angles[i])
+          this.$set(this.previewImages, i, img)
+        } catch (err) {
+          // on the legacy track!
+          this.previewImages.unshift(await this.getPreviewImage(-1))
+          this.previewImages.unshift(await this.getPreviewImage(-2))
+          // We have the image at 0, skipping
+          this.previewImages.push(await this.getPreviewImage(1))
+          this.previewImages.push(await this.getPreviewImage(2))
+          this.loading = false
+          break
+        }
+      }
+      this.loading = false
     }
   }
 }

--- a/packages/frontend/src/main/components/common/PreviewImage.vue
+++ b/packages/frontend/src/main/components/common/PreviewImage.vue
@@ -3,6 +3,7 @@
     :style="`position: relative; height: ${height}px;`"
     :class="`${$vuetify.theme.dark ? 'grey darken-4' : 'grey lighten-4'}`"
     @mouseenter="hovered = true"
+    @touchmove="parseTouch"
     @mouseleave="hovered = false"
     @mousemove="setIndex"
   >
@@ -11,12 +12,7 @@
     bg image props position. Results in less dom elements, and no flickering! 
     -->
     <div :style="bgStyle"></div>
-    <v-progress-linear
-      v-show="loading"
-      indeterminate
-      height="4"
-      style="position: absolute; bottom: 0"
-    />
+    <v-progress-linear v-show="loading" indeterminate height="4" style="position: absolute; bottom: 0" />
   </div>
 </template>
 <script>
@@ -48,10 +44,7 @@ export default {
       previewImages: [],
       imageIndex: 0,
       legacyMode: false,
-      angles: [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-        22, 23, 0
-      ]
+      angles: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 0]
     }
   },
   computed: {
@@ -71,9 +64,7 @@ export default {
       bgStyle += `
       background-position:`
       for (let i = 0; i < this.revImg.length; i++) {
-        bgStyle += `${i === this.imageIndex ? 'center' : '10000px'}${
-          i !== this.revImg.length - 1 ? ',' : ';'
-        }`
+        bgStyle += `${i === this.imageIndex ? 'center' : '10000px'}${i !== this.revImg.length - 1 ? ',' : ';'}`
       }
       return bgStyle
     }
@@ -91,8 +82,13 @@ export default {
     this.previewImages.push(await this.getPreviewImage())
   },
   methods: {
+    parseTouch(e) {
+      if (this.hasStartedLoadingImages && this.loading && !this.rotate) return
+      this.hovered = true
+      this.setIndex({ target: e.target, clientX: e.touches[0].clientX, clientY: e.touches[0].clientY })
+    },
     setIndex(e) {
-      if (this.hasStartedLoadingImages && this.loading) return
+      if (this.hasStartedLoadingImages && this.loading && !this.rotate) return
       const rect = e.target.getBoundingClientRect()
       const x = e.clientX - rect.left
       const step = rect.width / this.previewImages.length

--- a/packages/frontend/src/main/components/common/PreviewImage.vue
+++ b/packages/frontend/src/main/components/common/PreviewImage.vue
@@ -1,22 +1,34 @@
 <template>
   <div
-    style="position: relative"
+    :style="`position: relative; height: ${height}px;`"
     @mouseenter="hovered = true"
     @mouseleave="hovered = false"
     @mousemove="setIndex"
   >
-    <v-img
-      ref="cover"
-      :height="height"
-      cover
-      :class="`${color ? '' : 'grasycale-img'} preview-img`"
-      :src="revImg[imageIndex]"
-      :gradient="`to top right, ${
-        $vuetify.theme.dark
-          ? 'rgba(100,115,201,.13), rgba(25,32,72,.2)'
-          : 'rgba(100,115,231,.075), rgba(25,32,72,.02)'
-      }`"
-    />
+    <!-- 
+    Note: sketchfab stitches all frames into one single image and controls its visibility
+    by modifying the background position. Results in reliably less flickering, but it's a 
+    longer more tough implementation. At one point, we could ask the backend for a pre-stitched
+    frame and do the same.
+    -->
+    <template v-for="(img, index) in revImg">
+      <v-img
+        ref="cover"
+        :key="index"
+        :height="height"
+        cover
+        :class="`${color ? '' : 'grasycale-img'} preview-img`"
+        :src="img"
+        :style="`position: absolute; top: 0; transition: opacity 0.01s ease; opacity:${
+          index === imageIndex ? 1 : 0
+        };`"
+        :gradient="`to top right, ${
+          $vuetify.theme.dark
+            ? 'rgba(100,115,201,.13), rgba(25,32,72,.2)'
+            : 'rgba(100,115,231,.075), rgba(25,32,72,.02)'
+        }`"
+      />
+    </template>
     <v-progress-linear
       v-show="loading"
       indeterminate

--- a/packages/frontend/src/main/components/common/PreviewImage.vue
+++ b/packages/frontend/src/main/components/common/PreviewImage.vue
@@ -12,7 +12,12 @@
     bg image props position. Results in less dom elements, and no flickering! 
     -->
     <div :style="bgStyle"></div>
-    <v-progress-linear v-show="loading" indeterminate height="4" style="position: absolute; bottom: 0" />
+    <v-progress-linear
+      v-show="loading"
+      indeterminate
+      height="4"
+      style="position: absolute; bottom: 0"
+    />
   </div>
 </template>
 <script>
@@ -44,7 +49,10 @@ export default {
       previewImages: [],
       imageIndex: 0,
       legacyMode: false,
-      angles: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 0]
+      angles: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+        22, 23, 0
+      ]
     }
   },
   computed: {
@@ -64,7 +72,9 @@ export default {
       bgStyle += `
       background-position:`
       for (let i = 0; i < this.revImg.length; i++) {
-        bgStyle += `${i === this.imageIndex ? 'center' : '10000px'}${i !== this.revImg.length - 1 ? ',' : ';'}`
+        bgStyle += `${i === this.imageIndex ? 'center' : '10000px'}${
+          i !== this.revImg.length - 1 ? ',' : ';'
+        }`
       }
       return bgStyle
     }
@@ -85,7 +95,11 @@ export default {
     parseTouch(e) {
       if (this.hasStartedLoadingImages && this.loading && !this.rotate) return
       this.hovered = true
-      this.setIndex({ target: e.target, clientX: e.touches[0].clientX, clientY: e.touches[0].clientY })
+      this.setIndex({
+        target: e.target,
+        clientX: e.touches[0].clientX,
+        clientY: e.touches[0].clientY
+      })
     },
     setIndex(e) {
       if (this.hasStartedLoadingImages && this.loading && !this.rotate) return

--- a/packages/frontend/src/main/components/common/StreamPreviewCard.vue
+++ b/packages/frontend/src/main/components/common/StreamPreviewCard.vue
@@ -9,6 +9,7 @@
         <preview-image
           :url="`/preview/${stream.id}`"
           :height="previewHeight"
+          rotate
         ></preview-image>
         <stream-favorite-btn :user="user" :stream="stream" class="favorite-button" />
       </router-link>

--- a/packages/preview-service/routes/preview.js
+++ b/packages/preview-service/routes/preview.js
@@ -17,7 +17,7 @@ async function pageFunction(objectUrl) {
   }
 
   let t0 = Date.now()
-  let stepAngle = 0.261799
+  let stepAngle = 0.261799 // 15 deg
 
   try {
     await v.loadObject(objectUrl, '')
@@ -28,17 +28,10 @@ async function pageFunction(objectUrl) {
 
   v.interactions.zoomExtents(0.95, false)
   await waitForAnimation(100)
-  ret.scr['0'] = v.interactions.screenshot()
 
-  for (let i = 1; i < 3; i++) {
-    v.interactions.rotateCamera(stepAngle, undefined, false)
-    await waitForAnimation()
-    ret.scr[-1 * i + ''] = v.interactions.screenshot()
-  }
-  v.interactions.rotateCamera(-2 * stepAngle, undefined, false)
-  await waitForAnimation()
-  for (let i = 1; i < 3; i++) {
-    v.interactions.rotateCamera(-1 * stepAngle, undefined, false)
+  // full 360
+  for (let i = 0; i < 24; i++) {
+    v.interactions.rotateCamera(undefined, undefined, false)
     await waitForAnimation()
     ret.scr[i + ''] = v.interactions.screenshot()
   }


### PR DESCRIPTION
changes:
- preview service generates full 360 images now
- preview image component loads on hover
- preview image component backwards compat with non-360 image angles
- adds optional angle arguments in all preview routes & removes superflous route

Quick demo:

https://user-images.githubusercontent.com/7696515/169804357-4a4ac3a9-3de2-475a-b257-e4adbfbb526e.mov


