### PR TITLE
chore(.gitignore): ignore VSCode log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ events.json
 !.yarn/versions
 
 *yarn-error.log
+
+# VSCode log files
+packages/server/.vscode/*.log


### PR DESCRIPTION
In the event of an error in VSCode, the IDE produces log files in the .vscode directory.  These log files should
never be checked in to the project as they are specific to the error on the developer's local machine.