### PR TITLE
Allow save object to S3 in different region

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,6 +248,7 @@ jobs:
       S3_SECRET_KEY: 'minioadmin'
       S3_BUCKET: 'speckle-server'
       S3_CREATE_BUCKET: 'true'
+      S3_REGION: '' # optional, defaults to 'us-east-1'
     steps:
       - checkout
       - restore_cache:

--- a/docker-compose-speckle.yml
+++ b/docker-compose-speckle.yml
@@ -39,6 +39,7 @@ services:
       S3_SECRET_KEY: 'minioadmin'
       S3_BUCKET: 'speckle-server'
       S3_CREATE_BUCKET: 'true'
+      S3_REGION: '' # optional, defaults to 'us-east-1'
       FILE_SIZE_LIMIT_MB: 100
 
   preview-service:
@@ -77,5 +78,6 @@ services:
       S3_ACCESS_KEY: 'minioadmin'
       S3_SECRET_KEY: 'minioadmin'
       S3_BUCKET: 'speckle-server'
+      S3_REGION: '' # optional, defaults to 'us-east-1'
 
       SPECKLE_SERVER_URL: 'http://speckle-server:3000'

--- a/packages/server/modules/blobstorage/objectStorage.js
+++ b/packages/server/modules/blobstorage/objectStorage.js
@@ -27,7 +27,7 @@ const getS3Config = () => {
       forcePathStyle: true,
       // s3ForcePathStyle: true,
       // signatureVersion: 'v4',
-      region: 'us-east-1'
+      region: process.env.S3_REGION || 'us-east-1'
     }
   }
   return s3Config

--- a/utils/1click_image_scripts/template-docker-compose.yml
+++ b/utils/1click_image_scripts/template-docker-compose.yml
@@ -79,6 +79,7 @@ services:
       S3_SECRET_KEY: 'minioadmin'
       S3_BUCKET: 'speckle-server'
       S3_CREATE_BUCKET: 'true'
+      S3_REGION: '' # optional, defaults to 'us-east-1'
 
       FILE_SIZE_LIMIT_MB: 100
 
@@ -116,5 +117,6 @@ services:
       S3_ACCESS_KEY: 'minioadmin'
       S3_SECRET_KEY: 'minioadmin'
       S3_BUCKET: 'speckle-server'
+      S3_REGION: '' # optional, defaults to 'us-east-1'
 
       SPECKLE_SERVER_URL: 'http://speckle-server:3000'

--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -80,6 +80,8 @@ spec:
               secretKeyRef:
                 name: {{ .Values.secretName }}
                 key: s3_secret_key
+          - name: S3_REGION
+            value: "{{ .Values.s3.region }}"
 
           - name: FILE_IMPORT_TIME_LIMIT_MIN
             value: {{ .Values.fileimport_service.time_limit_min | quote }}

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -129,6 +129,8 @@ spec:
                 key: s3_secret_key
           - name: S3_CREATE_BUCKET
             value: "{{ .Values.s3.create_bucket }}"
+          - name: S3_REGION
+            value: "{{ .Values.s3.region }}"
 
           {{- end }}
 

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -17,6 +17,7 @@ s3:
   bucket: ''
   access_key: ''
   create_bucket: 'false'
+  region: '' # optional, defaults to 'us-east-1'
   # secret_key: secret -> s3_secret_key
 
 #redis:


### PR DESCRIPTION
Can we add the ability to save objects to different regions rather than hardcode it? Some projects require data to be stored in a particular country.