### PR TITLE
fix: relaxed engine constraint for libs

### DIFF
--- a/packages/objectloader/package.json
+++ b/packages/objectloader/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/objectloader"
   },
   "engines": {
-    "node": "^16.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "lint": "eslint . --ext .js,.ts",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "engines": {
-    "node": "^16.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "build": "NODE_ENV=production rollup --config",


### PR DESCRIPTION
Since we want the libraries managed in this monorepo (viewer & objectloader) to be usable across multiple Node versions I've relaxed their "engine" constraints to support Node 14 and up.