### PR TITLE
docs(vscode workspace): adds Helm as a top-level to VSCode workspace

### DIFF
--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -33,6 +33,10 @@
       "name": "🌐 objectloader"
     },
     {
+      "path": "utils/helm",
+      "name": "⛵ helm"
+    },
+    {
       "path": ".",
       "name": "🏡 root"
     }


### PR DESCRIPTION
Making helm one-click away in the VSCode workspace.

<img width="234" alt="Screenshot 2022-08-03 at 15 24 20" src="https://user-images.githubusercontent.com/68657/182632813-4f44ac58-10dd-42cd-b113-efef114d36e2.png">
