### PR TITLE
fix(frontend): workaround for @speckle/viewer not found error when running dev server

### DIFF
--- a/packages/viewer/rollup.config.js
+++ b/packages/viewer/rollup.config.js
@@ -10,23 +10,18 @@ import { DEFAULT_EXTENSIONS } from '@babel/core'
 const isProd = process.env.NODE_ENV === 'production'
 const sourcemap = isProd ? false : 'inline'
 
-/** @type {import('rollup').RollupOptions} */
-const config = {
+/** @returns {import('rollup').RollupOptions} */
+const config = (file, format) => ({
   input: 'src/index.ts',
   output: [
     {
-      file: 'dist/speckleviewer.esm.js',
-      format: 'esm',
-      sourcemap
-    },
-    {
-      file: 'dist/speckleviewer.js',
-      format: 'cjs',
+      file,
+      format,
       sourcemap
     }
   ],
   plugins: [
-    clean({ targets: 'dist/*' }),
+    ...(isProd ? [clean({ targets: 'dist/*' })] : []),
     rebasePlugin({ keepName: true }),
     copyPlugin({
       targets: [{ src: './always-bundled-assets/**/*', dest: 'dist/assets' }]
@@ -44,6 +39,9 @@ const config = {
   ],
   // Externalizing all deps, we don't want to bundle them in cause this is a library
   external: Object.keys(pkg.dependencies || {}).map((d) => new RegExp(`^${d}(\\/.*)?$`))
-}
+})
 
-export default config
+export default [
+  config('dist/speckleviewer.esm.js', 'esm'),
+  config('dist/speckleviewer.js', 'cjs')
+]


### PR DESCRIPTION
workaround for the following issue: https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/771

essentially we no longer clean the `dist` folder between @speckle/viewer rebuilds, so that fork-ts-checker-webpack-plugin doesn't break and think the types no longer exist

this does make the viewer package build process a few seconds longer, but there's no other option 