### PR TITLE
fix(frontend): branch stale cache bug when creating/deleting them

### DIFF
--- a/packages/frontend/src/main/components/common/UserAvatar.vue
+++ b/packages/frontend/src/main/components/common/UserAvatar.vue
@@ -1,6 +1,6 @@
 <template>
   <div style="display: inline-block">
-    <v-menu v-if="$loggedIn()" offset-x open-on-hover>
+    <v-menu v-if="$loggedIn()" offset-x open-on-hover :close-on-content-click="false">
       <template #activator="{ on, attrs }">
         <div v-bind="attrs" v-on="on">
           <user-avatar-icon

--- a/packages/frontend/src/main/dialogs/NewBranch.vue
+++ b/packages/frontend/src/main/dialogs/NewBranch.vue
@@ -93,9 +93,23 @@ export default {
         this.loading = false
         this.$emit('refetch-branches')
         this.$emit('close')
-        this.$router.push(
-          `/streams/${this.$route.params.streamId}/branches/${this.name.toLowerCase()}`
-        )
+
+        try {
+          await this.$router.push(
+            `/streams/${
+              this.$route.params.streamId
+            }/branches/${this.name.toLowerCase()}`
+          )
+        } catch (routerErr) {
+          if (routerErr?.name === 'NavigationDuplicated') {
+            // Just created a new branch, while we're on its 404 page
+            // Kind of an edge case, so as reloading the page is easier, i'll just do that instead of messing
+            // with the Apollo cache
+            location.reload()
+          } else {
+            throw routerErr
+          }
+        }
       } catch (err) {
         this.showError = true
         if (err.message.includes('branches_streamid_name_unique'))

--- a/packages/frontend/src/main/navigation/StreamNav.vue
+++ b/packages/frontend/src/main/navigation/StreamNav.vue
@@ -241,6 +241,7 @@ export default {
             branches {
               totalCount
               items {
+                id
                 name
                 description
                 author {

--- a/packages/frontend/src/main/pages/stream/TheBranch.vue
+++ b/packages/frontend/src/main/pages/stream/TheBranch.vue
@@ -129,7 +129,8 @@ export default {
           streamId: this.streamId,
           branchName: this.$route.params.branchName.toLowerCase()
         }
-      }
+      },
+      fetchPolicy: 'network-only'
     },
     $subscribe: {
       commitCreated: {


### PR DESCRIPTION
Fixed 3 bugs actually:

1. The branch entity remaining in the cache after it's deleted, causing issues later on (e.g. when creating a new one with the same name and trying to delete it). At first I tried to resolve this without refetching from server & just updating the Apollo cache, but the ApolloClientv2 cache eviction utilities are nonexistant (there are better ones in v3) so it was easier to refetch

2. The branch edit dialog component mutated its inputs which shouldn't be done. In this case it wasn't a mutation of the props, but the data that comes directly from the Apollo cache. So previously while you were changing the name of the branch, you were making direct changes to the apollo cache.

3. Fix for the issue Jedd mentioned once where the User Avatar hover menu closes once you select text inside of it. From now on the hover menu won't close on any clicks inside its content.

closes https://github.com/specklesystems/speckle-server/issues/755