### PR TITLE
feat(helm chart): use standard helm labels on all pods and services

### DIFF
--- a/utils/helm/speckle-server/templates/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "speckle.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "speckle.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "speckle.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "speckle.labels" -}}
+helm.sh/chart: {{ include "speckle.chart" . }}
+{{ include "speckle.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "speckle.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "speckle.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/utils/helm/speckle-server/templates/configmap-db-certificate.yml
+++ b/utils/helm/speckle-server/templates/configmap-db-certificate.yml
@@ -5,6 +5,8 @@ kind: ConfigMap
 metadata:
   name: postgres-certificate
   namespace: {{ .Values.namespace }}
+  labels:
+{{ include "speckle.labels" . | indent 4 }}
 data:
   ca-certificate.crt: |
 {{ .Values.db.certificate | indent 4 }}

--- a/utils/helm/speckle-server/templates/fileimport_service/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/fileimport_service/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fileimport_service.name" -}}
+{{- default "speckle-fileimport-service" .Values.fileimport_service.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fileimport_service.fullname" -}}
+{{- if .Values.fileimport_service.fullnameOverride }}
+{{- .Values.fileimport_service.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "speckle-fileimport-service" .Values.fileimport_service.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fileimport_service.labels" -}}
+helm.sh/chart: {{ include "speckle.chart" . }}
+{{ include "fileimport_service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ include "fileimport_service.name" . }}
+app.kubernetes.io/part-of: {{ include "speckle.name" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fileimport_service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fileimport_service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fileimport_service.serviceAccountName" -}}
+{{- if .Values.fileimport_service.serviceAccount.create }}
+{{- default (include "fileimport_service.fullname" .) .Values.fileimport_service.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.fileimport_service.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: speckle-fileimport-service
     project: speckle-server
+{{ include "fileimport_service.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.fileimport_service.replicas }}
   selector:
@@ -18,6 +19,7 @@ spec:
       labels:
         app: speckle-fileimport-service
         project: speckle-server
+{{ include "fileimport_service.labels" . | indent 8 }}
     spec:
       containers:
       - name: main

--- a/utils/helm/speckle-server/templates/fileimport_service/service.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/service.yml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: speckle-fileimport-service-metrics
     project: speckle-server
+{{ include "fileimport_service.labels" . | indent 4 }}
 spec:
   selector:
     app: speckle-fileimport-service

--- a/utils/helm/speckle-server/templates/frontend/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/frontend/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "frontend.name" -}}
+{{- default "speckle-frontend" .Values.frontend.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "frontend.fullname" -}}
+{{- if .Values.frontend.fullnameOverride }}
+{{- .Values.frontend.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "speckle-frontend" .Values.frontend.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "frontend.labels" -}}
+helm.sh/chart: {{ include "speckle.chart" . }}
+{{ include "frontend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ include "frontend.name" . }}
+app.kubernetes.io/part-of: {{ include "speckle.name" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "frontend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "frontend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "frontend.serviceAccountName" -}}
+{{- if .Values.frontend.serviceAccount.create }}
+{{- default (include "frontend.fullname" .) .Values.frontend.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.frontend.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/utils/helm/speckle-server/templates/frontend/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend/deployment.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: speckle-frontend
     project: speckle-server
+{{ include "frontend.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.frontend.replicas }}
   selector:
@@ -17,6 +18,7 @@ spec:
       labels:
         app: speckle-frontend
         project: speckle-server
+{{ include "frontend.labels" . | indent 8 }}
     spec:
       containers:
       - name: main

--- a/utils/helm/speckle-server/templates/frontend/service.yml
+++ b/utils/helm/speckle-server/templates/frontend/service.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: speckle-frontend
     project: speckle-server
+{{ include "fileimport_service.labels" . | indent 4 }}
 spec:
   selector:
     app: speckle-frontend

--- a/utils/helm/speckle-server/templates/ingress.yml
+++ b/utils/helm/speckle-server/templates/ingress.yml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: speckle-server
   namespace: {{ .Values.namespace }}
+  labels:
+{{ include "speckle.labels" . | indent 4 }}
   annotations:
     {{- if .Values.cert_manager_issuer }}
     cert-manager.io/cluster-issuer: {{ .Values.cert_manager_issuer }}

--- a/utils/helm/speckle-server/templates/monitoring/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/monitoring/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "monitoring.name" -}}
+{{- default "speckle-monitoring" .Values.monitoring.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "monitoring.fullname" -}}
+{{- if .Values.monitoring.fullnameOverride }}
+{{- .Values.monitoring.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "speckle-monitoring" .Values.monitoring.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "monitoring.labels" -}}
+helm.sh/chart: {{ include "speckle.chart" . }}
+{{ include "monitoring.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ include "monitoring.name" . }}
+app.kubernetes.io/part-of: {{ include "speckle.name" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "monitoring.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "monitoring.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "monitoring.serviceAccountName" -}}
+{{- if .Values.monitoring.serviceAccount.create }}
+{{- default (include "monitoring.fullname" .) .Values.monitoring.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.monitoring.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/utils/helm/speckle-server/templates/monitoring/deployment.yml
+++ b/utils/helm/speckle-server/templates/monitoring/deployment.yml
@@ -6,8 +6,9 @@ metadata:
   labels:
     app: speckle-monitoring
     project: speckle-server
+{{ include "monitoring.labels" . | indent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.monitoring.replicas }}
   selector:
     matchLabels:
       app: speckle-monitoring
@@ -17,6 +18,7 @@ spec:
       labels:
         app: speckle-monitoring
         project: speckle-server
+{{ include "monitoring.labels" . | indent 8 }}
     spec:
       containers:
       - name: main
@@ -30,11 +32,12 @@ spec:
 
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: {{ .Values.monitoring.requests.cpu }}
+            memory: {{ .Values.monitoring.requests.memory }}
           limits:
-            cpu: 200m
-            memory: 512Mi
+            cpu: {{ .Values.monitoring.limits.cpu }}
+            memory: {{ .Values.monitoring.limits.memory }}
+
 
         {{- if .Values.db.useCertificate }}
         volumeMounts:

--- a/utils/helm/speckle-server/templates/monitoring/service.yml
+++ b/utils/helm/speckle-server/templates/monitoring/service.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: speckle-monitoring
     project: speckle-server
+{{ include "monitoring.labels" . | indent 4 }}
 spec:
   selector:
     app: speckle-monitoring

--- a/utils/helm/speckle-server/templates/namespace.yml
+++ b/utils/helm/speckle-server/templates/namespace.yml
@@ -3,4 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
+  labels:
+{{ include "speckle.labels" . | indent 4 }}
 {{- end }}

--- a/utils/helm/speckle-server/templates/preview_service/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/preview_service/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "preview_service.name" -}}
+{{- default "speckle-preview-service" .Values.preview_service.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "preview_service.fullname" -}}
+{{- if .Values.preview_service.fullnameOverride }}
+{{- .Values.preview_service.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "speckle-preview-service" .Values.preview_service.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "preview_service.labels" -}}
+helm.sh/chart: {{ include "speckle.chart" . }}
+{{ include "preview_service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ include "preview_service.name" . }}
+app.kubernetes.io/part-of: {{ include "speckle.name" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "preview_service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "preview_service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "preview_service.serviceAccountName" -}}
+{{- if .Values.preview_service.serviceAccount.create }}
+{{- default (include "preview_service.fullname" .) .Values.preview_service.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.preview_service.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/utils/helm/speckle-server/templates/preview_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/preview_service/deployment.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: speckle-preview-service
     project: speckle-server
+{{ include "preview_service.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.preview_service.replicas }}
   selector:
@@ -17,6 +18,7 @@ spec:
       labels:
         app: speckle-preview-service
         project: speckle-server
+{{ include "preview_service.labels" . | indent 8 }}
     spec:
       containers:
       - name: main

--- a/utils/helm/speckle-server/templates/preview_service/service.yml
+++ b/utils/helm/speckle-server/templates/preview_service/service.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: speckle-preview-service-metrics
     project: speckle-server
+{{ include "preview_service.labels" . | indent 4 }}
 spec:
   selector:
     app: speckle-preview-service

--- a/utils/helm/speckle-server/templates/server/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/server/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "server.name" -}}
+{{- default "speckle-server" .Values.server.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "server.fullname" -}}
+{{- if .Values.server.fullnameOverride }}
+{{- .Values.server.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "speckle-server" .Values.server.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "server.labels" -}}
+helm.sh/chart: {{ include "speckle.chart" . }}
+{{ include "server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ include "server.name" . }}
+app.kubernetes.io/part-of: {{ include "speckle.name" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "server.serviceAccountName" -}}
+{{- if .Values.server.serviceAccount.create }}
+{{- default (include "server.fullname" .) .Values.server.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.server.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: speckle-server
     project: speckle-server
+{{ include "server.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.server.replicas }}
   selector:
@@ -17,6 +18,7 @@ spec:
       labels:
         app: speckle-server
         project: speckle-server
+{{ include "server.labels" . | indent 8 }}
     spec:
       containers:
       - name: main

--- a/utils/helm/speckle-server/templates/server/service.yml
+++ b/utils/helm/speckle-server/templates/server/service.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: speckle-server
     project: speckle-server
+{{ include "server.labels" . | indent 4 }}
 spec:
   selector:
     app: speckle-server

--- a/utils/helm/speckle-server/templates/servicemonitor.yml
+++ b/utils/helm/speckle-server/templates/servicemonitor.yml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: speckle-server
     release: kube-prometheus-stack
+{{ include "speckle.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:

--- a/utils/helm/speckle-server/templates/test/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/test/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "test.name" -}}
+{{- default "speckle-test-deployment" .Values.test.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "test.fullname" -}}
+{{- if .Values.test.fullnameOverride }}
+{{- .Values.test.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "speckle-test-deployment" .Values.test.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "test.labels" -}}
+helm.sh/chart: {{ include "speckle.chart" . }}
+{{ include "test.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ include "test.name" . }}
+app.kubernetes.io/part-of: {{ include "speckle.name" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "test.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "test.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "test.serviceAccountName" -}}
+{{- if .Values.test.serviceAccount.create }}
+{{- default (include "test.fullname" .) .Values.test.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.test.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/utils/helm/speckle-server/templates/test/deployment.yml
+++ b/utils/helm/speckle-server/templates/test/deployment.yml
@@ -9,6 +9,7 @@ metadata:
   labels:
     app: speckle-test-deployment
     project: speckle-server
+{{ include "test.labels" . | indent 4 }}
 spec:
   containers:
     - name: test-deployment
@@ -18,5 +19,12 @@ spec:
           value: https://{{ .Values.domain }}
         - name: SERVER_VERSION
           value: {{ .Values.docker_image_tag }}
+      resources:
+        requests:
+          cpu: {{ .Values.test.requests.cpu }}
+          memory: {{ .Values.test.requests.memory }}
+        limits:
+          cpu: {{ .Values.test.limits.cpu }}
+          memory: {{ .Values.test.limits.memory }}
   restartPolicy: Never
 {{- end }}

--- a/utils/helm/speckle-server/templates/webhook_service/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/webhook_service/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "webhook_service.name" -}}
+{{- default "speckle-webhook-service" .Values.webhook_service.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "webhook_service.fullname" -}}
+{{- if .Values.webhook_service.fullnameOverride }}
+{{- .Values.webhook_service.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "speckle-webhook-service" .Values.webhook_service.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "webhook_service.labels" -}}
+helm.sh/chart: {{ include "speckle.chart" . }}
+{{ include "webhook_service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ include "webhook_service.name" . }}
+app.kubernetes.io/part-of: {{ include "speckle.name" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "webhook_service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "webhook_service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "webhook_service.serviceAccountName" -}}
+{{- if .Values.webhook_service.serviceAccount.create }}
+{{- default (include "webhook_service.fullname" .) .Values.webhook_service.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.webhook_service.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/utils/helm/speckle-server/templates/webhook_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/deployment.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: speckle-webhook-service
     project: speckle-server
+{{ include "webhook_service.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.webhook_service.replicas }}
   selector:
@@ -17,6 +18,7 @@ spec:
       labels:
         app: speckle-webhook-service
         project: speckle-server
+{{ include "webhook_service.labels" . | indent 8 }}
     spec:
       containers:
       - name: main

--- a/utils/helm/speckle-server/templates/webhook_service/service.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/service.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: speckle-webhook-service
     project: speckle-server
+{{ include "webhook_service.labels" . | indent 4 }}
 spec:
   selector:
     app: speckle-webhook-service

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -104,6 +104,23 @@ fileimport_service:
     memory: 2Gi
   time_limit_min: 10
 
+monitoring:
+  replicas: 1
+  requests:
+    cpu: 100m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 512Mi
+
+test:
+  requests:
+    cpu: 100m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 512Mi
+
 secretName: server-vars
 
 enable_prometheus_monitoring: false


### PR DESCRIPTION
Helm best practices recommend use of standard labels
https://helm.sh/docs/chart_best_practices/labels/#standard-labels

This PR adds these standard labels to all deployed resources.
This is an additive change that is not breaking.

There is some duplication of helper methods, but this allows future flexibility to move the separate components to their own sub-charts in the future.

Additional changes:
* allows `monitoring` and `test` pod resources to be configurable

fixes https://github.com/specklesystems/speckle-server/issues/864