### PR TITLE
fix(frontend): frontend revert security context to prior permissions

### DIFF
--- a/utils/helm/speckle-server/templates/frontend/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend/deployment.yml
@@ -34,17 +34,6 @@ spec:
             cpu: {{ .Values.frontend.limits.cpu }}
             memory: {{ .Values.frontend.limits.memory }}
 
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
-            add:
-              - NET_BIND_SERVICE
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-
         # Allow for k8s to remove the pod from the service endpoints to stop receive traffic
         lifecycle:
           preStop:
@@ -62,33 +51,4 @@ spec:
           - name: FILE_SIZE_LIMIT_MB
             value: {{ .Values.file_size_limit_mb | quote }}
 
-        volumeMounts:
-          - mountPath: /var/cache/nginx
-            name: nginx-cache
-          - mountPath: /tmp/nginx
-            name: nginx-tmp
-          - mountPath: /etc/nginx/conf.d
-            name: nginx-confd
-          - mountPath: /usr/local/openresty/nginx/logs
-            name: openresty-logs
-          - mountPath: /var/run/openresty
-            name: openresty-tmp
-
       priorityClassName: high-priority
-
-      securityContext:
-        runAsNonRoot: false
-        seccompProfile:
-          type: RuntimeDefault
-
-      volumes:
-        - name: nginx-cache
-          emptyDir: {}
-        - name: nginx-confd
-          emptyDir: {}
-        - name: nginx-tmp
-          emptyDir: {}
-        - name: openresty-logs
-          emptyDir: {}
-        - name: openresty-tmp
-          emptyDir: {}


### PR DESCRIPTION
## Description & motivation

Frontend could not chown within an emptyDir with `rw` permissions; suspect the user is different from the directory owner, and escalation privileges were removed.

Until I can verify this, we'll revert to the prior good state.

## Changes:

- revert frontend securityContext and mounted emptyDir volumes.

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
