### PR TITLE
refactor(helm chart): use named ports where possible

### DIFF
--- a/utils/helm/speckle-server/templates/frontend/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend/deployment.yml
@@ -47,7 +47,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 80
+            port: www
           initialDelaySeconds: 5
           periodSeconds: 5
         


### PR DESCRIPTION
Follows on from https://github.com/specklesystems/speckle-server/issues/868 which introduced named ports.

If a port number is changed, it should not have to be updated in multiple places.  Instead the port should be by named reference.