### PR TITLE
style(vscode workspace): set EOL character to line feed (LF) symbol

### DIFF
--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -59,7 +59,8 @@
     "search.useParentIgnoreFiles": true,
     "[html]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
-    }
+    },
+    "files.eol": "\n"
   },
   "extensions": {
     // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.


### PR DESCRIPTION
To reduce likelihood of CRLF characters being incorporated, we wish to configure the project to use LF
only.