### PR TITLE
fix(fileimport service): s3 is not required by fileimport service

### DIFF
--- a/docker-compose-speckle.yml
+++ b/docker-compose-speckle.yml
@@ -72,10 +72,4 @@ services:
     environment:
       DEBUG: 'fileimport-service:*'
       PG_CONNECTION_STRING: 'postgres://speckle:speckle@postgres/speckle'
-
-      S3_ENDPOINT: 'http://minio:9000'
-      S3_ACCESS_KEY: 'minioadmin'
-      S3_SECRET_KEY: 'minioadmin'
-      S3_BUCKET: 'speckle-server'
-
       SPECKLE_SERVER_URL: 'http://speckle-server:3000'

--- a/packages/fileimport-service/package.json
+++ b/packages/fileimport-service/package.json
@@ -15,7 +15,7 @@
     "node": "^16.0.0"
   },
   "scripts": {
-    "dev": "cross-env S3_BUCKET=speckle-server POSTGRES_URL=postgres://speckle:speckle@localhost/speckle NODE_ENV=development SPECKLE_SERVER_URL=http://localhost:3000 nodemon ./src/daemon.js",
+    "dev": "cross-env POSTGRES_URL=postgres://speckle:speckle@localhost/speckle NODE_ENV=development SPECKLE_SERVER_URL=http://localhost:3000 nodemon ./src/daemon.js",
     "parse:ifc": "node ./ifc/import_file.js /tmp/file_to_import/file 33763848d6 2e4bfb467a main File upload: steelplates.ifc",
     "lint": "eslint . --ext .js,.ts"
   },

--- a/utils/1click_image_scripts/template-docker-compose.yml
+++ b/utils/1click_image_scripts/template-docker-compose.yml
@@ -110,11 +110,5 @@ services:
     environment:
       DEBUG: 'fileimport-service:*'
       PG_CONNECTION_STRING: 'postgres://speckle:speckle@postgres/speckle'
-      WAIT_HOSTS: 'postgres:5432, minio:9000'
-
-      S3_ENDPOINT: 'http://minio:9000'
-      S3_ACCESS_KEY: 'minioadmin'
-      S3_SECRET_KEY: 'minioadmin'
-      S3_BUCKET: 'speckle-server'
-
+      WAIT_HOSTS: 'postgres:5432'
       SPECKLE_SERVER_URL: 'http://speckle-server:3000'

--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -68,19 +68,6 @@ spec:
             value: "/postgres-certificate/ca-certificate.crt"
           {{- end }}
 
-
-          - name: S3_ENDPOINT
-            value: {{ .Values.s3.endpoint }}
-          - name: S3_ACCESS_KEY
-            value: {{ .Values.s3.access_key }}
-          - name: S3_BUCKET
-            value: {{ .Values.s3.bucket }}
-          - name: S3_SECRET_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: s3_secret_key
-
           - name: FILE_IMPORT_TIME_LIMIT_MIN
             value: {{ .Values.fileimport_service.time_limit_min | quote }}
 


### PR DESCRIPTION



## Description & motivation

Fileimport service retreives blobs via the server storage API, and not directly from s3.  Fileimport
service no longer requires information or credentials about s3.

## Changes:

* remove S3 environment variables from fileimport

## To-do before merge:

No requirements

## Screenshots:



## Validation of changes:

Fileimport service was deployed and verified as working.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References


