### PR TITLE
Acos fix

### DIFF
--- a/packages/viewer-sandbox/src/main.ts
+++ b/packages/viewer-sandbox/src/main.ts
@@ -32,7 +32,7 @@ pane.addInput(PARAMS, 'color')
 
 // Load demo object
 viewer.loadObject(
-  'https://speckle.xyz/streams/99abc74dd4/objects/ab503a2025e706717bff467ef8f96488'
+  'https://speckle.xyz/streams/9217731fc1/objects/111a9dc2ed245f26a6584354b11b083f'
 )
 
 viewer.on<{ progress: number; id: string; url: string }>('load-progress', (a) => {

--- a/packages/viewer/src/modules/converter/Converter.js
+++ b/packages/viewer/src/modules/converter/Converter.js
@@ -644,7 +644,7 @@ export default class Coverter {
      * values outside that interval, but due to floating point precision, you sometimes get -1.0000000004, which
      * makes acos return NaN
      */
-    const dot = Math.min(Math.max(v0.dot(v1, -1), 1))
+    const dot = Math.min(Math.max(v0.dot(v1), -1), 1)
     // This is just the angle between the start and end points. Should be same as obj.angleRadians(or something)
     const angle = Math.acos(dot)
     const radius = obj.radius

--- a/packages/viewer/src/modules/converter/Converter.js
+++ b/packages/viewer/src/modules/converter/Converter.js
@@ -639,9 +639,14 @@ export default class Coverter {
     v2.normalize()
     const v3 = new Vector3().crossVectors(v2, v0)
     v3.normalize()
-
+    /**
+     * We clamp the dot value to [-1,1] since that's the domain acos is defined on. Normally dot won't return
+     * values outside that interval, but due to floating point precision, you sometimes get -1.0000000004, which
+     * makes acos return NaN
+     */
+    const dot = Math.min(Math.max(v0.dot(v1, -1), 1))
     // This is just the angle between the start and end points. Should be same as obj.angleRadians(or something)
-    const angle = Math.acos(v0.dot(v1))
+    const angle = Math.acos(dot)
     const radius = obj.radius
     // We draw the arc in a local un-rotated coordinate system. We rotate it later on via transformation
     const curve = new THREE.EllipseCurve(


### PR DESCRIPTION
Fixes an issue with arcs. Hopefully the same one here -> https://speckle.community/t/objects-geometry-arc-not-displaying-as-it-should-on-the-viewer/2944