### PR TITLE
Remove Query timeout

### DIFF
--- a/packages/fileimport-service/knex.js
+++ b/packages/fileimport-service/knex.js
@@ -6,9 +6,7 @@ module.exports = require('knex')({
   connection: {
     application_name: 'speckle_fileimport_service',
     connectionString:
-      process.env.PG_CONNECTION_STRING ||
-      'postgres://speckle:speckle@localhost/speckle',
-    query_timeout: 4.32e7
+      process.env.PG_CONNECTION_STRING || 'postgres://speckle:speckle@localhost/speckle'
   },
   pool: { min: 0, max: 1 }
   // migrations are in managed in the server package

--- a/packages/preview-service/knex.js
+++ b/packages/preview-service/knex.js
@@ -6,9 +6,7 @@ module.exports = require('knex')({
   connection: {
     application_name: 'speckle_preview_service',
     connectionString:
-      process.env.PG_CONNECTION_STRING ||
-      'postgres://speckle:speckle@localhost/speckle',
-    query_timeout: 4.32e7
+      process.env.PG_CONNECTION_STRING || 'postgres://speckle:speckle@localhost/speckle'
   },
   pool: { min: 0, max: 2 }
   // migrations are in managed in the server package

--- a/packages/server/knexfile.js
+++ b/packages/server/knexfile.js
@@ -79,9 +79,7 @@ const config = {
     ...commonConfig,
     connection: {
       connectionString: connectionUri,
-      application_name: 'speckle_server',
-      // global timeout of 12 hours, that kills stuck connections
-      query_timeout: 4.32e7
+      application_name: 'speckle_server'
     }
   }
 }

--- a/packages/webhook-service/src/knex.js
+++ b/packages/webhook-service/src/knex.js
@@ -6,9 +6,7 @@ module.exports = require('knex')({
   connection: {
     application_name: 'speckle_webhook_service',
     connectionString:
-      process.env.PG_CONNECTION_STRING ||
-      'postgres://speckle:speckle@localhost/speckle',
-    query_timeout: 4.32e7
+      process.env.PG_CONNECTION_STRING || 'postgres://speckle:speckle@localhost/speckle'
   },
   pool: { min: 0, max: 1 }
   // migrations are in managed in the server package


### PR DESCRIPTION
An issue arose after merging #805.

Turns out it doesn't play nice with streaming connections as per:
https://github.com/vitaly-t/pg-promise/issues/715
https://github.com/brianc/node-postgres/issues/1860
https://github.com/brianc/node-postgres/pull/2560

based on the [knex connection pool docs](https://knexjs.org/guide/#pool), setting the min connections to 0 should be good enough.