### PR TITLE
fix: various server invites related improvements & fixes

### DIFF
--- a/packages/frontend/src/graphql/fragments/user.js
+++ b/packages/frontend/src/graphql/fragments/user.js
@@ -27,6 +27,7 @@ export const usersOwnInviteFieldsFragment = gql`
     inviteId
     streamId
     streamName
+    token
     invitedBy {
       ...LimitedUserFields
     }

--- a/packages/frontend/src/graphql/generated/graphql.ts
+++ b/packages/frontend/src/graphql/generated/graphql.ts
@@ -654,8 +654,8 @@ export type MutationStreamInviteCreateArgs = {
 
 export type MutationStreamInviteUseArgs = {
   accept: Scalars['Boolean'];
-  inviteId: Scalars['String'];
   streamId: Scalars['String'];
+  token: Scalars['String'];
 };
 
 
@@ -788,6 +788,8 @@ export type PendingStreamCollaborator = {
   streamName: Scalars['String'];
   /** E-mail address or name of the invited user */
   title: Scalars['String'];
+  /** Only available if the active user is the pending stream collaborator */
+  token?: Maybe<Scalars['String']>;
   /** Set only if user is registered */
   user?: Maybe<LimitedUser>;
 };
@@ -821,7 +823,7 @@ export type Query = {
    */
   stream?: Maybe<Stream>;
   /**
-   * Look for an invitation to a stream, for the current user (authed or not). If inviteId
+   * Look for an invitation to a stream, for the current user (authed or not). If token
    * isn't specified, the server will look for any valid invite.
    */
   streamInvite?: Maybe<PendingStreamCollaborator>;
@@ -885,8 +887,8 @@ export type QueryStreamArgs = {
 
 
 export type QueryStreamInviteArgs = {
-  inviteId?: InputMaybe<Scalars['String']>;
   streamId: Scalars['String'];
+  token?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -1186,6 +1188,8 @@ export type StreamCreateInput = {
 export type StreamInviteCreateInput = {
   email?: InputMaybe<Scalars['String']>;
   message?: InputMaybe<Scalars['String']>;
+  /** Defaults to the contributor role, if not specified */
+  role?: InputMaybe<Scalars['String']>;
   streamId: Scalars['String'];
   userId?: InputMaybe<Scalars['String']>;
 };
@@ -1529,25 +1533,25 @@ export type LimitedUserFieldsFragment = { __typename?: 'LimitedUser', id: string
 
 export type StreamCollaboratorFieldsFragment = { __typename?: 'StreamCollaborator', id: string, name: string, role: string, company?: string | null, avatar?: string | null };
 
-export type UsersOwnInviteFieldsFragment = { __typename?: 'PendingStreamCollaborator', id: string, inviteId: string, streamId: string, streamName: string, invitedBy: { __typename?: 'LimitedUser', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null } };
+export type UsersOwnInviteFieldsFragment = { __typename?: 'PendingStreamCollaborator', id: string, inviteId: string, streamId: string, streamName: string, token?: string | null, invitedBy: { __typename?: 'LimitedUser', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null } };
 
 export type StreamInviteQueryVariables = Exact<{
   streamId: Scalars['String'];
-  inviteId?: InputMaybe<Scalars['String']>;
+  token?: InputMaybe<Scalars['String']>;
 }>;
 
 
-export type StreamInviteQuery = { __typename?: 'Query', streamInvite?: { __typename?: 'PendingStreamCollaborator', id: string, inviteId: string, streamId: string, streamName: string, invitedBy: { __typename?: 'LimitedUser', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null } } | null };
+export type StreamInviteQuery = { __typename?: 'Query', streamInvite?: { __typename?: 'PendingStreamCollaborator', id: string, inviteId: string, streamId: string, streamName: string, token?: string | null, invitedBy: { __typename?: 'LimitedUser', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null } } | null };
 
 export type UserStreamInvitesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type UserStreamInvitesQuery = { __typename?: 'Query', streamInvites: Array<{ __typename?: 'PendingStreamCollaborator', id: string, inviteId: string, streamId: string, streamName: string, invitedBy: { __typename?: 'LimitedUser', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null } }> };
+export type UserStreamInvitesQuery = { __typename?: 'Query', streamInvites: Array<{ __typename?: 'PendingStreamCollaborator', id: string, inviteId: string, streamId: string, streamName: string, token?: string | null, invitedBy: { __typename?: 'LimitedUser', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null } }> };
 
 export type UseStreamInviteMutationVariables = Exact<{
   accept: Scalars['Boolean'];
   streamId: Scalars['String'];
-  inviteId: Scalars['String'];
+  token: Scalars['String'];
 }>;
 
 
@@ -1796,6 +1800,7 @@ export const UsersOwnInviteFields = gql`
   inviteId
   streamId
   streamName
+  token
   invitedBy {
     ...LimitedUserFields
   }
@@ -1936,8 +1941,8 @@ export const StreamCommitQuery = gql`
 }
     `;
 export const StreamInvite = gql`
-    query StreamInvite($streamId: String!, $inviteId: String) {
-  streamInvite(streamId: $streamId, inviteId: $inviteId) {
+    query StreamInvite($streamId: String!, $token: String) {
+  streamInvite(streamId: $streamId, token: $token) {
     ...UsersOwnInviteFields
   }
 }
@@ -1950,8 +1955,8 @@ export const UserStreamInvites = gql`
 }
     ${UsersOwnInviteFields}`;
 export const UseStreamInvite = gql`
-    mutation UseStreamInvite($accept: Boolean!, $streamId: String!, $inviteId: String!) {
-  streamInviteUse(accept: $accept, streamId: $streamId, inviteId: $inviteId)
+    mutation UseStreamInvite($accept: Boolean!, $streamId: String!, $token: String!) {
+  streamInviteUse(accept: $accept, streamId: $streamId, token: $token)
 }
     `;
 export const CancelStreamInvite = gql`
@@ -2340,6 +2345,7 @@ export const UsersOwnInviteFieldsFragmentDoc = gql`
   inviteId
   streamId
   streamName
+  token
   invitedBy {
     ...LimitedUserFields
   }
@@ -2569,8 +2575,8 @@ export const useStreamCommitQueryQuery = createSmartQueryOptionsFunction<
 >(StreamCommitQueryDocument, handleApolloError);
 
 export const StreamInviteDocument = gql`
-    query StreamInvite($streamId: String!, $inviteId: String) {
-  streamInvite(streamId: $streamId, inviteId: $inviteId) {
+    query StreamInvite($streamId: String!, $token: String) {
+  streamInvite(streamId: $streamId, token: $token) {
     ...UsersOwnInviteFields
   }
 }
@@ -2590,7 +2596,7 @@ export const StreamInviteDocument = gql`
  *     streamInvite: useStreamInviteQuery({
  *       variables: {
  *         streamId: // value for 'streamId'
- *         inviteId: // value for 'inviteId'
+ *         token: // value for 'token'
  *       },
  *       loadingKey: 'loading',
  *       fetchPolicy: 'no-cache',
@@ -2638,8 +2644,8 @@ export const useUserStreamInvitesQuery = createSmartQueryOptionsFunction<
 >(UserStreamInvitesDocument, handleApolloError);
 
 export const UseStreamInviteDocument = gql`
-    mutation UseStreamInvite($accept: Boolean!, $streamId: String!, $inviteId: String!) {
-  streamInviteUse(accept: $accept, streamId: $streamId, inviteId: $inviteId)
+    mutation UseStreamInvite($accept: Boolean!, $streamId: String!, $token: String!) {
+  streamInviteUse(accept: $accept, streamId: $streamId, token: $token)
 }
     `;
 
@@ -2658,7 +2664,7 @@ export const UseStreamInviteDocument = gql`
  *   variables: {
  *     accept: // value for 'accept'
  *     streamId: // value for 'streamId'
- *     inviteId: // value for 'inviteId'
+ *     token: // value for 'token'
  *   },
  * });
  */

--- a/packages/frontend/src/graphql/invites.js
+++ b/packages/frontend/src/graphql/invites.js
@@ -2,8 +2,8 @@ import gql from 'graphql-tag'
 import { usersOwnInviteFieldsFragment } from '@/graphql/fragments/user'
 
 export const streamInviteQuery = gql`
-  query StreamInvite($streamId: String!, $inviteId: String) {
-    streamInvite(streamId: $streamId, inviteId: $inviteId) {
+  query StreamInvite($streamId: String!, $token: String) {
+    streamInvite(streamId: $streamId, token: $token) {
       ...UsersOwnInviteFields
     }
   }
@@ -22,8 +22,8 @@ export const userStreamInvitesQuery = gql`
 `
 
 export const useStreamInviteMutation = gql`
-  mutation UseStreamInvite($accept: Boolean!, $streamId: String!, $inviteId: String!) {
-    streamInviteUse(accept: $accept, streamId: $streamId, inviteId: $inviteId)
+  mutation UseStreamInvite($accept: Boolean!, $streamId: String!, $token: String!) {
+    streamInviteUse(accept: $accept, streamId: $streamId, token: $token)
   }
 `
 

--- a/packages/frontend/src/main/components/activity/ListItemActivity.vue
+++ b/packages/frontend/src/main/components/activity/ListItemActivity.vue
@@ -152,7 +152,7 @@
                 <v-icon small class="mr-2 float-left">mdi-source-commit</v-icon>
                 {{ stream.commits.totalCount }}
               </v-btn>
-              <v-chip small outlined class="ml-3 no-hover">
+              <v-chip v-if="stream.role" small outlined class="ml-3 no-hover">
                 <v-icon small left>mdi-account-key-outline</v-icon>
                 {{ stream.role.split(':')[1] }}
               </v-chip>

--- a/packages/frontend/src/main/components/auth/AuthStrategies.vue
+++ b/packages/frontend/src/main/components/auth/AuthStrategies.vue
@@ -19,7 +19,7 @@
             :color="s.color"
             :href="`${s.url}?appId=${appId}&challenge=${challenge}${
               suuid ? '&suuid=' + suuid : ''
-            }${inviteId ? '&inviteId=' + inviteId : ''}`"
+            }${token ? '&token=' + token : ''}`"
           >
             <v-icon small class="mr-5">{{ s.icon }}</v-icon>
             {{ s.name }}
@@ -30,7 +30,7 @@
   </div>
 </template>
 <script>
-import { getInviteIdFromURL } from '@/main/lib/auth/services/authService'
+import { getInviteTokenFromRoute } from '@/main/lib/auth/services/authService'
 export default {
   name: 'AuthStrategies',
   props: {
@@ -51,18 +51,15 @@ export default {
       default: () => null
     }
   },
-  data() {
-    return {
-      inviteId: null
+  computed: {
+    token() {
+      return getInviteTokenFromRoute(this.$route)
     }
-  },
-  mounted() {
-    this.inviteId = getInviteIdFromURL()
   },
   methods: {
     trackSignIn(strategyName) {
       this.$mixpanel.track('Log In', {
-        isInvite: this.inviteId !== null,
+        isInvite: this.token !== null,
         type: 'action',
         provider: strategyName
       })

--- a/packages/frontend/src/main/components/stream/StreamActivity.vue
+++ b/packages/frontend/src/main/components/stream/StreamActivity.vue
@@ -91,7 +91,14 @@ export default {
   },
   methods: {
     groupSimilarActivities(data) {
+      if (!data) return
+
+      const skippableActionTypes = ['stream_invite_sent', 'stream_invite_declined']
       const groupedActivity = data.stream.activity.items.reduce(function (prev, curr) {
+        if (skippableActionTypes.includes(curr.actionType)) {
+          return prev
+        }
+
         //first item
         if (!prev.length) {
           prev.push([curr])

--- a/packages/frontend/src/main/components/stream/StreamInvitePlaceholder.vue
+++ b/packages/frontend/src/main/components/stream/StreamInvitePlaceholder.vue
@@ -8,8 +8,10 @@
           :avatar="streamInviter.avatar"
           :size="75"
         />
-        <v-icon class="mx-4">mdi-plus</v-icon>
-        <user-avatar :id="$userId()" :size="75" />
+        <template v-if="$userId()">
+          <v-icon class="mx-4">mdi-plus</v-icon>
+          <user-avatar :id="$userId()" :size="75" />
+        </template>
       </div>
     </template>
     <template #default>

--- a/packages/frontend/src/main/lib/auth/services/authService.ts
+++ b/packages/frontend/src/main/lib/auth/services/authService.ts
@@ -2,6 +2,7 @@ import { LocalStorageKeys } from '@/helpers/mainConstants'
 import { Nullable } from '@/helpers/typeHelpers'
 import { getCurrentQueryParams } from '@/main/lib/common/web-apis/helpers/urlHelper'
 import { AppLocalStorage } from '@/utils/localStorage'
+import { Route } from 'vue-router'
 
 /**
  * Process a successful authentication (from login page, registration page or elsewhere)
@@ -34,6 +35,16 @@ export function processSuccessfulAuth(res: Response): void {
 /**
  * Get invite id from URL query string
  */
-export function getInviteIdFromURL(): Nullable<string> {
-  return getCurrentQueryParams().get('inviteId')
+export function getInviteTokenFromURL(): Nullable<string> {
+  const query = getCurrentQueryParams()
+  return query.get('token') || query.get('inviteId')
+}
+
+/**
+ * Get invite id from VueRouter route, can be used instead of getInviteTokenFromURL()
+ * when you want the result to be reactive and dependant on the route object
+ */
+export function getInviteTokenFromRoute(route: Route): Nullable<string> {
+  const query = route.query
+  return (query.token as string) || (query.inviteId as string) || null
 }

--- a/packages/frontend/src/main/lib/stream/mixins/streamInviteMixin.ts
+++ b/packages/frontend/src/main/lib/stream/mixins/streamInviteMixin.ts
@@ -6,7 +6,6 @@ import {
   UserStreamInvitesDocument
 } from '@/graphql/generated/graphql'
 import { MaybeFalsy, Nullable, vueWithMixins } from '@/helpers/typeHelpers'
-import { getInviteTokenFromRoute } from '@/main/lib/auth/services/authService'
 import { StreamEvents } from '@/main/lib/core/helpers/eventHubHelper'
 import { IsLoggedInMixin } from '@/main/lib/core/mixins/isLoggedInMixin'
 import { Get } from 'type-fest'
@@ -24,6 +23,10 @@ export const UsersStreamInviteMixin = vueWithMixins(IsLoggedInMixin).extend({
     streamInvite: {
       type: Object as PropType<StreamInviteType>,
       required: true
+    },
+    inviteToken: {
+      type: String as PropType<Nullable<string>>,
+      default: null
     }
   },
   data: () => ({
@@ -37,7 +40,7 @@ export const UsersStreamInviteMixin = vueWithMixins(IsLoggedInMixin).extend({
       return this.streamInvite.inviteId
     },
     token(): Nullable<string> {
-      return this.streamInvite.token || getInviteTokenFromRoute(this.$route) || null
+      return this.streamInvite.token || this.inviteToken || null
     },
     streamInviter(): Nullable<Get<StreamInviteQuery, 'streamInvite.invitedBy'>> {
       return this.streamInvite.invitedBy

--- a/packages/frontend/src/main/pages/auth/TheLogin.vue
+++ b/packages/frontend/src/main/pages/auth/TheLogin.vue
@@ -106,7 +106,10 @@ import gql from 'graphql-tag'
 import AuthStrategies from '@/main/components/auth/AuthStrategies.vue'
 import { randomString } from '@/helpers/randomHelpers'
 import { isEmailValid } from '@/plugins/authHelpers'
-import { processSuccessfulAuth } from '@/main/lib/auth/services/authService'
+import {
+  getInviteTokenFromRoute,
+  processSuccessfulAuth
+} from '@/main/lib/auth/services/authService'
 
 export default {
   name: 'TheLogin',
@@ -152,8 +155,7 @@ export default {
     serverApp: null,
     appId: null,
     suuid: null,
-    challenge: null,
-    inviteId: null
+    challenge: null
   }),
   computed: {
     strategies() {
@@ -162,6 +164,9 @@ export default {
     hasLocalStrategy() {
       return this.serverInfo.authStrategies.findIndex((s) => s.id === 'local') !== -1
     },
+    token() {
+      return getInviteTokenFromRoute(this.$route)
+    },
     registerRoute() {
       return {
         name: 'Register',
@@ -169,7 +174,7 @@ export default {
           appId: this.$route.query.appId,
           challenge: this.$route.query.challenge,
           suuid: this.$route.query.suuid,
-          inviteId: this.$route.query.inviteId
+          token: this.token
         }
       }
     }
@@ -180,8 +185,6 @@ export default {
     const challenge = urlParams.get('challenge')
     const suuid = urlParams.get('suuid')
     this.suuid = suuid
-    const inviteId = urlParams.get('inviteId')
-    this.inviteId = inviteId
 
     this.$mixpanel.track('Visit Log In')
 

--- a/packages/frontend/src/main/pages/auth/TheRegistration.vue
+++ b/packages/frontend/src/main/pages/auth/TheRegistration.vue
@@ -12,7 +12,7 @@
       <v-icon small>mdi-shield-alert-outline</v-icon>
       This Speckle server is invite only.
     </div>
-    <v-alert v-if="serverInfo.inviteOnly && !inviteId" type="info">
+    <v-alert v-if="serverInfo.inviteOnly && !token" type="info">
       This server is invite only. If you have received an invitation email, please
       follow the instructions in it.
     </v-alert>
@@ -171,9 +171,7 @@
       </v-card-text>
     </div>
     <v-card-title
-      :class="`justify-center caption ${
-        serverInfo.inviteOnly && !inviteId ? 'pt-0' : ''
-      }`"
+      :class="`justify-center caption ${serverInfo.inviteOnly && !token ? 'pt-0' : ''}`"
     >
       <div class="mx-4 align-self-center">Already have an account?</div>
       <div class="mx-4 align-self-center">
@@ -189,7 +187,10 @@ import { randomString } from '@/helpers/randomHelpers'
 
 import AuthStrategies from '@/main/components/auth/AuthStrategies.vue'
 import { isEmailValid } from '@/plugins/authHelpers'
-import { processSuccessfulAuth } from '@/main/lib/auth/services/authService'
+import {
+  getInviteTokenFromRoute,
+  processSuccessfulAuth
+} from '@/main/lib/auth/services/authService'
 
 export default {
   name: 'TheRegistration',
@@ -249,11 +250,13 @@ export default {
       pwdSuggestions: null,
       appId: null,
       challenge: null,
-      suuid: null,
-      inviteId: null
+      suuid: null
     }
   },
   computed: {
+    token() {
+      return getInviteTokenFromRoute(this.$route)
+    },
     loginRoute() {
       return {
         name: 'Login',
@@ -261,7 +264,7 @@ export default {
           appId: this.$route.query.appId,
           challenge: this.$route.query.challenge,
           suuid: this.$route.query.suuid,
-          inviteId: this.$route.query.inviteId
+          token: this.token
         }
       }
     },
@@ -278,8 +281,6 @@ export default {
     const challenge = urlParams.get('challenge')
     const suuid = urlParams.get('suuid')
     this.suuid = suuid
-    const inviteId = urlParams.get('inviteId')
-    this.inviteId = inviteId
 
     this.$mixpanel.track('Visit Sign Up')
 
@@ -320,7 +321,7 @@ export default {
 
         const res = await fetch(
           `/auth/local/register?challenge=${this.challenge}${
-            this.inviteId ? '&inviteId=' + this.inviteId : ''
+            this.token ? '&token=' + this.token : ''
           }`,
           {
             method: 'POST',
@@ -334,7 +335,7 @@ export default {
 
         if (res.redirected) {
           this.$mixpanel.track('Sign Up', {
-            isInvite: this.inviteId !== null,
+            isInvite: this.token !== null,
             type: 'action'
           })
           processSuccessfulAuth(res)

--- a/packages/frontend/src/main/pages/stream/TheStream.vue
+++ b/packages/frontend/src/main/pages/stream/TheStream.vue
@@ -11,6 +11,7 @@
       <stream-invite-banner
         v-if="hasInvite && !showInvitePlaceholder"
         :stream-invite="streamInvite"
+        :invite-token="inviteToken"
         @invite-used="onInviteClosed"
       />
 
@@ -27,6 +28,7 @@
         <stream-invite-placeholder
           v-else
           :stream-invite="streamInvite"
+          :invite-token="inviteToken"
           @invite-used="onInviteClosed"
         />
       </div>

--- a/packages/frontend/src/main/pages/stream/TheStream.vue
+++ b/packages/frontend/src/main/pages/stream/TheStream.vue
@@ -53,11 +53,12 @@ import type { ApolloQueryResult } from 'apollo-client'
 import type { Get } from 'type-fest'
 import StreamInvitePlaceholder from '@/main/components/stream/StreamInvitePlaceholder.vue'
 import { StreamInviteType } from '@/main/lib/stream/mixins/streamInviteMixin'
+import { getInviteTokenFromRoute } from '@/main/lib/auth/services/authService'
 
 // Cause of a limitation of vue-apollo-smart-ops, this needs to be duplicated
 type VueThis = Vue & {
   streamId: string
-  inviteId: Nullable<string>
+  inviteToken: Nullable<string>
   error: Nullable<Error>
 }
 
@@ -81,8 +82,8 @@ export default Vue.extend({
     }
   },
   computed: {
-    inviteId(): Nullable<string> {
-      return this.$route.query['inviteId'] as Nullable<string>
+    inviteToken(): Nullable<string> {
+      return getInviteTokenFromRoute(this.$route)
     },
     streamId(): string {
       return this.$route.params.streamId
@@ -119,7 +120,7 @@ export default Vue.extend({
       variables() {
         return {
           streamId: this.streamId,
-          inviteId: this.inviteId
+          token: this.inviteToken
         }
       }
     }),

--- a/packages/frontend/src/plugins/helpers.ts
+++ b/packages/frontend/src/plugins/helpers.ts
@@ -3,7 +3,7 @@ import { getMixpanelUserId, getMixpanelServerId } from '@/mixpanelManager'
 import { NotificationEventPayload } from '@/main/lib/core/helpers/eventHubHelper'
 import { AppLocalStorage } from '@/utils/localStorage'
 import { LocalStorageKeys } from '@/helpers/mainConstants'
-import { getInviteIdFromURL } from '@/main/lib/auth/services/authService'
+import { getInviteTokenFromURL } from '@/main/lib/auth/services/authService'
 
 Vue.prototype.$userId = function () {
   return AppLocalStorage.get(LocalStorageKeys.Uuid)
@@ -38,10 +38,8 @@ Vue.prototype.$loginAndSetRedirect = function () {
   AppLocalStorage.set(LocalStorageKeys.ShouldRedirectTo, relativePath)
 
   // Carry inviteId over
-  const inviteId = getInviteIdFromURL()
-  this.$router.push(
-    inviteId ? { path: '/authn/login', query: { inviteId } } : '/authn/login'
-  )
+  const token = getInviteTokenFromURL()
+  this.$router.push(token ? { path: '/authn/login', query: { token } } : '/authn/login')
 }
 
 /**

--- a/packages/server/modules/auth/strategies.js
+++ b/packages/server/modules/auth/strategies.js
@@ -40,8 +40,9 @@ module.exports = async (app) => {
       req.session.suuid = req.query.suuid
     }
 
-    if (req.query.inviteId) {
-      req.session.inviteId = req.query.inviteId
+    const token = req.query.token || req.query.inviteId
+    if (token) {
+      req.session.token = token
     }
 
     next()

--- a/packages/server/modules/auth/strategies/azure-ad.js
+++ b/packages/server/modules/auth/strategies/azure-ad.js
@@ -98,14 +98,14 @@ module.exports = async (app, session, sessionStorage, finalizeAuth) => {
         }
 
         // if the server is invite only and we have no invite id, throw.
-        if (serverInfo.inviteOnly && !req.session.inviteId) {
+        if (serverInfo.inviteOnly && !req.session.token) {
           throw new Error(
             'This server is invite only. Please authenticate yourself through a valid invite link.'
           )
         }
 
         // validate the invite
-        const validInvite = await validateServerInvite(user.email, req.session.inviteId)
+        const validInvite = await validateServerInvite(user.email, req.session.token)
 
         // create the user
         const myUser = await findOrCreateUser({ user, rawProfile: req.user._json })

--- a/packages/server/modules/auth/strategies/github.js
+++ b/packages/server/modules/auth/strategies/github.js
@@ -72,14 +72,14 @@ module.exports = async (app, session, sessionStorage, finalizeAuth) => {
         }
 
         // if the server is invite only and we have no invite id, throw.
-        if (serverInfo.inviteOnly && !req.session.inviteId) {
+        if (serverInfo.inviteOnly && !req.session.token) {
           throw new Error(
             'This server is invite only. Please authenticate yourself through a valid invite link.'
           )
         }
 
         // validate the invite
-        const validInvite = await validateServerInvite(user.email, req.session.inviteId)
+        const validInvite = await validateServerInvite(user.email, req.session.token)
 
         // create the user
         const myUser = await findOrCreateUser({ user, rawProfile: profile._raw })

--- a/packages/server/modules/auth/strategies/google.js
+++ b/packages/server/modules/auth/strategies/google.js
@@ -69,14 +69,14 @@ module.exports = async (app, session, sessionStorage, finalizeAuth) => {
         }
 
         // if the server is invite only and we have no invite id, throw.
-        if (serverInfo.inviteOnly && !req.session.inviteId) {
+        if (serverInfo.inviteOnly && !req.session.token) {
           throw new Error(
             'This server is invite only. Please authenticate yourself through a valid invite link.'
           )
         }
 
         // validate the invite
-        const validInvite = await validateServerInvite(user.email, req.session.inviteId)
+        const validInvite = await validateServerInvite(user.email, req.session.token)
 
         // create the user
         const myUser = await findOrCreateUser({ user, rawProfile: profile._raw })

--- a/packages/server/modules/auth/strategies/local.js
+++ b/packages/server/modules/auth/strategies/local.js
@@ -86,14 +86,14 @@ module.exports = async (app, session, sessionAppId, finalizeAuth) => {
         }
 
         // 1. if the server is invite only you must have an invite
-        if (serverInfo.inviteOnly && !req.session.inviteId)
+        if (serverInfo.inviteOnly && !req.session.token)
           throw new Error('This server is invite only. Please provide an invite id.')
 
         // 2. if you have an invite it must be valid, both for invite only and public servers
         /** @type {import('@/modules/serverinvites/repositories').ServerInviteRecord} */
         let invite
-        if (req.session.inviteId) {
-          invite = await validateServerInvite(user.email, req.session.inviteId)
+        if (req.session.token) {
+          invite = await validateServerInvite(user.email, req.session.token)
         }
 
         // 3. at this point we know, that we have one of these cases:

--- a/packages/server/modules/comments/migrations/20220722110643_fix_comments_delete_cascade.js
+++ b/packages/server/modules/comments/migrations/20220722110643_fix_comments_delete_cascade.js
@@ -1,0 +1,60 @@
+const { Users } = require('@/modules/core/dbSchema')
+
+const COMMENTS_TABLE = 'comments'
+const COMMENT_VIEWS_TABLE = 'comment_views'
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  // Delete all orphaned comments, which can be there even though there was a FK there before for some reason
+  await knex
+    .table(COMMENTS_TABLE)
+    .whereNotNull(`${COMMENTS_TABLE}.parentComment`)
+    .whereNotIn(
+      `${COMMENTS_TABLE}.parentComment`,
+      knex.table(`${COMMENTS_TABLE} as c2`).select('c2.id')
+    )
+    .delete()
+
+  // Fix comments FKs
+  await knex.schema.alterTable(COMMENTS_TABLE, (table) => {
+    table.dropForeign('authorId')
+    table.foreign('authorId').references(Users.col.id).onDelete('CASCADE')
+
+    table.dropForeign('parentComment')
+    table
+      .foreign('parentComment')
+      .references(`${COMMENTS_TABLE}.id`)
+      .onDelete('CASCADE')
+  })
+
+  // Fix comment_views FKs
+  await knex.schema.alterTable(COMMENT_VIEWS_TABLE, (table) => {
+    table.dropForeign('userId')
+    table.foreign('userId').references(Users.col.id).onDelete('CASCADE')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.alterTable(COMMENTS_TABLE, (table) => {
+    table.dropForeign('authorId')
+    table.foreign('authorId').references(Users.col.id).onDelete('NO ACTION')
+
+    table.dropForeign('parentComment')
+    table
+      .foreign('parentComment')
+      .references(`${COMMENTS_TABLE}.id`)
+      .onDelete('NO ACTION')
+  })
+
+  await knex.schema.alterTable(COMMENT_VIEWS_TABLE, (table) => {
+    table.dropForeign('userId')
+    table.foreign('userId').references(Users.col.id).onDelete('NO ACTION')
+  })
+}

--- a/packages/server/modules/core/dbSchema.js
+++ b/packages/server/modules/core/dbSchema.js
@@ -99,7 +99,8 @@ module.exports = {
       message: 'server_invites.message',
       resourceTarget: 'server_invites.resourceTarget',
       resourceId: 'server_invites.resourceId',
-      role: 'server_invites.role'
+      role: 'server_invites.role',
+      token: 'server_invites.token'
     }
   },
   knex

--- a/packages/server/modules/core/graph/resolvers/streams.js
+++ b/packages/server/modules/core/graph/resolvers/streams.js
@@ -413,6 +413,24 @@ module.exports = {
       const { streamId } = parent
       const stream = await ctx.loaders.streams.getStream.load(streamId)
       return stream.name
+    },
+    /**
+     * @param {import('@/modules/serverinvites/services/inviteRetrievalService').PendingStreamCollaboratorGraphQLType} parent
+     * @param {Object} _args
+     * @param {import('@/modules/shared/index').GraphQLContext} ctx
+     */
+    async token(parent, _args, ctx) {
+      const authedUserId = ctx.userId
+      const targetUserId = parent.user?.id
+      const inviteId = parent.inviteId
+
+      // Only returning it for the user that is the pending stream collaborator
+      if (!authedUserId || !targetUserId || authedUserId !== targetUserId) {
+        return null
+      }
+
+      const invite = await ctx.loaders.invites.getInvite.load(inviteId)
+      return invite?.token || null
     }
   }
 }

--- a/packages/server/modules/core/graph/schemas/streams.graphql
+++ b/packages/server/modules/core/graph/schemas/streams.graphql
@@ -88,6 +88,10 @@ type PendingStreamCollaborator {
   Set only if user is registered
   """
   user: LimitedUser
+  """
+  Only available if the active user is the pending stream collaborator
+  """
+  token: String
 }
 
 type StreamCollection {

--- a/packages/server/modules/core/loaders.js
+++ b/packages/server/modules/core/loaders.js
@@ -7,6 +7,7 @@ const {
 } = require('@/modules/core/repositories/streams')
 const { getUsers } = require('@/modules/core/repositories/users')
 const { keyBy } = require('lodash')
+const { getInvites } = require('@/modules/serverinvites/repositories')
 
 /**
  * All DataLoaders available on the GQL ctx object
@@ -20,6 +21,9 @@ const { keyBy } = require('lodash')
  * @property {{
  *  getUser: DataLoader<string, import('@/modules/core/helpers/userHelper').UserRecord>
  * }} users
+ * @property {{
+ *  getInvite: DataLoader<string, import('@/modules/serverinvites/repositories').ServerInviteRecord>
+ * }} invites
  */
 
 module.exports = {
@@ -79,6 +83,15 @@ module.exports = {
         getUser: new DataLoader(async (userIds) => {
           const results = keyBy(await getUsers(userIds), 'id')
           return userIds.map((i) => results[i])
+        })
+      },
+      invites: {
+        /**
+         * Get invite from DB
+         */
+        getInvite: new DataLoader(async (inviteIds) => {
+          const results = keyBy(await getInvites(inviteIds), 'id')
+          return inviteIds.map((i) => results[i])
         })
       }
     }

--- a/packages/server/modules/core/tests/usersAdminList.spec.js
+++ b/packages/server/modules/core/tests/usersAdminList.spec.js
@@ -144,7 +144,7 @@ describe('[Admin users list]', () => {
 
     // Create a few more stream invites to registered users, which should not appear in
     // the users list
-    const inviteIds = await Promise.all(
+    const createdInvitesData = await Promise.all(
       times(3, () => {
         const { id: streamId, ownerId } = randomEl(streamData)
         const userId = randomEl(userIds.filter((i) => i !== ownerId))
@@ -158,7 +158,8 @@ describe('[Admin users list]', () => {
         )
       })
     )
-    if (!inviteIds.every((id) => !!id))
+
+    if (!createdInvitesData.every(({ inviteId, token }) => inviteId && token))
       throw new Error('Stream invite generation failed')
 
     // Resolve ordered ids

--- a/packages/server/modules/serverinvites/graph/schemas/serverInvites.graphql
+++ b/packages/server/modules/serverinvites/graph/schemas/serverInvites.graphql
@@ -24,7 +24,7 @@ extend type Mutation {
   """
   Accept or decline a stream invite
   """
-  streamInviteUse(accept: Boolean!, streamId: String!, inviteId: String!): Boolean!
+  streamInviteUse(accept: Boolean!, streamId: String!, token: String!): Boolean!
     @hasRole(role: "server:user")
 
   """
@@ -51,10 +51,10 @@ extend type Mutation {
 
 extend type Query {
   """
-  Look for an invitation to a stream, for the current user (authed or not). If inviteId
+  Look for an invitation to a stream, for the current user (authed or not). If token
   isn't specified, the server will look for any valid invite.
   """
-  streamInvite(streamId: String!, inviteId: String): PendingStreamCollaborator
+  streamInvite(streamId: String!, token: String): PendingStreamCollaborator
 
   """
   Get all invitations to streams that the active user has
@@ -80,4 +80,8 @@ input StreamInviteCreateInput {
   userId: String
   streamId: String!
   message: String
+  """
+  Defaults to the contributor role, if not specified
+  """
+  role: String
 }

--- a/packages/server/modules/serverinvites/migrations/20220722092821_add_invite_token_field.js
+++ b/packages/server/modules/serverinvites/migrations/20220722092821_add_invite_token_field.js
@@ -1,0 +1,31 @@
+const { ServerInvites } = require('@/modules/core/dbSchema')
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.alterTable(ServerInvites.name, (table) => {
+    // Add token field
+    table.string('token', 256).defaultTo('').notNullable()
+    table.index('token')
+  })
+
+  // Update all pre-existing rows and move inviteId to token
+  await knex.raw(`
+    UPDATE ${ServerInvites.name}
+    SET token = COALESCE(id, '')
+    WHERE coalesce(TRIM(token), '') = ''
+  `)
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.alterTable(ServerInvites.name, (table) => {
+    // Drop token field
+    table.dropColumn('token')
+  })
+}

--- a/packages/server/modules/serverinvites/repositories/index.js
+++ b/packages/server/modules/serverinvites/repositories/index.js
@@ -266,6 +266,16 @@ async function getInvite(inviteId) {
 }
 
 /**
+ * Retrieve a specific invite (irregardless of the type) by the token
+ * @param {string} inviteId
+ * @returns {Promise<ServerInviteRecord | null>}
+ */
+async function getInviteByToken(inviteToken) {
+  if (!inviteToken) return null
+  return await ServerInvites.knex().where(ServerInvites.col.token, inviteToken).first()
+}
+
+/**
  * Delete a specific invite (irregardless of the type)
  * @param {string} inviteId
  * @returns {Promise<boolean>}
@@ -342,5 +352,6 @@ module.exports = {
   deleteAllUserInvites,
   getResource,
   getAllUserStreamInvites,
-  getInvites
+  getInvites,
+  getInviteByToken
 }

--- a/packages/server/modules/serverinvites/services/inviteCreationService.js
+++ b/packages/server/modules/serverinvites/services/inviteCreationService.js
@@ -385,7 +385,10 @@ async function createAndSendInvite(params) {
       : [])
   ])
 
-  return invite.id
+  return {
+    inviteId: invite.id,
+    token: invite.token
+  }
 }
 
 /**

--- a/packages/server/modules/serverinvites/services/inviteProcessingService.js
+++ b/packages/server/modules/serverinvites/services/inviteProcessingService.js
@@ -49,20 +49,20 @@ function resolveAuthRedirectPath(invite) {
 /**
  * Validate that the new user has a valid invite for registering to the server
  * @param {Object} email User's email address
- * @param {string} inviteId Invite ID
+ * @param {string} token Invite token
  * @returns {import('@/modules/serverinvites/repositories').ServerInviteRecord}
  */
-async function validateServerInvite(email, inviteId) {
-  const invite = await getServerInvite(email, inviteId)
+async function validateServerInvite(email, token) {
+  const invite = await getServerInvite(email, token)
   if (!invite) {
     throw new NoInviteFoundError(
-      inviteId
-        ? "Wrong e-mail address or invite ID. Make sure you're using the same e-mail address that received the invite."
+      token
+        ? "Wrong e-mail address or invite token. Make sure you're using the same e-mail address that received the invite."
         : "Wrong e-mail address. Make sure you're using the same e-mail address that received the invite.",
       {
         info: {
           email,
-          inviteId
+          token
         }
       }
     )
@@ -90,16 +90,19 @@ async function finalizeInvitedServerRegistration(email, userId) {
  * Accept or decline a stream invite
  * @param {boolean} accept
  * @param {string} streamId
- * @param {string} inviteId
+ * @param {string} token
  * @param {string} userId User who's accepting the invite
  */
-async function finalizeStreamInvite(accept, streamId, inviteId, userId) {
-  const invite = await getStreamInvite(streamId, buildUserTarget(userId), inviteId)
+async function finalizeStreamInvite(accept, streamId, token, userId) {
+  const invite = await getStreamInvite(streamId, {
+    token,
+    target: buildUserTarget(userId)
+  })
   if (!invite) {
     throw new NoInviteFoundError('Attempted to finalize nonexistant stream invite', {
       info: {
         streamId,
-        inviteId,
+        token,
         userId
       }
     })
@@ -141,7 +144,7 @@ async function finalizeStreamInvite(accept, streamId, inviteId, userId) {
  * @param {string} inviteId
  */
 async function cancelStreamInvite(streamId, inviteId) {
-  const invite = await getStreamInvite(streamId, null, inviteId)
+  const invite = await getStreamInvite(streamId, { inviteId })
   if (!invite) {
     throw new NoInviteFoundError('Attempted to process nonexistant stream invite', {
       info: {

--- a/packages/server/modules/serverinvites/services/inviteRetrievalService.js
+++ b/packages/server/modules/serverinvites/services/inviteRetrievalService.js
@@ -14,6 +14,9 @@ const {
 const { keyBy, uniq } = require('lodash')
 
 /**
+ * The token field is intentionally ommited from this and only managed through the .token resolver
+ * for extra security - so that no one accidentally returns it out from this service
+ *
  * @typedef {{
  *  id: string,
  *  inviteId: string,
@@ -21,7 +24,7 @@ const { keyBy, uniq } = require('lodash')
  *  title: string,
  *  role: string,
  *  invitedById: string,
- *  user: import('@/modules/core/helpers/userHelper').LimitedUserRecord | null
+ *  user: import('@/modules/core/helpers/userHelper').LimitedUserRecord | null,
  * }} PendingStreamCollaboratorGraphQLType
  */
 
@@ -100,17 +103,16 @@ async function getPendingStreamCollaborators(streamId) {
  * Either the user ID or invite ID must be set
  * @param {string} streamId
  * @param {string|null} userId
- * @param {string|null} inviteId
+ * @param {string|null} token
  * @returns {Promise<PendingStreamCollaboratorGraphQLType>}
  */
-async function getUserPendingStreamInvite(streamId, userId, inviteId) {
-  if (!userId && !inviteId) return null
+async function getUserPendingStreamInvite(streamId, userId, token) {
+  if (!userId && !token) return null
 
-  const invite = await getStreamInvite(
-    streamId,
-    userId ? buildUserTarget(userId) : null,
-    inviteId
-  )
+  const invite = await getStreamInvite(streamId, {
+    target: buildUserTarget(userId),
+    token
+  })
   if (!invite) return null
 
   const targetUser = userId ? await getUser(userId) : null

--- a/packages/server/modules/serverinvites/tests/invites.spec.js
+++ b/packages/server/modules/serverinvites/tests/invites.spec.js
@@ -57,6 +57,14 @@ async function validateInviteExistanceFromEmail(emailParams) {
   expect(invite).to.be.ok
 }
 
+// TODO: 1. Invite (batch also) - role + invalid role
+/**
+ * More:
+ * - Get token, only if u own it
+ * - Invite with both token and invite ID
+ * (check links with both)
+ */
+
 describe('[Stream & Server Invites]', () => {
   const me = {
     name: 'Authenticated server invites guy',

--- a/packages/server/test/graphql/serverInvites.js
+++ b/packages/server/test/graphql/serverInvites.js
@@ -12,7 +12,8 @@ const { gql } = require('apollo-server-express')
  *  email: string | null,
  *  userId: string | null,
  *  streamId: string,
- *  message: string
+ *  message: string,
+ *  role: string | null
  * }} StreamInviteCreateInput
  */
 
@@ -79,8 +80,8 @@ const streamInviteFragment = gql`
 `
 
 const streamInviteQuery = gql`
-  query ($streamId: String!, $inviteId: String) {
-    streamInvite(streamId: $streamId, inviteId: $inviteId) {
+  query ($streamId: String!, $token: String) {
+    streamInvite(streamId: $streamId, token: $token) {
       ...StreamInviteData
     }
   }
@@ -99,8 +100,8 @@ const streamInvitesQuery = gql`
 `
 
 const useStreamInviteMutation = gql`
-  mutation ($accept: Boolean!, $streamId: String!, $inviteId: String!) {
-    streamInviteUse(accept: $accept, streamId: $streamId, inviteId: $inviteId)
+  mutation ($accept: Boolean!, $streamId: String!, $token: String!) {
+    streamInviteUse(accept: $accept, streamId: $streamId, token: $token)
   }
 `
 
@@ -209,10 +210,10 @@ module.exports = {
    * streamInvite query
    * @param {import('apollo-server-express').ApolloServer} apollo
    */
-  getStreamInvite(apollo, { streamId, inviteId }) {
+  getStreamInvite(apollo, { streamId, token }) {
     return apollo.executeOperation({
       query: streamInviteQuery,
-      variables: { streamId, inviteId }
+      variables: { streamId, token }
     })
   },
   /**
@@ -228,10 +229,10 @@ module.exports = {
    * streamInviteUse mutation
    * @param {import('apollo-server-express').ApolloServer} apollo
    */
-  useUpStreamInvite(apollo, { accept, streamId, inviteId }) {
+  useUpStreamInvite(apollo, { accept, streamId, token }) {
     return apollo.executeOperation({
       query: useStreamInviteMutation,
-      variables: { accept, streamId, inviteId }
+      variables: { accept, streamId, token }
     })
   },
   /**

--- a/packages/server/test/graphql/serverInvites.js
+++ b/packages/server/test/graphql/serverInvites.js
@@ -60,6 +60,7 @@ const streamInviteFragment = gql`
     streamId
     title
     role
+    token
     invitedBy {
       id
       name
@@ -118,6 +119,7 @@ const streamPendingCollaboratorsQuery = gql`
       pendingCollaborators {
         inviteId
         title
+        token
         user {
           id
           name

--- a/packages/server/test/speckle-helpers/inviteHelper.js
+++ b/packages/server/test/speckle-helpers/inviteHelper.js
@@ -19,6 +19,8 @@ const {
  *  streamId?: string
  * }} invite
  * @param {string} creatorId
+ *
+ * @returns {Promise<{inviteId: string, token: string}>}
  */
 function createInviteDirectly(invite, creatorId) {
   const userId = invite.userId || invite.user?.id || null


### PR DESCRIPTION
1. Adding back the `role` parameter to `streamInviteCreate` so that users can be invited with a specific role
2. Since the invite ID is now also publicly visible to stream owners & server admins for managing them (resending/canceling), it can no longer be used as the actual key that is used during validating invites. Thus, I've introduced a new serverInvites column - token, and this one is only visible to the user who has the invite. From now on `token` must be used instead of `inviteId` inside the invite links. All previous invites should be migrated to the new format and old invite links should also still work.
3. Some minor invites bugfixes (Removed invite specific activity stream items from the Stream feed; Fixed broken avatar in invite block, when user isnt logged in)
4. Added "on cascade delete" for a couple of FKs in comments related tables, because it prevented users from being deletable. I tried deleting a user who had made a comment before, and the server threw an error because of the FK
