### PR TITLE
Build(CircleCI): Do not run publish step for PRs from forks

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -12,7 +12,7 @@ fi
 FOLDER="${FOLDER:-packages}"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-# shellcheck disable=SC1091
+# shellcheck disable=SC1090,SC1091
 source "${SCRIPT_DIR}/common.sh"
 
 echo "Building image: ${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}"
@@ -21,5 +21,5 @@ export DOCKER_BUILDKIT=1
 
 docker build --build-arg SPECKLE_SERVER_VERSION="${IMAGE_VERSION_TAG}" --tag "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}" --file "${FOLDER}/${SPECKLE_SERVER_PACKAGE}/Dockerfile" .
 
-echo " Saving image"
+echo " Saving image: ${DOCKER_FILE_NAME}"
 docker save --output "/tmp/ci/workspace/${DOCKER_FILE_NAME}" "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}"

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -12,6 +12,7 @@ fi
 FOLDER="${FOLDER:-packages}"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}/common.sh"
 
 echo "Building image: ${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}"

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -10,27 +10,15 @@ fi
 # enables building the test-deployment container with the same script
 # defaults to packages for minimal intervention in the ci config
 FOLDER="${FOLDER:-packages}"
-SHOULD_PUBLISH="${SHOULD_PUBLISH:-false}"
 
-DOCKER_IMAGE_TAG="speckle/speckle-${SPECKLE_SERVER_PACKAGE}"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIR}/common.sh"
 
-# IMAGE_VERSION_TAG=$(./.circleci/get_version.sh)
-# if there is not image version tag, uses the SHA1 of the last git commit of the branch that triggered this build
-IMAGE_VERSION_TAG="${IMAGE_VERSION_TAG:-${CIRCLE_SHA1}}"
-echo "${IMAGE_VERSION_TAG}"
+echo "Building image: ${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}"
 
 export DOCKER_BUILDKIT=1
 
-docker build --build-arg SPECKLE_SERVER_VERSION="${IMAGE_VERSION_TAG}" -t "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}" . --file "${FOLDER}/${SPECKLE_SERVER_PACKAGE}/Dockerfile"
+docker build --build-arg SPECKLE_SERVER_VERSION="${IMAGE_VERSION_TAG}" --tag "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}" --file "${FOLDER}/${SPECKLE_SERVER_PACKAGE}/Dockerfile" .
 
-if [[ "${SHOULD_PUBLISH}" == "true" ]]; then
-  echo "publishing images"
-  docker tag "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}" "${DOCKER_IMAGE_TAG}:latest"
-
-  if [[ "${IMAGE_VERSION_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    docker tag "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}" "${DOCKER_IMAGE_TAG}:2"
-  fi
-
-  echo "${DOCKER_REG_PASS}" | docker login -u "${DOCKER_REG_USER}" --password-stdin "${DOCKER_REG_URL}"
-  docker push --all-tags "${DOCKER_IMAGE_TAG}"
-fi
+echo " Saving image"
+docker save --output "/tmp/ci/workspace/${DOCKER_FILE_NAME}" "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}"

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+DOCKER_IMAGE_TAG="speckle/speckle-${SPECKLE_SERVER_PACKAGE}"
+IMAGE_VERSION_TAG="${IMAGE_VERSION_TAG:-${CIRCLE_SHA1}}"
+DOCKER_FILE_NAME="$(echo ${DOCKER_IMAGE_TAG}_${IMAGE_VERSION_TAG} | sed -e 's/[^A-Za-z0-9._-]/_/g')"

--- a/.circleci/common.sh
+++ b/.circleci/common.sh
@@ -3,4 +3,5 @@ set -eo pipefail
 
 DOCKER_IMAGE_TAG="speckle/speckle-${SPECKLE_SERVER_PACKAGE}"
 IMAGE_VERSION_TAG="${IMAGE_VERSION_TAG:-${CIRCLE_SHA1}}"
+# shellcheck disable=SC2034,SC2086
 DOCKER_FILE_NAME="$(echo ${DOCKER_IMAGE_TAG}_${IMAGE_VERSION_TAG} | sed -e 's/[^A-Za-z0-9._-]/_/g')"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ workflows:
             - get-version
             - should-publish
             - docker-build-server
+            - pre-commit
 
       - docker-publish-frontend:
           context: *docker-hub-context
@@ -92,6 +93,7 @@ workflows:
             - get-version
             - should-publish
             - docker-build-frontend
+            - pre-commit
 
       - docker-publish-webhooks:
           context: *docker-hub-context
@@ -100,6 +102,7 @@ workflows:
             - get-version
             - should-publish
             - docker-build-webhooks
+            - pre-commit
 
       - docker-publish-file-imports:
           context: *docker-hub-context
@@ -108,6 +111,7 @@ workflows:
             - get-version
             - should-publish
             - docker-build-file-imports
+            - pre-commit
 
       - docker-publish-previews:
           context: *docker-hub-context
@@ -116,6 +120,7 @@ workflows:
             - get-version
             - should-publish
             - docker-build-previews
+            - pre-commit
 
       - docker-publish-test-container:
           context: *docker-hub-context
@@ -124,6 +129,7 @@ workflows:
             - get-version
             - should-publish
             - docker-build-test-container
+            - pre-commit
 
       - docker-publish-monitor-container:
           context: *docker-hub-context
@@ -132,6 +138,7 @@ workflows:
             - get-version
             - should-publish
             - docker-build-monitor-container
+            - pre-commit
 
       - publish-helm-chart:
           filters: &filters-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ workflows:
           filters: &filters-build
             tags:
               only: /.*/
+              ignore: /pull\/[0-9]+/
           requires:
             - test-server
             - get-version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,7 +360,6 @@ jobs:
           at: /tmp/ci/workspace
       - run: cat workspace/env-vars >> $BASH_ENV
       - run: cat workspace/should-build >> $BASH_ENV
-      - run: cat workspace/should-publish >> $BASH_ENV
       - setup_remote_docker:
           # a weird issue with yarn installing packages throwing EPERM errors
           # this fixes it

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,70 +23,115 @@ workflows:
       - pre-commit:
           filters: *filters-everything
 
-      - docker-build-and-publish-server:
-          context: &docker-hub-context
-            - docker-hub
+      - docker-build-server:
           filters: &filters-build
             tags:
               only: /.*/
+          requires:
+            - test-server
+            - get-version
+            - should-build
+
+      - docker-build-frontend:
+          filters: *filters-build
+          requires:
+            - get-version
+            - should-build
+
+      - docker-build-webhooks:
+          filters: *filters-build
+          requires:
+            - get-version
+            - test-server
+            - should-build
+
+      - docker-build-file-imports:
+          filters: *filters-build
+          requires:
+            - get-version
+            - test-server
+            - should-build
+
+      - docker-build-previews:
+          filters: *filters-build
+          requires:
+            - get-version
+            - test-server
+            - should-build
+
+      - docker-build-test-container:
+          filters: *filters-build
+          requires:
+            - get-version
+            - test-server
+            - should-build
+
+      - docker-build-monitor-container:
+          filters: *filters-build
+          requires:
+            - get-version
+            - should-build
+
+      - docker-publish-server:
+          context: &docker-hub-context
+            - docker-hub
+          filters: &filters-publish
+            branches:
               ignore: /pull\/[0-9]+/
+            tags:
+              only: /.*/
           requires:
-            - test-server
             - get-version
-            - should-build
             - should-publish
+            - docker-build-server
 
-      - docker-build-and-publish-frontend:
+      - docker-publish-frontend:
           context: *docker-hub-context
-          filters: *filters-build
+          filters: *filters-publish
           requires:
             - get-version
-            - should-build
             - should-publish
+            - docker-build-frontend
 
-      - docker-build-and-publish-webhooks:
+      - docker-publish-webhooks:
           context: *docker-hub-context
-          filters: *filters-build
+          filters: *filters-publish
           requires:
             - get-version
-            - test-server
-            - should-build
             - should-publish
+            - docker-build-webhooks
 
-      - docker-build-and-publish-file-imports:
+      - docker-publish-file-imports:
           context: *docker-hub-context
-          filters: *filters-build
+          filters: *filters-publish
           requires:
             - get-version
-            - test-server
-            - should-build
             - should-publish
+            - docker-build-file-imports
 
-      - docker-build-and-publish-previews:
+      - docker-publish-previews:
           context: *docker-hub-context
-          filters: *filters-build
+          filters: *filters-publish
           requires:
             - get-version
-            - test-server
-            - should-build
             - should-publish
+            - docker-build-previews
 
-      - docker-build-and-publish-test-container:
+      - docker-publish-test-container:
           context: *docker-hub-context
-          filters: *filters-build
+          filters: *filters-publish
           requires:
             - get-version
-            - test-server
-            - should-build
             - should-publish
+            - docker-build-test-container
 
-      - docker-build-and-publish-monitor-container:
+      - docker-publish-monitor-container:
           context: *docker-hub-context
-          filters: *filters-build
+          filters: *filters-publish
           requires:
             - get-version
-            - should-build
             - should-publish
+            - docker-build-monitor-container
 
       - publish-helm-chart:
           filters: &filters-publish
@@ -97,16 +142,15 @@ workflows:
             tags:
               only: &filters-tag /^[0-9]+\.[0-9]+\.[0-9]+$/
           requires:
-            - test-server
             - get-version
             - should-publish
-            - docker-build-and-publish-server
-            - docker-build-and-publish-frontend
-            - docker-build-and-publish-webhooks
-            - docker-build-and-publish-file-imports
-            - docker-build-and-publish-previews
-            - docker-build-and-publish-monitor-container
-            - docker-build-and-publish-test-container
+            - docker-publish-server
+            - docker-publish-frontend
+            - docker-publish-webhooks
+            - docker-publish-file-imports
+            - docker-publish-previews
+            - docker-publish-monitor-container
+            - docker-publish-test-container
 
       - publish-npm:
           filters:
@@ -305,7 +349,7 @@ jobs:
           path: packages/server/coverage/lcov-report
           destination: package/server/coverage
 
-  docker-build-and-publish: &docker-job
+  docker-build: &build-job
     docker: &docker-image
       - image: cimg/node:16.15
     resource_class: xlarge
@@ -325,40 +369,101 @@ jobs:
       - run:
           name: Build and Publish
           command: ./.circleci/build.sh
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - speckle*
 
-  docker-build-and-publish-server:
-    <<: *docker-job
+  docker-build-server:
+    <<: *build-job
     environment:
       SPECKLE_SERVER_PACKAGE: server
 
-  docker-build-and-publish-frontend:
-    <<: *docker-job
+  docker-build-frontend:
+    <<: *build-job
     environment:
       SPECKLE_SERVER_PACKAGE: frontend
 
-  docker-build-and-publish-previews:
-    <<: *docker-job
+  docker-build-previews:
+    <<: *build-job
     environment:
       SPECKLE_SERVER_PACKAGE: preview-service
 
-  docker-build-and-publish-webhooks:
-    <<: *docker-job
+  docker-build-webhooks:
+    <<: *build-job
     environment:
       SPECKLE_SERVER_PACKAGE: webhook-service
 
-  docker-build-and-publish-file-imports:
-    <<: *docker-job
+  docker-build-file-imports:
+    <<: *build-job
     environment:
       SPECKLE_SERVER_PACKAGE: fileimport-service
 
-  docker-build-and-publish-test-container:
-    <<: *docker-job
+  docker-build-test-container:
+    <<: *build-job
     environment:
       FOLDER: utils
       SPECKLE_SERVER_PACKAGE: test-deployment
 
-  docker-build-and-publish-monitor-container:
-    <<: *docker-job
+  docker-build-monitor-container:
+    <<: *build-job
+    environment:
+      FOLDER: utils
+      SPECKLE_SERVER_PACKAGE: monitor-deployment
+
+  docker-publish: &publish-job
+    docker: &base-image
+      - image: cimg/base:2022.08
+    resource_class: medium
+    working_directory: *work-dir
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/ci/workspace
+      - run: cat workspace/env-vars >> $BASH_ENV
+      - run: cat workspace/should-publish >> $BASH_ENV
+      - setup_remote_docker:
+          # a weird issue with yarn installing packages throwing EPERM errors
+          # this fixes it
+          version: 20.10.12
+          docker_layer_caching: true
+      - run:
+          name: Publish
+          command: ./.circleci/publish.sh
+
+  docker-publish-server:
+    <<: *publish-job
+    environment:
+      SPECKLE_SERVER_PACKAGE: server
+
+  docker-publish-frontend:
+    <<: *publish-job
+    environment:
+      SPECKLE_SERVER_PACKAGE: frontend
+
+  docker-publish-previews:
+    <<: *publish-job
+    environment:
+      SPECKLE_SERVER_PACKAGE: preview-service
+
+  docker-publish-webhooks:
+    <<: *publish-job
+    environment:
+      SPECKLE_SERVER_PACKAGE: webhook-service
+
+  docker-publish-file-imports:
+    <<: *publish-job
+    environment:
+      SPECKLE_SERVER_PACKAGE: fileimport-service
+
+  docker-publish-test-container:
+    <<: *publish-job
+    environment:
+      FOLDER: utils
+      SPECKLE_SERVER_PACKAGE: test-deployment
+
+  docker-publish-monitor-container:
+    <<: *publish-job
     environment:
       FOLDER: utils
       SPECKLE_SERVER_PACKAGE: monitor-deployment
@@ -407,14 +512,6 @@ jobs:
       - run:
           name: publish to npm
           command: 'yarn workspaces foreach -pv --no-private npm publish --access public'
-
-      # - run:
-      # name: commit changes
-      # command: |
-      # yarn prettier:fix
-      # git add .
-      # git commit -m '[ci skip] bump version to $IMAGE_VERSION_TAG'
-      # git push
 
   publish-helm-chart:
     docker: *docker-image

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -9,6 +9,7 @@ if [[ "${SHOULD_PUBLISH}" != "true" ]]; then
 fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}/common.sh"
 
 echo "Publishing: ${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}"

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -9,7 +9,7 @@ if [[ "${SHOULD_PUBLISH}" != "true" ]]; then
 fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-# shellcheck disable=SC1091
+# shellcheck disable=SC1090,SC1091
 source "${SCRIPT_DIR}/common.sh"
 
 echo "Publishing: ${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}"

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SHOULD_PUBLISH="${SHOULD_PUBLISH:-false}"
+
+if [[ "${SHOULD_PUBLISH}" != "true" ]]; then
+  echo "Not publishing as the SHOULD_PUBLISH environment variable is not 'true'."
+  exit 0
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIR}/common.sh"
+
+echo "Publishing: ${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}"
+
+echo "💾 Loading image"
+docker load --input "/tmp/ci/workspace/${DOCKER_FILE_NAME}"
+
+echo "🐳 Publishing image"
+docker tag "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}" "${DOCKER_IMAGE_TAG}:latest"
+
+if [[ "${IMAGE_VERSION_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  docker tag "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}" "${DOCKER_IMAGE_TAG}:2"
+fi
+
+echo "${DOCKER_REG_PASS}" | docker login -u "${DOCKER_REG_USER}" --password-stdin "${DOCKER_REG_URL}"
+docker push --all-tags "${DOCKER_IMAGE_TAG}"


### PR DESCRIPTION
## Description & motivation

Although prevented in CircleCI configuration, a more robust method of preventing context being leaked is to prevent trusted steps being run on PRs from forks.

## Changes:

Amends CircleCI to separate build jobs (which are non-trusted steps) from publish jobs (which have secrets in them).

## To-do before merge:


## Screenshots:
<img width="1067" alt="Screenshot 2022-08-17 at 17 38 20" src="https://user-images.githubusercontent.com/68657/185195136-874b2f2c-9c56-4cac-a2db-aaa03a08af9e.png">


## Validation of changes:


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References
https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/