### PR TITLE
Handles three issues: 1) Line weigth is now scaled according to units…

### DIFF
--- a/packages/viewer-sandbox/src/main.ts
+++ b/packages/viewer-sandbox/src/main.ts
@@ -39,4 +39,6 @@ viewer.on('load-complete', () => {
 sandbox.makeGenericUI()
 sandbox.makeSceneUI()
 // Load demo object
-sandbox.loadUrl('https://latest.speckle.dev/streams/3ed8357f29/commits/b21fb0dcf7')
+sandbox.loadUrl(
+  'https://speckle.xyz/streams/638d3b1f83/commits/6025e2b546?c=%5B2.18058,-0.20814,9.67642,3.85491,5.05364,0,0,1%5D'
+)

--- a/packages/viewer/src/modules/SceneObjectManager.js
+++ b/packages/viewer/src/modules/SceneObjectManager.js
@@ -8,6 +8,7 @@ import SpeckleStandardMaterial from './materials/SpeckleStandardMaterial'
 import SpeckleLineMaterial from './materials/SpeckleLineMaterial'
 import SpeckleLineBasicMaterial from './materials/SpeckleLineBasicMaterial'
 import SpeckleBasicMaterial from './materials/SpeckleBasicMaterial'
+import { getConversionFactor } from './converter/Units'
 /**
  * Manages objects and provides some convenience methods to focus on the entire scene, or one specific object.
  */
@@ -234,7 +235,11 @@ export default class SceneObjectManager {
     if (wrapper.meta.displayStyle) {
       material = this.lineMaterial.clone()
       if (wrapper.meta.displayStyle.lineweight > 0) {
-        material.linewidth = wrapper.meta.displayStyle.lineweight
+        material.linewidth =
+          wrapper.meta.displayStyle.lineweight *
+          getConversionFactor(
+            wrapper.meta.displayStyle.units ? wrapper.meta.displayStyle.units : 'm' // We default to meters, since we don't have access to the parent's units (in this implementation)
+          )
         material.worldUnits = true
         material.pixelThreshold = 0.5
       } else {

--- a/packages/viewer/src/modules/converter/Converter.ts
+++ b/packages/viewer/src/modules/converter/Converter.ts
@@ -684,7 +684,16 @@ export default class Coverter {
    */
   async CircleToGeometryData(obj, scale = true) {
     const conversionFactor = scale ? getConversionFactor(obj.units) : 1
-    const points = this.getCircularCurvePoints(obj.plane, obj.radius * conversionFactor)
+    const points = this.getCircularCurvePoints(
+      obj.plane,
+      obj.radius * conversionFactor,
+      0,
+      2 * Math.PI,
+      scale
+        ? this.curveSegmentLength * getConversionFactor(obj.units)
+        : this.curveSegmentLength,
+      scale
+    )
     return {
       attributes: {
         POSITION: this.FlattenVector3Array(points)
@@ -869,10 +878,11 @@ export default class Coverter {
     radius,
     startAngle = 0,
     endAngle = 2 * Math.PI,
-    res = this.curveSegmentLength
+    res = this.curveSegmentLength,
+    scale
   ) {
     // Get alignment vectors
-    const center = this.PointToVector3(plane.origin)
+    const center = this.PointToVector3(plane.origin, scale)
     const xAxis = this.PointToVector3(plane.xdir)
     const yAxis = this.PointToVector3(plane.ydir)
 


### PR DESCRIPTION
Handles three issues: 
1) Line weight is now scaled according to units specified in the lineStyle. If there is not lineStyle it defaults to meters
2) Fixed an [issue ](https://github.com/specklesystems/speckle-server/issues/792)where the circle point computation would scale the origin wrongly, leading to incorrect circle positioning. [Example stream](https://speckle.xyz/streams/638d3b1f83/commits/6025e2b546?c=%5B2.18058,-0.20814,9.67642,3.85491,5.05364,0,0,1%5D)
3) Fixed an issue where the step size when computing point on a circle was too large, and the circles were very coarse, even squares. [Example stream](https://speckle.xyz/streams/928e8d9523/commits/5717427fcf?c=%5B0.9324,-0.06938,0.45706,0.31667,0,0,0,1%5D)