### PR TITLE
refactor(object-loader): disable debug console logs

### DIFF
--- a/packages/objectloader/src/index.js
+++ b/packages/objectloader/src/index.js
@@ -30,7 +30,7 @@ export default class ObjectLoader {
     this.serverUrl = serverUrl || window.location.origin
     this.streamId = streamId
     this.objectId = objectId
-    console.log('Object loader constructor called!')
+    // console.log('Object loader constructor called!')
     try {
       this.token = token || localStorage.getItem('AuthToken')
     } catch (error) {
@@ -253,7 +253,7 @@ export default class ObjectLoader {
       count += 1
       yield obj
     }
-    console.log(`Loaded ${count} objects in: ${(Date.now() - t0) / 1000}`)
+    // console.log(`Loaded ${count} objects in: ${(Date.now() - t0) / 1000}`)
   }
 
   processLine(chunk) {
@@ -303,7 +303,7 @@ export default class ObjectLoader {
         splitBeforeCacheCheck[3].push(childrenIds[crtChildIndex])
       }
 
-      console.log('Cache check for: ', splitBeforeCacheCheck)
+      // console.log('Cache check for: ', splitBeforeCacheCheck)
 
       const newChildren = []
       let nextCachePromise = this.cacheGetObjects(splitBeforeCacheCheck[0])


### PR DESCRIPTION
When working with the object-loader on a server, several logs which I believe were there for debug purposes were "polluting" the logging. For example, if am downloading a large object, or if I am instantiating several ObjectLoaders.

E.g.:

![image](https://user-images.githubusercontent.com/61347148/172374018-a1b71891-92e9-4f7d-969c-d1f0ed51523f.png)

![image](https://user-images.githubusercontent.com/61347148/172374058-ecd4f822-98e7-4acb-a8fd-fd5088bc512d.png)
