### PR TITLE
Configurable `imagePullPolicy`

### DIFF
--- a/utils/helm/speckle-server/templates/deployment-backend.yml
+++ b/utils/helm/speckle-server/templates/deployment-backend.yml
@@ -28,11 +28,6 @@ spec:
             containerPort: 3000
             protocol: TCP
 
-        ports:
-          - name: http
-            containerPort: 3000
-            protocol: TCP
-
         resources:
           requests:
             cpu: {{ .Values.server.requests.cpu }}

--- a/utils/helm/speckle-server/templates/deployment-backend.yml
+++ b/utils/helm/speckle-server/templates/deployment-backend.yml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: main
         image: speckle/speckle-server:{{ .Values.docker_image_tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
 
         ports:
           - name: http
@@ -242,7 +243,6 @@ spec:
                 name: {{ .Values.secretName }}
                 key: apollo_key
           {{- end }}
-      imagePullPolicy: {{ .Values.imagePullPolicy }}
       priorityClassName: high-priority
       terminationGracePeriodSeconds: 310
       {{- if .Values.db.useCertificate }}

--- a/utils/helm/speckle-server/templates/deployment-backend.yml
+++ b/utils/helm/speckle-server/templates/deployment-backend.yml
@@ -18,17 +18,6 @@ spec:
         app: speckle-server
         project: speckle-server
     spec:
-      priorityClassName: high-priority
-
-      {{- if .Values.db.useCertificate }}
-      volumes:
-        - name: postgres-certificate
-          configMap:
-            name: postgres-certificate
-      {{- end }}
-
-      terminationGracePeriodSeconds: 310
-
       containers:
       - name: main
         image: speckle/speckle-server:{{ .Values.docker_image_tag }}
@@ -253,3 +242,12 @@ spec:
                 name: {{ .Values.secretName }}
                 key: apollo_key
           {{- end }}
+      imagePullPolicy: {{ .Values.imagePullPolicy }}
+      priorityClassName: high-priority
+      terminationGracePeriodSeconds: 310
+      {{- if .Values.db.useCertificate }}
+      volumes:
+        - name: postgres-certificate
+          configMap:
+            name: postgres-certificate
+      {{- end }}

--- a/utils/helm/speckle-server/templates/deployment-backend.yml
+++ b/utils/helm/speckle-server/templates/deployment-backend.yml
@@ -33,6 +33,11 @@ spec:
       - name: main
         image: speckle/speckle-server:{{ .Values.docker_image_tag }}
 
+        ports:
+          - name: http
+            containerPort: 3000
+            protocol: TCP
+
         resources:
           requests:
             cpu: {{ .Values.server.requests.cpu }}

--- a/utils/helm/speckle-server/templates/deployment-fileimport-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-fileimport-service.yml
@@ -30,11 +30,6 @@ spec:
             containerPort: 9093
             protocol: TCP
 
-        ports:
-          - name: metrics
-            containerPort: 9093
-            protocol: TCP
-
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 60

--- a/utils/helm/speckle-server/templates/deployment-fileimport-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-fileimport-service.yml
@@ -20,18 +20,6 @@ spec:
         app: speckle-fileimport-service
         project: speckle-server
     spec:
-      priorityClassName: low-priority
-
-      {{- if .Values.db.useCertificate }}
-      volumes:
-        - name: postgres-certificate
-          configMap:
-            name: postgres-certificate
-      {{- end }}
-
-      # Should be > File import timeout to allow finishing up imports
-      terminationGracePeriodSeconds: 610
-
       containers:
       - name: main
         image: speckle/speckle-fileimport-service:{{ .Values.docker_image_tag }}
@@ -98,4 +86,16 @@ spec:
           - name: FILE_IMPORT_TIME_LIMIT_MIN
             value: {{ .Values.fileimport_service.time_limit_min | quote }}
 
+      imagePullPolicy: {{ .Values.imagePullPolicy }}
+      priorityClassName: low-priority
+
+      {{- if .Values.db.useCertificate }}
+      volumes:
+        - name: postgres-certificate
+          configMap:
+            name: postgres-certificate
+      {{- end }}
+
+      # Should be > File import timeout to allow finishing up imports
+      terminationGracePeriodSeconds: 610
 {{- end }}

--- a/utils/helm/speckle-server/templates/deployment-fileimport-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-fileimport-service.yml
@@ -36,6 +36,11 @@ spec:
       - name: main
         image: speckle/speckle-fileimport-service:{{ .Values.docker_image_tag }}
 
+        ports:
+          - name: metrics
+            containerPort: 9093
+            protocol: TCP
+
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 60

--- a/utils/helm/speckle-server/templates/deployment-fileimport-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-fileimport-service.yml
@@ -23,6 +23,7 @@ spec:
       containers:
       - name: main
         image: speckle/speckle-fileimport-service:{{ .Values.docker_image_tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
 
         ports:
           - name: metrics
@@ -86,7 +87,6 @@ spec:
           - name: FILE_IMPORT_TIME_LIMIT_MIN
             value: {{ .Values.fileimport_service.time_limit_min | quote }}
 
-      imagePullPolicy: {{ .Values.imagePullPolicy }}
       priorityClassName: low-priority
 
       {{- if .Values.db.useCertificate }}

--- a/utils/helm/speckle-server/templates/deployment-frontend.yml
+++ b/utils/helm/speckle-server/templates/deployment-frontend.yml
@@ -23,6 +23,12 @@ spec:
       containers:
       - name: main
         image: speckle/speckle-frontend:{{ .Values.docker_image_tag }}
+
+        ports:
+          - name: www
+            containerPort: 80
+            protocol: TCP
+
         resources:
           requests:
             cpu: {{ .Values.frontend.requests.cpu }}

--- a/utils/helm/speckle-server/templates/deployment-frontend.yml
+++ b/utils/helm/speckle-server/templates/deployment-frontend.yml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: main
         image: speckle/speckle-frontend:{{ .Values.docker_image_tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
 
         ports:
           - name: www
@@ -52,5 +53,4 @@ spec:
           - name: FILE_SIZE_LIMIT_MB
             value: {{ .Values.file_size_limit_mb | quote }}
 
-      imagePullPolicy: {{ .Values.imagePullPolicy }}
       priorityClassName: high-priority

--- a/utils/helm/speckle-server/templates/deployment-frontend.yml
+++ b/utils/helm/speckle-server/templates/deployment-frontend.yml
@@ -18,8 +18,6 @@ spec:
         app: speckle-frontend
         project: speckle-server
     spec:
-      priorityClassName: high-priority
-
       containers:
       - name: main
         image: speckle/speckle-frontend:{{ .Values.docker_image_tag }}
@@ -53,3 +51,6 @@ spec:
         env: 
           - name: FILE_SIZE_LIMIT_MB
             value: {{ .Values.file_size_limit_mb | quote }}
+
+      imagePullPolicy: {{ .Values.imagePullPolicy }}
+      priorityClassName: high-priority

--- a/utils/helm/speckle-server/templates/deployment-monitor-deployment.yml
+++ b/utils/helm/speckle-server/templates/deployment-monitor-deployment.yml
@@ -28,11 +28,6 @@ spec:
             containerPort: 9092
             protocol: TCP
 
-        ports:
-          - name: metrics
-            containerPort: 9092
-            protocol: TCP
-
         resources:
           requests:
             cpu: 100m

--- a/utils/helm/speckle-server/templates/deployment-monitor-deployment.yml
+++ b/utils/helm/speckle-server/templates/deployment-monitor-deployment.yml
@@ -18,17 +18,6 @@ spec:
         app: speckle-monitoring
         project: speckle-server
     spec:
-      priorityClassName: low-priority
-
-      {{- if .Values.db.useCertificate }}
-      volumes:
-        - name: postgres-certificate
-          configMap:
-            name: postgres-certificate
-      {{- end }}
-
-      terminationGracePeriodSeconds: 10
-
       containers:
       - name: main
         image: speckle/speckle-monitor-deployment:{{ .Values.docker_image_tag }}
@@ -64,3 +53,14 @@ spec:
             value: "/postgres-certificate/ca-certificate.crt"
           {{- end }}
 
+      imagePullPolicy: {{ .Values.imagePullPolicy }}
+      priorityClassName: low-priority
+
+      {{- if .Values.db.useCertificate }}
+      volumes:
+        - name: postgres-certificate
+          configMap:
+            name: postgres-certificate
+      {{- end }}
+
+      terminationGracePeriodSeconds: 10

--- a/utils/helm/speckle-server/templates/deployment-monitor-deployment.yml
+++ b/utils/helm/speckle-server/templates/deployment-monitor-deployment.yml
@@ -33,6 +33,11 @@ spec:
       - name: main
         image: speckle/speckle-monitor-deployment:{{ .Values.docker_image_tag }}
 
+        ports:
+          - name: metrics
+            containerPort: 9092
+            protocol: TCP
+
         resources:
           requests:
             cpu: 100m

--- a/utils/helm/speckle-server/templates/deployment-monitor-deployment.yml
+++ b/utils/helm/speckle-server/templates/deployment-monitor-deployment.yml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: main
         image: speckle/speckle-monitor-deployment:{{ .Values.docker_image_tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
 
         ports:
           - name: metrics
@@ -53,7 +54,6 @@ spec:
             value: "/postgres-certificate/ca-certificate.crt"
           {{- end }}
 
-      imagePullPolicy: {{ .Values.imagePullPolicy }}
       priorityClassName: low-priority
 
       {{- if .Values.db.useCertificate }}

--- a/utils/helm/speckle-server/templates/deployment-preview-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-preview-service.yml
@@ -34,6 +34,11 @@ spec:
       - name: main
         image: speckle/speckle-preview-service:{{ .Values.docker_image_tag }}
 
+        ports:
+          - name: metrics
+            containerPort: 9094
+            protocol: TCP
+
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 60

--- a/utils/helm/speckle-server/templates/deployment-preview-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-preview-service.yml
@@ -18,18 +18,6 @@ spec:
         app: speckle-preview-service
         project: speckle-server
     spec:
-      priorityClassName: low-priority
-
-      {{- if .Values.db.useCertificate }}
-      volumes:
-        - name: postgres-certificate
-          configMap:
-            name: postgres-certificate
-      {{- end }}
-
-      # Should be > preview generation time ( 1 hour for good measure )
-      terminationGracePeriodSeconds: 3600
-
       containers:
       - name: main
         image: speckle/speckle-preview-service:{{ .Values.docker_image_tag }}
@@ -77,3 +65,15 @@ spec:
             value: "/postgres-certificate/ca-certificate.crt"
           {{- end }}
 
+      imagePullPolicy: {{ .Values.imagePullPolicy }}
+      priorityClassName: low-priority
+
+      # Should be > preview generation time ( 1 hour for good measure )
+      terminationGracePeriodSeconds: 3600
+
+      {{- if .Values.db.useCertificate }}
+      volumes:
+        - name: postgres-certificate
+          configMap:
+            name: postgres-certificate
+      {{- end }}

--- a/utils/helm/speckle-server/templates/deployment-preview-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-preview-service.yml
@@ -28,11 +28,6 @@ spec:
             containerPort: 9094
             protocol: TCP
 
-        ports:
-          - name: metrics
-            containerPort: 9094
-            protocol: TCP
-
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 60

--- a/utils/helm/speckle-server/templates/deployment-preview-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-preview-service.yml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: main
         image: speckle/speckle-preview-service:{{ .Values.docker_image_tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
 
         ports:
           - name: metrics
@@ -65,7 +66,6 @@ spec:
             value: "/postgres-certificate/ca-certificate.crt"
           {{- end }}
 
-      imagePullPolicy: {{ .Values.imagePullPolicy }}
       priorityClassName: low-priority
 
       # Should be > preview generation time ( 1 hour for good measure )

--- a/utils/helm/speckle-server/templates/deployment-webhook-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-webhook-service.yml
@@ -28,11 +28,6 @@ spec:
             containerPort: 9095
             protocol: TCP
 
-        ports:
-          - name: metrics
-            containerPort: 9095
-            protocol: TCP
-
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 60

--- a/utils/helm/speckle-server/templates/deployment-webhook-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-webhook-service.yml
@@ -18,18 +18,6 @@ spec:
         app: speckle-webhook-service
         project: speckle-server
     spec:
-      priorityClassName: low-priority
-
-      {{- if .Values.db.useCertificate }}
-      volumes:
-        - name: postgres-certificate
-          configMap:
-            name: postgres-certificate
-      {{- end }}
-
-      # Should be > webhook max call time ( ~= 10 seconds )
-      terminationGracePeriodSeconds: 30
-
       containers:
       - name: main
         image: speckle/speckle-webhook-service:{{ .Values.docker_image_tag }}
@@ -77,3 +65,15 @@ spec:
             value: "/postgres-certificate/ca-certificate.crt"
           {{- end }}
 
+      imagePullPolicy: {{ .Values.imagePullPolicy }}
+      priorityClassName: low-priority
+
+      # Should be > webhook max call time ( ~= 10 seconds )
+      terminationGracePeriodSeconds: 30
+
+      {{- if .Values.db.useCertificate }}
+      volumes:
+        - name: postgres-certificate
+          configMap:
+            name: postgres-certificate
+      {{- end }}

--- a/utils/helm/speckle-server/templates/deployment-webhook-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-webhook-service.yml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: main
         image: speckle/speckle-webhook-service:{{ .Values.docker_image_tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
 
         ports:
           - name: metrics
@@ -65,7 +66,6 @@ spec:
             value: "/postgres-certificate/ca-certificate.crt"
           {{- end }}
 
-      imagePullPolicy: {{ .Values.imagePullPolicy }}
       priorityClassName: low-priority
 
       # Should be > webhook max call time ( ~= 10 seconds )

--- a/utils/helm/speckle-server/templates/deployment-webhook-service.yml
+++ b/utils/helm/speckle-server/templates/deployment-webhook-service.yml
@@ -34,6 +34,11 @@ spec:
       - name: main
         image: speckle/speckle-webhook-service:{{ .Values.docker_image_tag }}
 
+        ports:
+          - name: metrics
+            containerPort: 9095
+            protocol: TCP
+
         livenessProbe:
           initialDelaySeconds: 60
           periodSeconds: 60

--- a/utils/helm/speckle-server/templates/services.yml
+++ b/utils/helm/speckle-server/templates/services.yml
@@ -14,7 +14,7 @@ spec:
     - protocol: TCP
       name: web
       port: 3000
-      targetPort: 3000
+      targetPort: http
 ---
 apiVersion: v1
 kind: Service
@@ -32,7 +32,7 @@ spec:
     - protocol: TCP
       name: www
       port: 80
-      targetPort: 80
+      targetPort: www
 ---
 apiVersion: v1
 kind: Service
@@ -50,7 +50,7 @@ spec:
     - protocol: TCP
       name: web
       port: 9094
-      targetPort: 9094
+      targetPort: metrics
 ---
 apiVersion: v1
 kind: Service
@@ -68,7 +68,7 @@ spec:
     - protocol: TCP
       name: web
       port: 9093
-      targetPort: 9093
+      targetPort: metrics
 ---
 apiVersion: v1
 kind: Service
@@ -86,7 +86,7 @@ spec:
     - protocol: TCP
       name: web
       port: 9095
-      targetPort: 9095
+      targetPort: metrics
 ---
 apiVersion: v1
 kind: Service
@@ -104,4 +104,4 @@ spec:
     - protocol: TCP
       name: web
       port: 9092
-      targetPort: 9092
+      targetPort: metrics

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -113,3 +113,4 @@ helm_test_enabled: true
 
 create_namespace: false
 file_size_limit_mb: 100
+imagePullPolicy: IfNotPresent


### PR DESCRIPTION
`imagePullPolicy` can be configured.
Pod template keys are now in alphabetical order.

**Note**: based on top of https://github.com/specklesystems/speckle-server/pull/873
 
Fixes https://github.com/specklesystems/speckle-server/issues/869