### PR TITLE
feat(helm chart): prometheus monitoring namespace and release name should be configurable

### DIFF
--- a/utils/helm/speckle-server/templates/servicemonitor.yml
+++ b/utils/helm/speckle-server/templates/servicemonitor.yml
@@ -4,10 +4,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: speckle-server
-  namespace: {{ .Values.namespace }}
+  namespace: {{ default .Values.namespace .Values.prometheusMonitoring.namespace }}
   labels:
     app: speckle-server
-    release: kube-prometheus-stack
+    release: {{ default "kube-prometheus-stack" .Values.prometheusMonitoring.release }}
 {{ include "speckle.labels" . | indent 4 }}
 spec:
   selector:
@@ -15,5 +15,4 @@ spec:
       project: speckle-server
   endpoints:
   - port: web
-
 {{ end }}

--- a/utils/helm/speckle-server/templates/servicemonitor.yml
+++ b/utils/helm/speckle-server/templates/servicemonitor.yml
@@ -12,7 +12,7 @@ spec:
   selector:
     matchLabels:
       project: speckle-server
-{{- if ne .Values.namespace .Values.prometheusMonitoring.namespace }}
+{{- if and .Values.prometheusMonitoring.namespace (ne .Values.namespace .Values.prometheusMonitoring.namespace) }}
   namespaceSelector:
     matchNames:
     - {{ .Values.namespace }}

--- a/utils/helm/speckle-server/templates/servicemonitor.yml
+++ b/utils/helm/speckle-server/templates/servicemonitor.yml
@@ -1,5 +1,4 @@
-{{ if .Values.enable_prometheus_monitoring }}
-
+{{- if .Values.enable_prometheus_monitoring }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -13,6 +12,11 @@ spec:
   selector:
     matchLabels:
       project: speckle-server
+{{- if ne .Values.namespace .Values.prometheusMonitoring.namespace }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.namespace }}
+{{- end }}
   endpoints:
   - port: web
-{{ end }}
+{{- end }}

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -124,6 +124,9 @@ test:
 secretName: server-vars
 
 enable_prometheus_monitoring: false
+prometheusMonitoring:
+  namespace: ''
+  release: ''
 cert_manager_issuer: letsencrypt-staging
 
 helm_test_enabled: true


### PR DESCRIPTION
Currently Speckle assumes prometheus is deployed in the 'speckle' namespace and is deployed as a
release named 'kube-prometheus-stack'.  This commit introduces non-breaking changes that allow
custom values for these to be provided, defaulting to the current assumed values if they are not
provided.

fixes https://github.com/specklesystems/speckle-server/issues/863