### PR TITLE
ci(gitguardian): the matches-ignore property should be a list and not a map

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,3 +1,3 @@
 matches-ignore:
-  name: MIXPANEL_TOKEN
-  match: acd87c5a50b56df91a795e999812a3a4
+  - name: MIXPANEL_TOKEN
+    match: acd87c5a50b56df91a795e999812a3a4


### PR DESCRIPTION
## Description & motivation

Resolution provided by GitGuardian in response to https://github.com/GitGuardian/ggshield/issues/318

## Changes:

- amend .gitguardian file to comply with .gitguardian file specification

## To-do before merge:


## Screenshots:


## Validation of changes:


## Checklist:


- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

https://github.com/GitGuardian/ggshield/issues/318