### PR TITLE
weird webpack cache issue

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -113,7 +113,6 @@
   },
   "vuePlugins": {
     "service": [
-      "./build-config/esbuildPlugin.js",
       "./build-config/gqlPlugin.js"
     ]
   }

--- a/packages/frontend/src/helpers/vuetifyHelpers.ts
+++ b/packages/frontend/src/helpers/vuetifyHelpers.ts
@@ -17,5 +17,6 @@ export type VFormInstance = CombinedVueInstance<
     validate(): boolean
   },
   unknown,
+  unknown,
   unknown
 >

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -24,7 +24,8 @@
       "@types/node",
       "@types/mixpanel-browser",
       "vuetify",
-      "@types/dompurify"
+      "@types/dompurify",
+      "@speckle/viewer"
     ]
   },
   "include": [


### PR DESCRIPTION
1. Checkout the branch
2. Run `yarn dev:frontend` from repo root to run the webpack dev server
3. Once its running, run `yarn dev` from 'packages/viewer'
4. The frontend dev server will rebuild, but wont be able to find the linked `viewer` dependency anymore