### PR TITLE
fix(frontend): fixed toolbars/navbars/action bars showing the wrong content randomly

### DIFF
--- a/packages/frontend/src/main/navigation/AdminNav.vue
+++ b/packages/frontend/src/main/navigation/AdminNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <portal to="subnav-admin">
+  <portal v-if="canRenderSubnavPortal" to="subnav-admin">
     <v-list class="ml-12 pr-0" dense nav subheader>
       <v-list-item to="/admin/dashboard" exact>
         <v-list-item-content>
@@ -32,5 +32,27 @@
   </portal>
 </template>
 <script>
-export default {}
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
+export default {
+  data: () => ({ portalIdentity: 'admin-nav' }),
+  computed: {
+    canRenderSubnavPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.SubnavAdmin] ===
+        this.portalIdentity
+      )
+    }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.SubnavAdmin, this.portalIdentity, 0)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.SubnavAdmin, this.portalIdentity)
+  }
+}
 </script>

--- a/packages/frontend/src/main/navigation/StreamNav.vue
+++ b/packages/frontend/src/main/navigation/StreamNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <portal to="nav">
+  <portal v-if="canRenderNavPortal" to="nav">
     <div v-if="!$loggedIn()" class="px-4 my-2">
       <v-btn small block color="primary" to="/authn/login">Sign In</v-btn>
     </div>
@@ -222,6 +222,13 @@
 </template>
 <script>
 import gql from 'graphql-tag'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
+
 export default {
   components: {
     NewBranch: () => import('@/main/dialogs/NewBranch')
@@ -269,7 +276,8 @@ export default {
   data() {
     return {
       branchMenuOpen: false,
-      newBranchDialog: false
+      newBranchDialog: false,
+      portalIdentity: 'stream-nav'
     }
   },
   computed: {
@@ -323,6 +331,11 @@ export default {
     branchesTotalCount() {
       if (!this.branchQuery) return 0
       return this.branchQuery.branches.items.filter((b) => b.name !== 'globals').length
+    },
+    canRenderNavPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Nav] === this.portalIdentity
+      )
     }
   },
   watch: {
@@ -336,6 +349,10 @@ export default {
     this.$eventHub.$on('branch-refresh', () => {
       this.$apollo.queries.branchQuery.refetch()
     })
+    claimPortal(STANDARD_PORTAL_KEYS.Nav, this.portalIdentity, 0)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Nav, this.portalIdentity)
   }
 }
 </script>

--- a/packages/frontend/src/main/pages/TheCommits.vue
+++ b/packages/frontend/src/main/pages/TheCommits.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       <div class="font-weight-bold">
         Your Latest Commits
         <span v-if="user" class="caption">({{ user.commits.totalCount }})</span>
@@ -61,12 +61,30 @@
 </template>
 <script>
 import gql from 'graphql-tag'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
+
 export default {
   name: 'TheCommits',
   components: {
     InfiniteLoading: () => import('vue-infinite-loading'),
     CommitPreviewCard: () => import('@/main/components/common/CommitPreviewCard'),
     NoDataPlaceholder: () => import('@/main/components/common/NoDataPlaceholder')
+  },
+  data: () => ({
+    portalIdentity: 'commits'
+  }),
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    }
   },
   apollo: {
     user: {
@@ -94,6 +112,12 @@ export default {
         }
       `
     }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 0)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   },
   methods: {
     infiniteHandler($state) {

--- a/packages/frontend/src/main/pages/TheFavoriteStreams.vue
+++ b/packages/frontend/src/main/pages/TheFavoriteStreams.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       Favorite Streams
       <span v-if="streams.length" class="caption">
         ({{ user.favoriteStreams.totalCount }})
@@ -36,6 +36,12 @@
 </template>
 <script>
 import { UserFavoriteStreamsQuery } from '@/graphql/user'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'TheFavoriteStreams',
@@ -50,6 +56,7 @@ export default {
       query: UserFavoriteStreamsQuery
     }
   },
+  data: () => ({ portalIdentity: 'favorite-streams' }),
   computed: {
     streams() {
       return this.user?.favoriteStreams?.items || []
@@ -62,7 +69,19 @@ export default {
         this.streams.length &&
         this.streams.length >= this.user.favoriteStreams.totalCount
       )
+    },
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
     }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 0)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   },
   methods: {
     infiniteHandler($state) {

--- a/packages/frontend/src/main/pages/TheFeed.vue
+++ b/packages/frontend/src/main/pages/TheFeed.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       <div class="font-weight-bold">Feed</div>
     </portal>
     <v-row>
@@ -12,11 +12,33 @@
   </div>
 </template>
 <script>
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
+
 export default {
   name: 'TheFeed',
   components: {
     FeedTimeline: () => import('@/main/components/feed/FeedTimeline.vue'),
     LatestBlogposts: () => import('@/main/components/feed/LatestBlogposts')
+  },
+  data: () => ({ portalIdentity: 'feed' }),
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 0)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   }
 }
 </script>

--- a/packages/frontend/src/main/pages/TheStreams.vue
+++ b/packages/frontend/src/main/pages/TheStreams.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       <span class="font-weight-bold mr-2">Your Streams</span>
       <span class="caption">({{ streams ? streams.totalCount : '...' }})</span>
       <div class="d-none d-md-inline-block">
@@ -82,6 +82,12 @@
 <script>
 import streamsQuery from '@/graphql/streams.gql'
 import { MainUserDataQuery } from '@/graphql/user'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'TheStreams',
@@ -101,7 +107,8 @@ export default {
   data() {
     return {
       streamFilter: 1,
-      infiniteId: 0
+      infiniteId: 0,
+      portalIdentity: 'streams'
     }
   },
   computed: {
@@ -121,6 +128,12 @@ export default {
      */
     allStreamsLoaded() {
       return this.streams && this.streams.items.length >= this.streams.totalCount
+    },
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
     }
   },
   watch: {
@@ -133,6 +146,10 @@ export default {
       this.$apollo.queries.streams.refetch()
       this.$router.replace({ path: this.$route.path, query: null })
     }
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 0)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   },
   methods: {
     checkFilter(role) {

--- a/packages/frontend/src/main/pages/admin/Admin.vue
+++ b/packages/frontend/src/main/pages/admin/Admin.vue
@@ -5,7 +5,7 @@
 
   <v-container v-else-if="isAdmin" class="pa-0">
     <admin-nav />
-    <portal to="actions"><div></div></portal>
+    <portal v-if="canRenderActionsPortal" to="actions"><div></div></portal>
     <v-container fluid class="pa-0">
       <transition name="fade">
         <router-view></router-view>
@@ -21,6 +21,12 @@
 
 <script>
 import gql from 'graphql-tag'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'AdminPanel',
@@ -30,7 +36,8 @@ export default {
   },
   data() {
     return {
-      adminNav: true
+      adminNav: true,
+      portalIdentity: 'admin'
     }
   },
   apollo: {
@@ -49,7 +56,19 @@ export default {
   computed: {
     isAdmin() {
       return this.user?.role === 'server:admin'
+    },
+    canRenderActionsPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Actions] ===
+        this.portalIdentity
+      )
     }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Actions, this.portalIdentity, 0)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Actions, this.portalIdentity)
   }
 }
 </script>

--- a/packages/frontend/src/main/pages/admin/Dashboard.vue
+++ b/packages/frontend/src/main/pages/admin/Dashboard.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <portal to="toolbar">Your server at a glance</portal>
+    <portal v-if="canRenderToolbarPortal" to="toolbar">Your server at a glance</portal>
     <general-info-card />
     <div class="my-5" />
     <version-info-card />
@@ -10,12 +10,34 @@
 </template>
 
 <script>
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
+
 export default {
   name: 'AdminOverview',
   components: {
     GeneralInfoCard: () => import('@/main/components/admin/GeneralInfoCard'),
     ActivityCard: () => import('@/main/components/admin/ActivityCard'),
     VersionInfoCard: () => import('@/main/components/admin/VersionInfoCard')
+  },
+  data: () => ({ portalIdentity: 'admin-dashboard' }),
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   }
 }
 </script>

--- a/packages/frontend/src/main/pages/admin/Invites.vue
+++ b/packages/frontend/src/main/pages/admin/Invites.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <portal to="toolbar">Bulk Invites</portal>
+    <portal v-if="canRenderToolbarPortal" to="toolbar">Bulk Invites</portal>
     <section-card>
       <v-card-text>
         <v-alert v-model="success" prominent timeout="3000" dismissible type="success">
@@ -93,6 +93,12 @@ import gql from 'graphql-tag'
 import DOMPurify from 'dompurify'
 import { isEmailValid } from '@/plugins/authHelpers'
 import { MainServerInfoQuery } from '@/graphql/server'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'AdminInvites',
@@ -125,12 +131,19 @@ export default {
             else return true
           }
         ]
-      }
+      },
+      portalIdentity: 'admin-invites'
     }
   },
   computed: {
     submitable() {
       return this.chips && this.chips.length !== 0
+    },
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
     }
   },
   apollo: {
@@ -148,6 +161,12 @@ export default {
     serverInfo: {
       query: MainServerInfoQuery
     }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   },
   methods: {
     setStream(stream) {

--- a/packages/frontend/src/main/pages/admin/ServerSettings.vue
+++ b/packages/frontend/src/main/pages/admin/ServerSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <portal to="toolbar">Server Info and Settings</portal>
+    <portal v-if="canRenderToolbarPortal" to="toolbar">Server Info and Settings</portal>
     <section-card>
       <v-card-text>Here you can edit your server's basic information.</v-card-text>
     </section-card>
@@ -47,6 +47,12 @@
 import gql from 'graphql-tag'
 import { MainServerInfoQuery } from '@/graphql/server'
 import pick from 'lodash/pick'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'ServerInfoAdminCard',
@@ -84,7 +90,8 @@ export default {
           hint: 'Only users with an invitation will be able to join',
           type: 'boolean'
         }
-      }
+      },
+      portalIdentity: 'admin-settings'
     }
   },
   apollo: {
@@ -96,6 +103,20 @@ export default {
         return data.serverInfo
       }
     }
+  },
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   },
   methods: {
     async saveEdit() {

--- a/packages/frontend/src/main/pages/admin/Streams.vue
+++ b/packages/frontend/src/main/pages/admin/Streams.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       Stream Administration
       <span v-if="adminStreams">
         ({{ adminStreams.items.length }} of {{ adminStreams.totalCount }} streams)
       </span>
     </portal>
-    <portal to="actions">
+    <portal v-if="canRenderActionsPortal" to="actions">
       <v-pagination
         v-model="currentPage"
         :length="numberOfPages"
@@ -108,6 +108,12 @@
 <script>
 import gql from 'graphql-tag'
 import debounce from 'lodash/debounce'
+import {
+  claimPortals,
+  unclaimPortals,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'AdminStreams',
@@ -129,10 +135,23 @@ export default {
       adminStreams: {
         items: [],
         totalCount: 0
-      }
+      },
+      portalIdentity: 'admin-streams'
     }
   },
   computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    },
+    canRenderActionsPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Actions] ===
+        this.portalIdentity
+      )
+    },
     numberOfPages() {
       return Math.ceil(this.adminStreams.totalCount / this.queryLimit)
     },
@@ -189,6 +208,19 @@ export default {
         this.navigateNext({ visibility })
       }
     }
+  },
+  mounted() {
+    claimPortals(
+      [STANDARD_PORTAL_KEYS.Toolbar, STANDARD_PORTAL_KEYS.Actions],
+      this.portalIdentity,
+      1
+    )
+  },
+  beforeDestroy() {
+    unclaimPortals(
+      [STANDARD_PORTAL_KEYS.Toolbar, STANDARD_PORTAL_KEYS.Actions],
+      this.portalIdentity
+    )
   },
   methods: {
     initiateDeleteStreams(stream) {

--- a/packages/frontend/src/main/pages/admin/Users.vue
+++ b/packages/frontend/src/main/pages/admin/Users.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       User Management (showing
       <span v-if="users">{{ users.items.length }} of {{ users.totalCount }} users</span>
       )
     </portal>
-    <portal to="actions">
+    <portal v-if="canRenderActionsPortal" to="actions">
       <v-pagination
         v-model="currentPage"
         :length="numberOfPages"
@@ -101,6 +101,12 @@
 <script>
 import gql from 'graphql-tag'
 import debounce from 'lodash/debounce'
+import {
+  claimPortals,
+  unclaimPortals,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'UserAdmin',
@@ -129,7 +135,8 @@ export default {
       showConfirmDialog: false,
       showDeleteDialog: false,
       manipulatedUser: null,
-      newRole: null
+      newRole: null,
+      portalIdentity: 'admin-users'
     }
   },
   computed: {
@@ -164,7 +171,32 @@ export default {
         roleItems.push({ text: this.roleLookupTable[role], value: role })
       }
       return roleItems
+    },
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    },
+    canRenderActionsPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Actions] ===
+        this.portalIdentity
+      )
     }
+  },
+  mounted() {
+    claimPortals(
+      [STANDARD_PORTAL_KEYS.Toolbar, STANDARD_PORTAL_KEYS.Actions],
+      this.portalIdentity,
+      1
+    )
+  },
+  beforeDestroy() {
+    unclaimPortals(
+      [STANDARD_PORTAL_KEYS.Toolbar, STANDARD_PORTAL_KEYS.Actions],
+      this.portalIdentity
+    )
   },
   methods: {
     initiateDeleteUser(user) {

--- a/packages/frontend/src/main/pages/stream/TheBranch.vue
+++ b/packages/frontend/src/main/pages/stream/TheBranch.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="">
     <branch-toolbar
-      v-if="stream && stream.branch"
+      v-if="canRenderToolbarPortal && stream && stream.branch"
       :stream="stream"
       @edit-branch="branchEditDialog = true"
     />
@@ -102,6 +102,12 @@
 <script>
 import gql from 'graphql-tag'
 import branchQuery from '@/graphql/branch.gql'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'TheBranch',
@@ -118,7 +124,8 @@ export default {
     return {
       branchEditDialog: false,
       error: null,
-      listMode: false
+      listMode: false,
+      portalIdentity: 'stream-branch'
     }
   },
   apollo: {
@@ -181,6 +188,12 @@ export default {
     }
   },
   computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    },
     loggedInUserId() {
       return localStorage.getItem('uuid')
     },
@@ -215,8 +228,13 @@ export default {
     }
   },
   mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+
     if (this.$route.params.branchName === 'globals')
       this.$router.push(`/streams/${this.$route.params.streamId}/globals`)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   },
   methods: {
     infiniteHandler($state) {

--- a/packages/frontend/src/main/pages/stream/TheCollaborators.vue
+++ b/packages/frontend/src/main/pages/stream/TheCollaborators.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid class="px-0 py-0" xxxstyle="max-width: 768px">
-    <portal v-if="stream" to="toolbar">
+    <portal v-if="stream && canRenderToolbarPortal" to="toolbar">
       <div class="d-flex align-center">
         <div class="text-truncate">
           <router-link
@@ -236,6 +236,12 @@ import gql from 'graphql-tag'
 import streamCollaboratorsQuery from '@/graphql/streamCollaborators.gql'
 import userSearchQuery from '@/graphql/userSearch.gql'
 import { FullServerInfoQuery } from '@/graphql/server'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'TheCollaborators',
@@ -251,7 +257,8 @@ export default {
     selectedRole: null,
     userSearch: { items: [] },
     serverInfo: { roles: [] },
-    loading: false
+    loading: false,
+    portalIdentity: 'stream-collaborators'
   }),
   apollo: {
     stream: {
@@ -305,6 +312,12 @@ export default {
       }
       return ret
     },
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    },
     collaborators() {
       if (!this.stream) return []
       return this.stream.collaborators.filter((user) => user.id !== this.myId)
@@ -334,6 +347,12 @@ export default {
     myId() {
       return localStorage.getItem('uuid')
     }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   },
   methods: {
     getRoleCount(role) {

--- a/packages/frontend/src/main/pages/stream/TheComments.vue
+++ b/packages/frontend/src/main/pages/stream/TheComments.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="">
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       <div v-if="!$apollo.loading" class="d-flex align-center">
         <div class="text-truncate flex-shrink-1">
           <router-link
@@ -68,6 +68,12 @@
 </template>
 <script>
 import gql from 'graphql-tag'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'TheComments',
@@ -81,11 +87,24 @@ export default {
       localComments: [],
       showArchivedComments: false,
       commentFilter: 1,
-      cursor: null
+      cursor: null,
+      portalIdentity: 'stream-comments'
+    }
+  },
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
     }
   },
   mounted() {
     this.$apollo.queries.comments.refetch()
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   },
   apollo: {
     stream: {
@@ -184,4 +203,3 @@ export default {
   }
 }
 </script>
-<style scoped></style>

--- a/packages/frontend/src/main/pages/stream/TheGlobals.vue
+++ b/packages/frontend/src/main/pages/stream/TheGlobals.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       <div class="d-flex align-center">
         <div class="text-truncate">
           <router-link
@@ -149,6 +149,12 @@
 <script>
 import gql from 'graphql-tag'
 import branchQuery from '@/graphql/branch.gql'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'TheGlobals',
@@ -194,7 +200,8 @@ export default {
       branchName: 'globals', //TODO: handle multipile globals branches,
       revealBuilder: false,
       loading: false,
-      showHistory: true
+      showHistory: true,
+      portalIdentity: 'stream-globals'
     }
   },
   computed: {
@@ -210,7 +217,19 @@ export default {
     },
     objectId() {
       return this.commit?.referencedObject
+    },
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
     }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   },
   methods: {
     async createGlobals() {
@@ -245,5 +264,3 @@ export default {
   }
 }
 </script>
-
-<style scoped></style>

--- a/packages/frontend/src/main/pages/stream/TheSettings.vue
+++ b/packages/frontend/src/main/pages/stream/TheSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="pa-0">
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       <div v-if="stream" class="d-flex align-center">
         <div class="text-truncate">
           <router-link
@@ -175,6 +175,12 @@
 
 <script>
 import gql from 'graphql-tag'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'TheSettings',
@@ -228,7 +234,8 @@ export default {
     allowPublicComments: true,
     validation: {
       nameRules: [(v) => !!v || 'A stream must have a name!']
-    }
+    },
+    portalIdentity: 'stream-settings'
   }),
   computed: {
     canSave() {
@@ -240,6 +247,12 @@ export default {
           this.isPublic !== this.stream.isPublic ||
           this.allowPublicComments !== this.stream.allowPublicComments)
       )
+    },
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
     }
   },
   watch: {
@@ -249,6 +262,12 @@ export default {
     isPublic(newVal) {
       if (!newVal && this.allowPublicComments) this.allowPublicComments = false
     }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   },
   methods: {
     async save() {

--- a/packages/frontend/src/main/pages/stream/TheUploads.vue
+++ b/packages/frontend/src/main/pages/stream/TheUploads.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       <div v-if="stream" class="d-flex align-center">
         <div class="text-truncate">
           <router-link
@@ -128,6 +128,12 @@
 
 <script>
 import gql from 'graphql-tag'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'TheUploads',
@@ -186,10 +192,24 @@ export default {
       files: [],
       showUploadDialog: false,
       error: null,
-      dragError: null
+      dragError: null,
+      portalIdentity: 'stream-uploads'
     }
   },
-  computed: {},
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
+  },
   methods: {
     onFileSelect(e) {
       this.parseFiles(e.target.files)

--- a/packages/frontend/src/main/pages/stream/TheWebhooks.vue
+++ b/packages/frontend/src/main/pages/stream/TheWebhooks.vue
@@ -53,7 +53,7 @@
       </p>
     </error-placeholder>
 
-    <v-container v-if="!$apollo.loading && webhooks.length !== 0" fluid class="pa-0">
+    <v-container v-if="showToolbar && canRenderToolbarPortal" fluid class="pa-0">
       <portal to="toolbar">
         <div class="d-flex align-center">
           <div class="text-truncate">
@@ -268,6 +268,13 @@
 
 <script>
 import webhooksQuery from '@/graphql/webhooks.gql'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
+
 export default {
   name: 'TheWebhooks',
   components: {
@@ -304,14 +311,39 @@ export default {
       editWebhookDialog: false,
       statusReportsDialog: false,
       selectedWebhook: null,
-      error: null
+      error: null,
+      portalIdentity: 'stream-webhooks'
     }
   },
   computed: {
     webhooks() {
       if (this.stream) return this.stream.webhooks.items
       return []
+    },
+    showToolbar() {
+      return !this.$apollo.loading && this.webhooks.length !== 0
+    },
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
     }
+  },
+  watch: {
+    showToolbar: {
+      handler(newVal) {
+        if (newVal) {
+          claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+        } else {
+          unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+        }
+      },
+      immediate: true
+    }
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
   },
   methods: {
     getStatusIcon(webhook) {

--- a/packages/frontend/src/main/pages/user/TheProfileSelf.vue
+++ b/packages/frontend/src/main/pages/user/TheProfileSelf.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="pa-0" fluid>
-    <portal to="toolbar"><b>Your Profile</b></portal>
+    <portal v-if="canRenderToolbarPortal" to="toolbar"><b>Your Profile</b></portal>
     <v-row>
       <v-col cols="12" lg="4">
         <user-info-card :user="user" @update="update"></user-info-card>
@@ -41,6 +41,12 @@
 <script>
 import { ProfileSelfQuery } from '@/graphql/user'
 import { signOut } from '@/plugins/authHelpers'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'TheProfileSelf',
@@ -52,13 +58,26 @@ export default {
     UserAuthorisedApps: () => import('@/main/components/user/UserAuthorisedApps'),
     UserDeleteCard: () => import('@/main/components/user/UserDeleteCard')
   },
-  data: () => ({}),
+  data: () => ({ portalIdentity: 'user-profile-self' }),
   apollo: {
     user: {
       query: ProfileSelfQuery
     }
   },
-  computed: {},
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
+  },
   methods: {
     update() {
       this.$apollo.queries.user.refetch()

--- a/packages/frontend/src/main/pages/user/TheProfileUser.vue
+++ b/packages/frontend/src/main/pages/user/TheProfileUser.vue
@@ -1,6 +1,8 @@
 <template>
   <v-container fluid class="pa-0">
-    <portal v-if="user" to="toolbar">Profile Page of {{ user.name }}</portal>
+    <portal v-if="canRenderToolbarPortal && user" to="toolbar">
+      Profile Page of {{ user.name }}
+    </portal>
     <v-row v-if="$apollo.loading">
       <v-col cols="12">
         <v-skeleton-loader type="card, article"></v-skeleton-loader>
@@ -40,6 +42,12 @@
 <script>
 import ListItemStream from '@/main/components/user/ListItemStream'
 import gql from 'graphql-tag'
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
 
 export default {
   name: 'TheProfileUser',
@@ -48,7 +56,7 @@ export default {
     SectionCard: () => import('@/main/components/common/SectionCard'),
     ListItemStream
   },
-  data: () => ({}),
+  data: () => ({ portalIdentity: 'user-profile' }),
   apollo: {
     user: {
       query: gql`
@@ -87,7 +95,20 @@ export default {
       }
     }
   },
-  computed: {},
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
+  },
   created() {
     // Move to self profile
     if (this.$route.params.userId === localStorage.getItem('uuid')) {

--- a/packages/frontend/src/main/toolbars/CommitToolbar.vue
+++ b/packages/frontend/src/main/toolbars/CommitToolbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <portal to="toolbar">
+  <portal v-if="canRenderToolbarPortal" to="toolbar">
     <div class="d-flex align-center">
       <!-- <div class="text-truncate flex-shrink-0">
         <router-link v-tooltip="'all streams'" to="/streams" class="text-decoration-none mx-1">
@@ -159,6 +159,13 @@
   </portal>
 </template>
 <script>
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
+
 export default {
   components: {
     SourceAppAvatar: () => import('@/main/components/common/SourceAppAvatar'),
@@ -173,8 +180,21 @@ export default {
     }
   },
   data() {
-    return { showCommitInfo: false }
+    return { showCommitInfo: false, portalIdentity: 'stream-commit' }
   },
-  computed: {}
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
+  }
 }
 </script>

--- a/packages/frontend/src/main/toolbars/MultipleResourcesToolbar.vue
+++ b/packages/frontend/src/main/toolbars/MultipleResourcesToolbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <portal to="toolbar">
+  <portal v-if="canRenderToolbarPortal" to="toolbar">
     <div class="d-flex align-center">
       <div class="text-truncate flex-shrink-0 flex-lg-shrink-1">
         <router-link
@@ -27,6 +27,13 @@
   </portal>
 </template>
 <script>
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
+
 export default {
   props: {
     stream: {
@@ -37,6 +44,21 @@ export default {
       type: Array,
       default: () => []
     }
+  },
+  data: () => ({ portalIdentity: 'stream-commit-multiple-resources' }),
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   }
 }
 </script>

--- a/packages/frontend/src/main/toolbars/ObjectToolbar.vue
+++ b/packages/frontend/src/main/toolbars/ObjectToolbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <portal to="toolbar">
+  <portal v-if="canRenderToolbarPortal" to="toolbar">
     <div class="d-flex align-center">
       <div class="text-truncate flex-shrink-0 flex-lg-shrink-1">
         <router-link
@@ -43,6 +43,13 @@
   </portal>
 </template>
 <script>
+import {
+  claimPortal,
+  unclaimPortal,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
+
 export default {
   props: {
     stream: {
@@ -51,7 +58,7 @@ export default {
     }
   },
   data() {
-    return { showInfo: false }
+    return { showInfo: false, portalIdentity: 'stream-commit-objects' }
   },
   computed: {
     commitDate() {
@@ -60,7 +67,19 @@ export default {
       const options = { year: 'numeric', month: 'long', day: 'numeric' }
 
       return date.toLocaleString(undefined, options)
+    },
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
     }
+  },
+  mounted() {
+    claimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity, 1)
+  },
+  beforeDestroy() {
+    unclaimPortal(STANDARD_PORTAL_KEYS.Toolbar, this.portalIdentity)
   }
 }
 </script>

--- a/packages/frontend/src/main/toolbars/StreamToolbar.vue
+++ b/packages/frontend/src/main/toolbars/StreamToolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="stream">
-    <portal to="toolbar">
+    <portal v-if="canRenderToolbarPortal" to="toolbar">
       <div class="d-flex align-center">
         <div class="text-truncate">
           <router-link
@@ -41,7 +41,7 @@
         </div>
       </div>
     </portal>
-    <portal to="actions">
+    <portal v-if="canRenderActionsPortal" to="actions">
       <span v-if="user" style="position: relative; right: -5px">
         <stream-favorite-btn :stream="stream" :user="user" />
       </span>
@@ -71,6 +71,13 @@
   </div>
 </template>
 <script>
+import {
+  claimPortals,
+  unclaimPortals,
+  portalsState,
+  STANDARD_PORTAL_KEYS
+} from '@/main/utils/portalStateManager'
+
 export default {
   components: {
     CollaboratorsDisplay: () => import('@/main/components/stream/CollaboratorsDisplay'),
@@ -83,7 +90,34 @@ export default {
     user: { type: Object, default: () => null }
   },
   data() {
-    return { shareStream: false }
+    return { shareStream: false, portalIdentity: 'stream-main' }
+  },
+  computed: {
+    canRenderToolbarPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Toolbar] ===
+        this.portalIdentity
+      )
+    },
+    canRenderActionsPortal() {
+      return (
+        portalsState.currentPortals[STANDARD_PORTAL_KEYS.Actions] ===
+        this.portalIdentity
+      )
+    }
+  },
+  mounted() {
+    claimPortals(
+      [STANDARD_PORTAL_KEYS.Toolbar, STANDARD_PORTAL_KEYS.Actions],
+      this.portalIdentity,
+      0
+    )
+  },
+  beforeDestroy() {
+    unclaimPortals(
+      [STANDARD_PORTAL_KEYS.Toolbar, STANDARD_PORTAL_KEYS.Actions],
+      this.portalIdentity
+    )
   }
 }
 </script>

--- a/packages/frontend/src/main/utils/portalStateManager.js
+++ b/packages/frontend/src/main/utils/portalStateManager.js
@@ -3,7 +3,8 @@ import Vue from 'vue'
 export const STANDARD_PORTAL_KEYS = {
   Toolbar: 'toolbar',
   Actions: 'actions',
-  Nav: 'nav'
+  Nav: 'nav',
+  SubnavAdmin: 'subnav-admin'
 }
 
 /**
@@ -33,6 +34,13 @@ function recalculateState() {
       if (!highestPriorityIdentity || data.priority > highestPriority) {
         highestPriorityIdentity = identity
         highestPriority = data.priority
+      } else if (
+        highestPriority === data.priority &&
+        highestPriorityIdentity === identity
+      ) {
+        console.error(
+          'Multiple portals with the same priority encountered, your portals might not act deterministically'
+        )
       }
     }
     newPortals[portalKey] = highestPriorityIdentity
@@ -76,7 +84,9 @@ export function claimPortals(portals, identity, priority) {
  * @param {string} identity
  */
 export function unclaimPortal(portal, identity) {
-  delete claims[portal][identity]
+  if (claims[portal]) {
+    delete claims[portal][identity]
+  }
   recalculateState()
 }
 

--- a/packages/frontend/src/main/utils/portalStateManager.js
+++ b/packages/frontend/src/main/utils/portalStateManager.js
@@ -1,0 +1,92 @@
+import Vue from 'vue'
+
+export const STANDARD_PORTAL_KEYS = {
+  Toolbar: 'toolbar',
+  Actions: 'actions',
+  Nav: 'nav'
+}
+
+/**
+ * We currently have multiple <portal> sources trying to use the same destination, which usually
+ * results in the source being chosen at random. To solve this, we're using this custom portal state
+ * manager which manages multiple claims to the same portal space and only allows one source to use it at a time.
+ */
+
+/**
+ * @type {{currentPortals: Object<string, string>}}
+ */
+export const portalsState = Vue.observable({
+  currentPortals: {}
+})
+
+/**
+ * @type {Object<string, Object<string, {priority: number }>>}
+ */
+const claims = {}
+
+function recalculateState() {
+  const newPortals = {}
+  for (const [portalKey, portalClaims] of Object.entries(claims)) {
+    let highestPriority = undefined
+    let highestPriorityIdentity = undefined
+    for (const [identity, data] of Object.entries(portalClaims)) {
+      if (!highestPriorityIdentity || data.priority > highestPriority) {
+        highestPriorityIdentity = identity
+        highestPriority = data.priority
+      }
+    }
+    newPortals[portalKey] = highestPriorityIdentity
+  }
+
+  Vue.set(portalsState, 'currentPortals', newPortals)
+}
+
+/**
+ * Claim access to a specific toolbar
+ * @param {string} portal
+ * @param {string} identity
+ * @param {number} priority
+ */
+export function claimPortal(portal, identity, priority) {
+  // Register claim
+  if (!claims[portal]) {
+    claims[portal] = {}
+  }
+
+  claims[portal][identity] = { priority }
+
+  recalculateState()
+}
+
+/**
+ * Claim access to multiple toolbars
+ * @param {string[]} portals
+ * @param {string} identity
+ * @param {number} priority
+ */
+export function claimPortals(portals, identity, priority) {
+  for (const portal of portals) {
+    claimPortal(portal, identity, priority)
+  }
+}
+
+/**
+ * Remove claim to a specific toolbar
+ * @param {string} portal
+ * @param {string} identity
+ */
+export function unclaimPortal(portal, identity) {
+  delete claims[portal][identity]
+  recalculateState()
+}
+
+/**
+ * Remove claims to multiple toolbars
+ * @param {string[]} portals
+ * @param {string} identity
+ */
+export function unclaimPortals(portals, identity) {
+  for (const portal of portals) {
+    unclaimPortal(portal, identity)
+  }
+}


### PR DESCRIPTION
It could be done cleaner without requiring state management for portals, but that would require re-architecting how all of the toolbars & nav bars are done. So for now we've at least got a working fix - portals only send things through if they've got approval from the portal state manager.

I went through all of the usages for the main portal targets (toolbar, nav, actions) and tested them out as well, seemed to work OK.