### PR TITLE
Add minio container to the test deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,8 @@ jobs:
     environment:
       NODE_ENV: test
       DATABASE_URL: 'postgres://speckle:speckle@localhost:5432/speckle2_test'
+      PGDATABASE: speckle2_test
+      PGUSER: speckle
       SESSION_SECRET: 'keyboard cat'
       STRATEGY_LOCAL: 'true'
       CANONICAL_URL: 'http://localhost:3000'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,10 @@ jobs:
           POSTGRES_DB: speckle2_test
           POSTGRES_PASSWORD: speckle
           POSTGRES_USER: speckle
+      - image: 'minio/minio'
+        command: server /data --console-address ":9001"
+        # environment:
+
     environment:
       NODE_ENV: test
       DATABASE_URL: 'postgres://speckle:speckle@localhost:5432/speckle2_test'
@@ -128,7 +132,7 @@ jobs:
       SESSION_SECRET: 'keyboard cat'
       STRATEGY_LOCAL: 'true'
       CANONICAL_URL: 'http://localhost:3000'
-      DISABLE_FILE_UPLOADS: 'true'
+      DISABLE_FILE_UPLOADS: 'false'
       S3_ENDPOINT: 'http://localhost:9000'
       S3_ACCESS_KEY: 'minioadmin'
       S3_SECRET_KEY: 'minioadmin'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,12 +127,9 @@ jobs:
     environment:
       NODE_ENV: test
       DATABASE_URL: 'postgres://speckle:speckle@localhost:5432/speckle2_test'
-      PGDATABASE: speckle2_test
-      PGUSER: speckle
       SESSION_SECRET: 'keyboard cat'
       STRATEGY_LOCAL: 'true'
       CANONICAL_URL: 'http://localhost:3000'
-      DISABLE_FILE_UPLOADS: 'false'
       S3_ENDPOINT: 'http://localhost:9000'
       S3_ACCESS_KEY: 'minioadmin'
       S3_SECRET_KEY: 'minioadmin'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
     docker:
       - image: cimg/node:16.15
       - image: cimg/redis:6.2.6
-      - image: 'cimg/postgres:12.8'
+      - image: 'cimg/postgres:14.2'
         environment:
           POSTGRES_DB: speckle2_test
           POSTGRES_PASSWORD: speckle


### PR DESCRIPTION
Turns out, i was dumb, and couldn't pass in commands to the minio container startup for some reason.
Now S3 storage can also be part of the integration tests