### PR TITLE
Silencing the noisy Embedded Viewer console log

### DIFF
--- a/packages/frontend/src/main/components/viewer/ViewerFilters.vue
+++ b/packages/frontend/src/main/components/viewer/ViewerFilters.vue
@@ -164,12 +164,14 @@ export default {
     if (this.props) {
       this.parseAndSetFilters()
     }
-    this.$eventHub.$on('structure-filters', () => {
-      this.activeFilter = null
-    })
-    this.$eventHub.$on('selection-filters', () => {
-      this.activeFilter = null
-    })
+    if (this.$eventHub) {
+      this.$eventHub.$on('structure-filters', () => {
+        this.activeFilter = null
+      })
+      this.$eventHub.$on('selection-filters', () => {
+        this.activeFilter = null
+      })
+    }
   },
   methods: {
     parseAndSetFilters() {


### PR DESCRIPTION
The embedded viewer either doesn't implement the event-hub or doesn't add it at mount time for the Viewer Filter component. Consequently, this is noisy with associated errors of accessing the $on event triggers for $eventHub.
<img src="https://user-images.githubusercontent.com/760691/172047118-8ddea63b-f4a0-4023-8213-abf0130744c5.png" width="150"/>

This edit makes the addition of the $on event listener conditional on the $eventHub being instantiated.