### PR TITLE
feat(helm chart): add SecurityContext to pods and containers

### DIFF
--- a/packages/frontend/nginx/templates/nginx.conf.template
+++ b/packages/frontend/nginx/templates/nginx.conf.template
@@ -56,9 +56,6 @@ set_real_ip_from 2a06:98c0::/29;
 real_ip_header CF-Connecting-IP;
 #real_ip_header X-Forwarded-For;
 
-error_log  /tmp/nginx/error.log warn;
-pid        /tmp/nginx/nginx.pid;
-
 server {
   listen 80;
   client_max_body_size 100m;

--- a/packages/frontend/nginx/templates/nginx.conf.template
+++ b/packages/frontend/nginx/templates/nginx.conf.template
@@ -56,10 +56,21 @@ set_real_ip_from 2a06:98c0::/29;
 real_ip_header CF-Connecting-IP;
 #real_ip_header X-Forwarded-For;
 
+error_log  /tmp/nginx/error.log warn;
+pid        /tmp/nginx/nginx.pid;
 
 server {
   listen 80;
   client_max_body_size 100m;
+
+  # move default write paths to a custom directory
+  # kubernetes can mount this directory and prevent writes to the root directory
+  # https://github.com/openresty/docker-openresty/issues/119
+  client_body_temp_path /var/run/openresty/nginx-client-body;
+  proxy_temp_path /var/run/openresty/nginx-proxy;
+  fastcgi_temp_path /var/run/openresty/nginx-fastcgi;
+  uwsgi_temp_path /var/run/openresty/nginx-uwsgi;
+  scgi_temp_path /var/run/openresty/nginx-scgi;
 
   location / {
     root   /usr/share/nginx/html;

--- a/utils/helm/Makefile
+++ b/utils/helm/Makefile
@@ -7,6 +7,7 @@ build:
 	cd ../.. && docker build -t speckle/speckle-webhook-service:local -f packages/webhook-service/Dockerfile .
 	cd ../.. && docker build -t speckle/speckle-fileimport-service:local -f packages/fileimport-service/Dockerfile .
 	cd ../.. && docker build -t speckle/speckle-monitor-deployment:local -f utils/monitor-deployment/Dockerfile .
+	cd ../.. && docker build -t speckle/speckle-test-deployment:local -f utils/test-deployment/Dockerfile .
 
 	echo "Making locally built images available inside minikube cluster. This takes a bit to copy, unfortunately..."
 
@@ -16,6 +17,7 @@ build:
 	minikube image load speckle/speckle-webhook-service:local
 	minikube image load speckle/speckle-fileimport-service:local
 	minikube image load speckle/speckle-monitor-deployment:local
+	minikube image load speckle/speckle-test-deployment:local
 
 
 install:

--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -44,6 +44,12 @@ spec:
             cpu: {{ .Values.fileimport_service.limits.cpu }}
             memory: {{ .Values.fileimport_service.limits.memory }}
 
+        securityContext:
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+              - ALL
+
         {{- if .Values.db.useCertificate }}
         volumeMounts:
           - name: postgres-certificate
@@ -83,6 +89,13 @@ spec:
 
           - name: FILE_IMPORT_TIME_LIMIT_MIN
             value: {{ .Values.fileimport_service.time_limit_min | quote }}
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 3000
+        seccompProfile:
+          type: RuntimeDefault
 
       priorityClassName: low-priority
 

--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -99,6 +99,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 20000
+        fsGroup: 25000
+        fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 30000
         seccompProfile:
           type: RuntimeDefault

--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -45,13 +45,19 @@ spec:
             memory: {{ .Values.fileimport_service.limits.memory }}
 
         securityContext:
-          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
               - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 20000
 
-        {{- if .Values.db.useCertificate }}
         volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+        {{- if .Values.db.useCertificate }}
           - name: postgres-certificate
             mountPath: /postgres-certificate
         {{- end }}
@@ -92,15 +98,17 @@ spec:
 
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 3000
+        runAsUser: 20000
+        runAsGroup: 30000
         seccompProfile:
           type: RuntimeDefault
 
       priorityClassName: low-priority
 
-      {{- if .Values.db.useCertificate }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- if .Values.db.useCertificate }}
         - name: postgres-certificate
           configMap:
             name: postgres-certificate

--- a/utils/helm/speckle-server/templates/frontend/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend/deployment.yml
@@ -34,6 +34,11 @@ spec:
             cpu: {{ .Values.frontend.limits.cpu }}
             memory: {{ .Values.frontend.limits.memory }}
 
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: false
+
         # Allow for k8s to remove the pod from the service endpoints to stop receive traffic
         lifecycle:
           preStop:
@@ -52,3 +57,8 @@ spec:
             value: {{ .Values.file_size_limit_mb | quote }}
 
       priorityClassName: high-priority
+
+      securityContext:
+        runAsNonRoot: false
+        seccompProfile:
+          type: RuntimeDefault

--- a/utils/helm/speckle-server/templates/frontend/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend/deployment.yml
@@ -36,8 +36,15 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - NET_BIND_SERVICE
           privileged: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 20000
 
         # Allow for k8s to remove the pod from the service endpoints to stop receive traffic
         lifecycle:
@@ -56,9 +63,29 @@ spec:
           - name: FILE_SIZE_LIMIT_MB
             value: {{ .Values.file_size_limit_mb | quote }}
 
+        volumeMounts:
+          - mountPath: /var/run/openresty
+            name: openresty-tmp
+          - mountPath: /var/cache/nginx
+            name: nginx-cache
+          - mountPath: /tmp/nginx
+            name: nginx-tmp
+
       priorityClassName: high-priority
 
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
+        runAsUser: 20000
+        fsGroup: 25000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 30000
         seccompProfile:
           type: RuntimeDefault
+
+      volumes:
+        - name: openresty-tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}

--- a/utils/helm/speckle-server/templates/frontend/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend/deployment.yml
@@ -70,6 +70,8 @@ spec:
             name: nginx-tmp
           - mountPath: /etc/nginx/conf.d
             name: nginx-confd
+          - mountPath: /usr/local/openresty/nginx/logs
+            name: openresty-logs
           - mountPath: /var/run/openresty
             name: openresty-tmp
 
@@ -90,6 +92,8 @@ spec:
         - name: nginx-confd
           emptyDir: {}
         - name: nginx-tmp
+          emptyDir: {}
+        - name: openresty-logs
           emptyDir: {}
         - name: openresty-tmp
           emptyDir: {}

--- a/utils/helm/speckle-server/templates/frontend/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend/deployment.yml
@@ -64,12 +64,14 @@ spec:
             value: {{ .Values.file_size_limit_mb | quote }}
 
         volumeMounts:
-          - mountPath: /var/run/openresty
-            name: openresty-tmp
           - mountPath: /var/cache/nginx
             name: nginx-cache
           - mountPath: /tmp/nginx
             name: nginx-tmp
+          - mountPath: /etc/nginx/conf.d
+            name: nginx-confd
+          - mountPath: /var/run/openresty
+            name: openresty-tmp
 
       priorityClassName: high-priority
 
@@ -83,9 +85,11 @@ spec:
           type: RuntimeDefault
 
       volumes:
-        - name: openresty-tmp
-          emptyDir: {}
         - name: nginx-cache
           emptyDir: {}
+        - name: nginx-confd
+          emptyDir: {}
         - name: nginx-tmp
+          emptyDir: {}
+        - name: openresty-tmp
           emptyDir: {}

--- a/utils/helm/speckle-server/templates/monitoring/deployment.yml
+++ b/utils/helm/speckle-server/templates/monitoring/deployment.yml
@@ -34,6 +34,15 @@ spec:
             cpu: {{ .Values.monitoring.limits.cpu }}
             memory: {{ .Values.monitoring.limits.memory }}
 
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 20000
 
         {{- if .Values.db.useCertificate }}
         volumeMounts:
@@ -54,6 +63,13 @@ spec:
           {{- end }}
 
       priorityClassName: low-priority
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 20000
+        runAsGroup: 30000
+        seccompProfile:
+          type: RuntimeDefault
 
       {{- if .Values.db.useCertificate }}
       volumes:

--- a/utils/helm/speckle-server/templates/monitoring/deployment.yml
+++ b/utils/helm/speckle-server/templates/monitoring/deployment.yml
@@ -67,6 +67,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 20000
+        fsGroup: 25000
+        fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 30000
         seccompProfile:
           type: RuntimeDefault

--- a/utils/helm/speckle-server/templates/preview_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/preview_service/deployment.yml
@@ -43,8 +43,20 @@ spec:
             cpu: {{ .Values.preview_service.limits.cpu }}
             memory: {{ .Values.preview_service.limits.memory }}
 
-        {{- if .Values.db.useCertificate }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 20000
+
         volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+        {{- if .Values.db.useCertificate }}
           - name: postgres-certificate
             mountPath: /postgres-certificate
         {{- end }}
@@ -66,11 +78,20 @@ spec:
 
       priorityClassName: low-priority
 
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 20000
+        runAsGroup: 30000
+        seccompProfile:
+          type: RuntimeDefault
+
       # Should be > preview generation time ( 1 hour for good measure )
       terminationGracePeriodSeconds: 3600
 
-      {{- if .Values.db.useCertificate }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- if .Values.db.useCertificate }}
         - name: postgres-certificate
           configMap:
             name: postgres-certificate

--- a/utils/helm/speckle-server/templates/preview_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/preview_service/deployment.yml
@@ -81,6 +81,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 20000
+        fsGroup: 25000
+        fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 30000
         seccompProfile:
           type: RuntimeDefault

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -34,10 +34,22 @@ spec:
             cpu: {{ .Values.server.limits.cpu }}
             memory: {{ .Values.server.limits.memory }}
 
-        {{- if .Values.db.useCertificate }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 20000
+
         volumeMounts:
-        - name: postgres-certificate
-          mountPath: /postgres-certificate
+          - mountPath: /tmp
+            name: tmp
+        {{- if .Values.db.useCertificate }}
+          - name: postgres-certificate
+            mountPath: /postgres-certificate
         {{- end }}
 
         # Allow for k8s to remove the pod from the service endpoints to stop receive traffic
@@ -242,9 +254,19 @@ spec:
                 key: apollo_key
           {{- end }}
       priorityClassName: high-priority
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 20000
+        runAsGroup: 30000
+        seccompProfile:
+          type: RuntimeDefault
+
       terminationGracePeriodSeconds: 310
-      {{- if .Values.db.useCertificate }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- if .Values.db.useCertificate }}
         - name: postgres-certificate
           configMap:
             name: postgres-certificate

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -258,6 +258,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 20000
+        fsGroup: 25000
+        fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 30000
         seccompProfile:
           type: RuntimeDefault

--- a/utils/helm/speckle-server/templates/test/deployment.yml
+++ b/utils/helm/speckle-server/templates/test/deployment.yml
@@ -24,5 +24,23 @@ spec:
         limits:
           cpu: {{ .Values.test.limits.cpu }}
           memory: {{ .Values.test.limits.memory }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 20000
+
   restartPolicy: Never
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 20000
+    runAsGroup: 30000
+    seccompProfile:
+      type: RuntimeDefault
+
 {{- end }}

--- a/utils/helm/speckle-server/templates/webhook_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/deployment.yml
@@ -43,8 +43,20 @@ spec:
             cpu: {{ .Values.webhook_service.limits.cpu }}
             memory: {{ .Values.webhook_service.limits.memory }}
 
-        {{- if .Values.db.useCertificate }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 20000
+
         volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+        {{- if .Values.db.useCertificate }}
           - name: postgres-certificate
             mountPath: /postgres-certificate
         {{- end }}
@@ -66,11 +78,20 @@ spec:
 
       priorityClassName: low-priority
 
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 20000
+        runAsGroup: 30000
+        seccompProfile:
+          type: RuntimeDefault
+
       # Should be > webhook max call time ( ~= 10 seconds )
       terminationGracePeriodSeconds: 30
 
-      {{- if .Values.db.useCertificate }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- if .Values.db.useCertificate }}
         - name: postgres-certificate
           configMap:
             name: postgres-certificate

--- a/utils/helm/speckle-server/templates/webhook_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/deployment.yml
@@ -81,6 +81,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 20000
+        fsGroup: 25000
+        fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 30000
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
Speckle pods should run with minimal privileges and capabilities to function.

To verify, run the following and follow the advisory guidance:
```shell
helm template my-speckle-server ./utils/helm/speckle-server \
 --values ../iain_speckle_dev-values.yaml \
 --namespace speckle | \
 docker run -i kubesec/kubesec:v2 scan /dev/stdin
```

## Notes

- kubesec schema has a [known issue](https://github.com/controlplaneio/kubesec/issues/315) that incorrectly throws an error for `seccompProfile`. `seccompProfile` should be commented out while running kubesec 🙄 
- empty directory (`emptyDir`) mounted at `/tmp` for all containers that write temporary files.  This allows root directory to be read only.
- tailored seccomp and appArmor profiles are not included, and will be provided as part of https://github.com/specklesystems/speckle-server/issues/918
- openResty & nginx by default requires root user and chown capabilities: https://github.com/openresty/docker-openresty/issues/24
  - to resolve, nginx.conf amended per https://github.com/openresty/docker-openresty/issues/119 and https://discuss.kubernetes.io/t/why-i-am-getting-read-only-file-system-error-from-nginx-in-my-container/5782
  - nginx requires `NET_BIND_SERVICE` capability to run as nonRoot. https://github.com/kubernetes/ingress-nginx/issues/3668
- service accounts will be added as part of https://github.com/specklesystems/speckle-server/issues/859

### References
https://kubernetes.io/docs/concepts/security/pod-security-standards/
https://cheatsheetseries.owasp.org/cheatsheets/Kubernetes_Security_Cheat_Sheet.html

Fixes https://github.com/specklesystems/speckle-server/issues/857
Fixes https://github.com/specklesystems/speckle-server/issues/919