### PR TITLE
feat(helm chart): serviceAccounts are provided for each service

### DIFF
--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -85,14 +85,13 @@ spec:
             value: {{ .Values.fileimport_service.time_limit_min | quote }}
 
       priorityClassName: low-priority
-
+      serviceAccountName: {{ include "fileimport_service.name" $ }}
+      # Should be > File import timeout to allow finishing up imports
+      terminationGracePeriodSeconds: 610
       {{- if .Values.db.useCertificate }}
       volumes:
         - name: postgres-certificate
           configMap:
             name: postgres-certificate
       {{- end }}
-
-      # Should be > File import timeout to allow finishing up imports
-      terminationGracePeriodSeconds: 610
 {{- end }}

--- a/utils/helm/speckle-server/templates/fileimport_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/serviceaccount.yml
@@ -1,0 +1,14 @@
+{{- if .Values.fileimport_service.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fileimport_service.name" $ }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "fileimport_service.labels" $ | indent 4 }}
+  annotations:
+    "kubernetes.io/enforce-mountable-secrets": "true"
+automountServiceAccountToken: false
+secrets:
+  - name: {{ .Values.secretName }}
+{{- end -}}

--- a/utils/helm/speckle-server/templates/frontend/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend/deployment.yml
@@ -52,3 +52,4 @@ spec:
             value: {{ .Values.file_size_limit_mb | quote }}
 
       priorityClassName: high-priority
+      serviceAccountName: {{ include "frontend.name" $ }}

--- a/utils/helm/speckle-server/templates/frontend/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/frontend/serviceaccount.yml
@@ -1,0 +1,13 @@
+{{- if .Values.frontend.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "frontend.name" $ }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "frontend.labels" $ | indent 4 }}
+  annotations:
+    "kubernetes.io/enforce-mountable-secrets": "true"
+automountServiceAccountToken: false
+secrets: [] # no access to any secret
+{{- end -}}

--- a/utils/helm/speckle-server/templates/monitoring/deployment.yml
+++ b/utils/helm/speckle-server/templates/monitoring/deployment.yml
@@ -54,12 +54,11 @@ spec:
           {{- end }}
 
       priorityClassName: low-priority
-
+      serviceAccountName: {{ include "monitoring.name" $ }}
+      terminationGracePeriodSeconds: 10
       {{- if .Values.db.useCertificate }}
       volumes:
         - name: postgres-certificate
           configMap:
             name: postgres-certificate
       {{- end }}
-
-      terminationGracePeriodSeconds: 10

--- a/utils/helm/speckle-server/templates/monitoring/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/monitoring/serviceaccount.yml
@@ -1,0 +1,14 @@
+{{- if .Values.monitoring.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "monitoring.name" $ }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "monitoring.labels" $ | indent 4 }}
+  annotations:
+    "kubernetes.io/enforce-mountable-secrets": "true"
+automountServiceAccountToken: false
+secrets:
+  - name: {{ .Values.secretName }}
+{{- end -}}

--- a/utils/helm/speckle-server/templates/preview_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/preview_service/deployment.yml
@@ -65,6 +65,7 @@ spec:
           {{- end }}
 
       priorityClassName: low-priority
+      serviceAccountName: {{ include "preview_service.name" $ }}
 
       # Should be > preview generation time ( 1 hour for good measure )
       terminationGracePeriodSeconds: 3600

--- a/utils/helm/speckle-server/templates/preview_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/preview_service/serviceaccount.yml
@@ -1,0 +1,14 @@
+{{- if .Values.preview_service.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "preview_service.name" $ }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "preview_service.labels" $ | indent 4 }}
+  annotations:
+    "kubernetes.io/enforce-mountable-secrets": "true"
+automountServiceAccountToken: false
+secrets:
+  - name: {{ .Values.secretName }}
+{{- end -}}

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -242,6 +242,7 @@ spec:
                 key: apollo_key
           {{- end }}
       priorityClassName: high-priority
+      serviceAccountName: {{ include "server.name" $ }}
       terminationGracePeriodSeconds: 310
       {{- if .Values.db.useCertificate }}
       volumes:

--- a/utils/helm/speckle-server/templates/server/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/server/serviceaccount.yml
@@ -1,0 +1,14 @@
+{{- if .Values.server.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "server.name" $ }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "server.labels" $ | indent 4 }}
+  annotations:
+    "kubernetes.io/enforce-mountable-secrets": "true"
+automountServiceAccountToken: false
+secrets:
+  - name: {{ .Values.secretName }}
+{{- end -}}

--- a/utils/helm/speckle-server/templates/test/deployment.yml
+++ b/utils/helm/speckle-server/templates/test/deployment.yml
@@ -25,4 +25,5 @@ spec:
           cpu: {{ .Values.test.limits.cpu }}
           memory: {{ .Values.test.limits.memory }}
   restartPolicy: Never
+  serviceAccountName: {{ include "test.name" $ }}
 {{- end }}

--- a/utils/helm/speckle-server/templates/test/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/test/serviceaccount.yml
@@ -1,0 +1,13 @@
+{{- if .Values.test.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "test.name" $ }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "test.labels" $ | indent 4 }}
+  annotations:
+    "kubernetes.io/enforce-mountable-secrets": "true"
+automountServiceAccountToken: false
+secrets: [] # does not have access to any secrets
+{{- end -}}

--- a/utils/helm/speckle-server/templates/webhook_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/deployment.yml
@@ -65,6 +65,7 @@ spec:
           {{- end }}
 
       priorityClassName: low-priority
+      serviceAccountName: {{ include "webhook_service.name" $ }}
 
       # Should be > webhook max call time ( ~= 10 seconds )
       terminationGracePeriodSeconds: 30

--- a/utils/helm/speckle-server/templates/webhook_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/serviceaccount.yml
@@ -1,0 +1,14 @@
+{{- if .Values.webhook_service.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "webhook_service.name" $ }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{ include "webhook_service.labels" $ | indent 4 }}
+  annotations:
+    "kubernetes.io/enforce-mountable-secrets": "true"
+automountServiceAccountToken: false
+secrets:
+  - name: {{ .Values.secretName }}
+{{- end -}}

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -55,6 +55,8 @@ server:
   limits:
     cpu: 1000m
     memory: 3Gi
+  serviceAccount:
+    create: true
 
   monitoring:
     apollo:
@@ -75,6 +77,8 @@ frontend:
   limits:
     cpu: 1000m
     memory: 512Mi
+  serviceAccount:
+    create: true
 
 preview_service:
   replicas: 1
@@ -84,6 +88,8 @@ preview_service:
   limits:
     cpu: 1000m
     memory: 4Gi
+  serviceAccount:
+    create: true
 
 webhook_service:
   replicas: 1
@@ -93,6 +99,8 @@ webhook_service:
   limits:
     cpu: 200m
     memory: 512Mi
+  serviceAccount:
+    create: true
 
 fileimport_service:
   replicas: 1
@@ -102,6 +110,8 @@ fileimport_service:
   limits:
     cpu: 1000m
     memory: 2Gi
+  serviceAccount:
+    create: true
   time_limit_min: 10
 
 monitoring:
@@ -112,6 +122,8 @@ monitoring:
   limits:
     cpu: 200m
     memory: 512Mi
+  serviceAccount:
+    create: true
 
 test:
   requests:
@@ -120,6 +132,8 @@ test:
   limits:
     cpu: 200m
     memory: 512Mi
+  serviceAccount:
+    create: true
 
 secretName: server-vars
 


### PR DESCRIPTION
ServiceAccounts are provided for each service.

These ServiceAccounts do not mount service account token (which allows access to the kubernetes API).
The ServiceAccount only allows mounting of the secret that the pod requires access to.  i.e. it blocks mounting of arbitrary secrets.  For test and frontend, no secrets need to be mounted.

Fixes https://github.com/specklesystems/speckle-server/issues/859