### PR TITLE
fix(frontend container): add default value for FILE_SIZE_LIMIT_MB

### DIFF
--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -29,6 +29,7 @@ RUN yarn workspaces foreach -pt run build
 
 
 FROM openresty/openresty:1.21.4.1-bullseye as production-stage
+ENV FILE_SIZE_LIMIT_MB=100
 COPY --from=build-stage /speckle-server/packages/frontend/dist /usr/share/nginx/html
 RUN rm /etc/nginx/conf.d/default.conf
 

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -23,5 +23,6 @@ RUN yarn workspaces focus --production
 
 COPY packages/server .
 
+ENV FILE_SIZE_LIMIT_MB=100
 ENV SPECKLE_SERVER_VERSION=${SPECKLE_SERVER_VERSION}
 CMD ["yarn", "node", "bin/www"]


### PR DESCRIPTION
this prevents breaking the existing deployments which do not provide this env variable
