### PR TITLE
fix(helm chart): remove unnecessary values from helm chart

### DIFF
--- a/utils/helm/speckle-server/templates/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/_helpers.tpl
@@ -100,12 +100,13 @@ Creates a network policy egress definition for connecting to Redis
 Expects the global context "$" to be passed as the parameter
 */}}
 {{- define "speckle.networkpolicy.egress.redis" -}}
-{{- $port := (default "6379" .Values.redis.networkPolicy.port ) -}}
 {{- if .Values.redis.networkPolicy.inCluster.enabled -}}
+  {{- $port := (default "6379" .Values.redis.networkPolicy.inCluster.port ) -}}
 {{ include "speckle.networkpolicy.egress.internal" (dict "podSelector" .Values.redis.networkPolicy.inCluster.kubernetes.podSelector "namespaceSelector" .Values.redis.networkPolicy.inCluster.kubernetes.namespaceSelector "port" $port) }}
 {{- else if .Values.redis.networkPolicy.externalToCluster.enabled -}}
   {{- $secret := ( include "speckle.getSecret" (dict "secret_key" "redis_url" "context" . ) ) -}}
   {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
+  {{- $port := ( default "6379" ( include "speckle.networkPolicy.portFromUrl" $secret ) ) -}}
 {{ include "speckle.networkpolicy.egress.external" (dict "ip" $domain "port" $port) }}
 {{- end -}}
 {{- end }}
@@ -116,12 +117,13 @@ Creates a Cilium Network Policy egress definition for connecting to Redis
 Expects the global context "$" to be passed as the parameter
 */}}
 {{- define "speckle.networkpolicy.egress.redis.cilium" -}}
-{{- $port := (default "6379" .Values.redis.networkPolicy.port ) -}}
 {{- if .Values.redis.networkPolicy.inCluster.enabled -}}
+  {{- $port := (default "6379" .Values.redis.networkPolicy.inCluster.port ) -}}
 {{ include "speckle.networkpolicy.egress.internal.cilium" (dict "endpointSelector" .Values.redis.networkPolicy.inCluster.cilium.endpointSelector "serviceSelector" .Values.redis.networkPolicy.inCluster.cilium.serviceSelector "port" $port) }}
 {{- else if .Values.redis.networkPolicy.externalToCluster.enabled -}}
   {{- $secret := ( include "speckle.getSecret" (dict "secret_key" "redis_url" "context" . ) ) -}}
   {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
+  {{- $port := ( default "6379" ( include "speckle.networkPolicy.portFromUrl" $secret ) ) -}}
 {{ include "speckle.networkpolicy.egress.external.cilium" (dict "ip" $domain "port" $port) }}
 {{- end -}}
 {{- end }}
@@ -130,12 +132,13 @@ Expects the global context "$" to be passed as the parameter
 Creates a Kubernetes Network Policy egress definition for connecting to Postgres
 */}}
 {{- define "speckle.networkpolicy.egress.postgres" -}}
-{{- $port := (default "5432" .Values.db.networkPolicy.port ) -}}
 {{- if .Values.db.networkPolicy.inCluster.enabled -}}
+  {{- $port := (default "5432" .Values.db.networkPolicy.inCluster.port ) -}}
 {{ include "speckle.networkpolicy.egress.internal" (dict "podSelector" .Values.db.networkPolicy.inCluster.kubernetes.podSelector "namespaceSelector" .Values.db.networkPolicy.inCluster.kubernetes.namespaceSelector "port" $port) }}
 {{- else if .Values.db.networkPolicy.externalToCluster.enabled -}}
   {{- $secret := ( include "speckle.getSecret" (dict "secret_key" "postgres_url" "context" . ) ) -}}
   {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
+  {{- $port := ( default "5432" ( include "speckle.networkPolicy.portFromUrl" $secret ) ) -}}
 {{ include "speckle.networkpolicy.egress.external" (dict "ip" $domain "port" $port) }}
 {{- end -}}
 {{- end }}
@@ -144,12 +147,13 @@ Creates a Kubernetes Network Policy egress definition for connecting to Postgres
 Creates a Cilium network policy egress definition for connecting to Postgres
 */}}
 {{- define "speckle.networkpolicy.egress.postgres.cilium" -}}
-{{- $port := (default "5432" .Values.db.networkPolicy.port ) -}}
 {{- if .Values.db.networkPolicy.inCluster.enabled -}}
+  {{- $port := (default "5432" .Values.db.networkPolicy.inCluster.port ) -}}
 {{ include "speckle.networkpolicy.egress.internal.cilium" (dict "endpointSelector" .Values.db.networkPolicy.inCluster.cilium.endpointSelector "serviceSelector" .Values.db.networkPolicy.inCluster.cilium.serviceSelector "port" $port) }}
 {{- else if .Values.db.networkPolicy.externalToCluster.enabled -}}
   {{- $secret := ( include "speckle.getSecret" (dict "secret_key" "postgres_url" "context" . ) ) -}}
   {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
+  {{- $port := ( default "5432" ( include "speckle.networkPolicy.portFromUrl" $secret ) ) -}}
 {{ include "speckle.networkpolicy.egress.external.cilium" (dict "ip" $domain "port" $port) }}
 {{- end -}}
 {{- end }}
@@ -158,26 +162,26 @@ Creates a Cilium network policy egress definition for connecting to Postgres
 Creates a Kubernetes network policy egress definition for connecting to S3 compatible storage
 */}}
 {{- define "speckle.networkpolicy.egress.blob_storage" -}}
-{{- $port := (default "443" .Values.s3.networkPolicy.port ) -}}
-{{- if .Values.s3.networkPolicy.inCluster.enabled -}}
+  {{- $port := (default "443" .Values.s3.networkPolicy.port ) -}}
+  {{- if .Values.s3.networkPolicy.inCluster.enabled -}}
 {{ include "speckle.networkpolicy.egress.internal" (dict "podSelector" .Values.s3.networkPolicy.inCluster.kubernetes.podSelector "namespaceSelector" .Values.s3.networkPolicy.inCluster.kubernetes.namespaceSelector "port" $port) }}
-{{- else if .Values.s3.networkPolicy.externalToCluster.enabled -}}
-  {{- $ip := ( include "speckle.networkPolicy.domainFromUrl" .Values.s3.endpoint ) -}}
+  {{- else if .Values.s3.networkPolicy.externalToCluster.enabled -}}
+    {{- $ip := ( include "speckle.networkPolicy.domainFromUrl" .Values.s3.endpoint ) -}}
 {{ include "speckle.networkpolicy.egress.external" (dict "ip" $ip "port" $port) }}
-{{- end -}}
+  {{- end -}}
 {{- end }}
 
 {{/*
 Creates a Cilium Network Policy egress definition for connecting to S3 compatible storage
 */}}
 {{- define "speckle.networkpolicy.egress.blob_storage.cilium" -}}
-{{- $port := (default "443" .Values.s3.networkPolicy.port ) -}}
-{{- if .Values.s3.networkPolicy.inCluster.enabled -}}
+  {{- $port := (default "443" .Values.s3.networkPolicy.port ) -}}
+  {{- if .Values.s3.networkPolicy.inCluster.enabled -}}
 {{ include "speckle.networkpolicy.egress.internal.cilium" (dict "endpointSelector" .Values.s3.networkPolicy.inCluster.cilium.endpointSelector "serviceSelector" .Values.s3.networkPolicy.inCluster.cilium.serviceSelector "port" $port) }}
-{{- else if .Values.s3.networkPolicy.externalToCluster.enabled -}}
-  {{- $host := ( include "speckle.networkPolicy.domainFromUrl" .Values.s3.endpoint ) -}}
+  {{- else if .Values.s3.networkPolicy.externalToCluster.enabled -}}
+    {{- $host := ( include "speckle.networkPolicy.domainFromUrl" .Values.s3.endpoint ) -}}
 {{ include "speckle.networkpolicy.egress.external.cilium" (dict "ip" $host "port" $port) }}
-{{- end -}}
+  {{- end -}}
 {{- end }}
 
 {{/*
@@ -404,6 +408,18 @@ Extracts the domain name from a url
 {{ printf "%s" $host }}
 {{- end }}
 
+{{/*
+Extracts the port from a url
+*/}}
+{{- define "speckle.networkPolicy.portFromUrl" -}}
+  {{- if not . -}}
+      {{- printf "\nERROR: The url was not provided as the context \"%s\"\n" . | fail -}}
+  {{- end -}}
+  {{- $host := ( urlParse . ).host -}}
+  {{- if (contains ":" $host) -}}
+{{ printf "%s" ( index (mustRegexSplit ":" $host -1) 1 ) }}
+  {{- end -}}
+{{- end }}
 {{/*
 Renders a value that contains template.
 Usage:

--- a/utils/helm/speckle-server/templates/fileimport_service/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/networkpolicy.cilium.yml
@@ -10,6 +10,7 @@ spec:
   endpointSelector:
     matchLabels:
 {{ include "fileimport_service.selectorLabels" . | indent 6 }}
+{{- if .Values.enable_prometheus_monitoring }}
   ingress:
     - fromEndpoints:
         - matchLabels:
@@ -18,6 +19,11 @@ spec:
         - ports:
             - port: "metrics"
               protocol: TCP
+{{- else }}
+  ingressDeny:
+    - fromEntities:
+      - "all"
+{{- end }}
   egress:
     - toEndpoints:
         - matchLabels:

--- a/utils/helm/speckle-server/templates/fileimport_service/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/networkpolicy.cilium.yml
@@ -30,7 +30,7 @@ spec:
           rules:
             dns:
               - matchName: {{ include "server.service.fqdn" $ }}
-{{ include "speckle.networkpolicy.dns.cilium" (list .Values.db.networkPolicy.externalToCluster) | indent 14 }}
+{{ include "speckle.networkpolicy.dns.postgres.cilium" $ | indent 14 }}
     # allow egress to speckle-server
     - toServices:
         - k8sServiceSelector:

--- a/utils/helm/speckle-server/templates/fileimport_service/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/networkpolicy.kubernetes.yml
@@ -13,6 +13,7 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+{{- if .Values.enable_prometheus_monitoring }}
   ingress:
     - from:
         - namespaceSelector:
@@ -23,6 +24,10 @@ spec:
               {{ include  "speckle.prometheus.selectorLabels.release" $ | indent 14 }}
       ports:
         - port: metrics
+{{- else }}
+  # deny all ingress
+  ingress: []
+{{- end }}
   egress:
     # allow access to DNS
     - to:

--- a/utils/helm/speckle-server/templates/monitoring/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/monitoring/networkpolicy.cilium.yml
@@ -29,7 +29,7 @@ spec:
               protocol: UDP
           rules:
             dns:
-{{ include "speckle.networkpolicy.dns.cilium" (list .Values.db.networkPolicy.externalToCluster) | indent 14 }}
+{{ include "speckle.networkpolicy.dns.postgres.cilium" $ | indent 14 }}
     # postgres
 {{ include "speckle.networkpolicy.egress.postgres.cilium" $ | indent 4 }}
 {{- end }}

--- a/utils/helm/speckle-server/templates/monitoring/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/monitoring/networkpolicy.cilium.yml
@@ -10,6 +10,7 @@ spec:
   endpointSelector:
     matchLabels:
 {{ include "monitoring.selectorLabels" . | indent 6 }}
+{{- if .Values.enable_prometheus_monitoring }}
   ingress:
     - fromEndpoints:
         - matchLabels:
@@ -18,6 +19,11 @@ spec:
         - ports:
             - port: "metrics"
               protocol: TCP
+{{- else }}
+  ingressDeny:
+    - fromEntities:
+      - "all"
+{{- end }}
   egress:
     - toEndpoints:
         - matchLabels:

--- a/utils/helm/speckle-server/templates/monitoring/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/monitoring/networkpolicy.kubernetes.yml
@@ -13,6 +13,7 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+{{- if .Values.enable_prometheus_monitoring }}
   ingress:
     - from:
         - namespaceSelector:
@@ -23,6 +24,10 @@ spec:
               {{ include  "speckle.prometheus.selectorLabels.release" $ | indent 14 }}
       ports:
         - port: metrics
+{{- else }}
+  # deny all ingress
+  ingress: []
+{{- end }}
   egress:
     # allow access to DNS
     - to:

--- a/utils/helm/speckle-server/templates/preview_service/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/preview_service/networkpolicy.cilium.yml
@@ -29,7 +29,7 @@ spec:
               protocol: UDP
           rules:
             dns:
-{{ include "speckle.networkpolicy.dns.cilium" (list .Values.db.networkPolicy.externalToCluster) | indent 14 }}
+{{ include "speckle.networkpolicy.dns.postgres.cilium" $ | indent 14 }}
     # postgres
 {{ include "speckle.networkpolicy.egress.postgres.cilium" $ | indent 4 }}
 {{- end }}

--- a/utils/helm/speckle-server/templates/preview_service/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/preview_service/networkpolicy.cilium.yml
@@ -10,6 +10,7 @@ spec:
   endpointSelector:
     matchLabels:
 {{ include "preview_service.selectorLabels" . | indent 6 }}
+{{- if .Values.enable_prometheus_monitoring }}
   ingress:
     - fromEndpoints:
         - matchLabels:
@@ -18,6 +19,11 @@ spec:
         - ports:
             - port: "metrics"
               protocol: TCP
+{{- else }}
+  ingressDeny:
+    - fromEntities:
+      - "all"
+{{- end }}
   egress:
     - toEndpoints:
         - matchLabels:

--- a/utils/helm/speckle-server/templates/preview_service/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/preview_service/networkpolicy.kubernetes.yml
@@ -13,6 +13,7 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+{{- if .Values.enable_prometheus_monitoring }}
   ingress:
     - from:
         - namespaceSelector:
@@ -23,6 +24,10 @@ spec:
               {{ include  "speckle.prometheus.selectorLabels.release" $ | indent 14 }}
       ports:
         - port: metrics
+{{- else }}
+  # deny all ingress
+  ingress: []
+{{- end }}
   egress:
     # allow access to DNS
     - to:

--- a/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
@@ -46,12 +46,13 @@ spec:
           rules:
             dns:
               # TODO: remove egress to domain once https://github.com/specklesystems/speckle-server/issues/959 is fixed
-              - matchPattern: {{ .Values.domain }}
+              - matchName: {{ .Values.domain }}
 {{- if .Values.server.sentry_dns }}
               # DNS lookup for sentry
               - matchPattern: "*.ingest.sentry.io"
 {{- end }}
-{{ include "speckle.networkpolicy.dns.cilium" (list .Values.db.networkPolicy.externalToCluster .Values.redis.networkPolicy.externalToCluster ) | indent 14 }}
+{{ include "speckle.networkpolicy.dns.postgres.cilium" $ | indent 14 }}
+{{ include "speckle.networkpolicy.dns.redis.cilium" $ | indent 14 }}
 {{ include  "speckle.networkpolicy.dns.blob_storage.cilium" $ | indent 14 }}
 {{- if .Values.server.sentry_dns }}
     # egress to sentry

--- a/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
@@ -19,6 +19,7 @@ spec:
         - ports:
             - port: http
               protocol: TCP
+{{- if .Values.enable_prometheus_monitoring }}
     - fromEndpoints:
         - matchLabels:
 {{ include "speckle.prometheus.selectorLabels" $ | indent 12 }}
@@ -26,6 +27,7 @@ spec:
         - ports:
             - port: http
               protocol: TCP
+{{- end }}
     # ingress from file import service
     - fromEndpoints:
         - matchLabels:

--- a/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
@@ -48,6 +48,7 @@ spec:
               app.kubernetes.io/name: {{ .Values.ingress.controllerName }}
       ports:
         - port: http
+{{- if .Values.enable_prometheus_monitoring }}
     # allow ingress from servicemonitor/prometheus
     - from:
         - namespaceSelector:
@@ -58,6 +59,7 @@ spec:
               {{ include  "speckle.prometheus.selectorLabels.release" $ | indent 14 }}
       ports:
         - port: http
+{{- end }}
     # allow ingress from the fileimport service
     - from:
         - podSelector:

--- a/utils/helm/speckle-server/templates/tests/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/tests/networkpolicy.cilium.yml
@@ -11,8 +11,8 @@ spec:
     matchLabels:
 {{ include "test.selectorLabels" . | indent 6 }}
   ingressDeny:
-  - fromEntities:
-    - "all"
+    - fromEntities:
+      - "all"
   egress:
     - toEndpoints:
         - matchLabels:

--- a/utils/helm/speckle-server/templates/webhook_service/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/networkpolicy.cilium.yml
@@ -31,7 +31,7 @@ spec:
             dns:
               # allow dns discoverability for all entities
               - matchPattern: "*"
-{{ include "speckle.networkpolicy.dns.cilium" (list .Values.db.networkPolicy.externalToCluster) | indent 14 }}
+{{ include "speckle.networkpolicy.dns.postgres.cilium" $ | indent 14 }}
     # postgres
 {{ include "speckle.networkpolicy.egress.postgres.cilium" $ | indent 4 }}
     # allow access to all entities outside of the cluster

--- a/utils/helm/speckle-server/templates/webhook_service/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/networkpolicy.cilium.yml
@@ -10,6 +10,7 @@ spec:
   endpointSelector:
     matchLabels:
 {{ include "webhook_service.selectorLabels" . | indent 6 }}
+{{- if .Values.enable_prometheus_monitoring }}
   ingress:
     - fromEndpoints:
         - matchLabels:
@@ -18,6 +19,11 @@ spec:
         - ports:
             - port: "metrics"
               protocol: TCP
+{{- else }}
+  ingressDeny:
+    - fromEntities:
+      - "all"
+{{- end }}
   egress:
     - toEndpoints:
         - matchLabels:

--- a/utils/helm/speckle-server/templates/webhook_service/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/networkpolicy.kubernetes.yml
@@ -13,6 +13,7 @@ spec:
   policyTypes:
     - Egress
     - Ingress
+{{- if .Values.enable_prometheus_monitoring }}
   ingress:
     - from:
         - namespaceSelector:
@@ -23,6 +24,10 @@ spec:
               {{ include  "speckle.prometheus.selectorLabels.release" $ | indent 14 }}
       ports:
         - port: metrics
+{{- else }}
+  # deny all ingress
+  ingress: []
+{{- end }}
   egress:
     # webhook can call anything external, but is blocked from egress elsewhere within the cluster
     - to:

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -230,16 +230,6 @@
                   "type": "boolean",
                   "description": "If enabled, indicates that the s3 compatible storage is hosted externally to the Kubernetes cluster",
                   "default": true
-                },
-                "host": {
-                  "type": "string",
-                  "description": "The domain name at which the s3 compatible storage is hosted.",
-                  "default": ""
-                },
-                "ipv4": {
-                  "type": "string",
-                  "description": "The IP address at which the s3 compatible storage is hosted",
-                  "default": ""
                 }
               }
             },

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -118,11 +118,6 @@
         "networkPolicy": {
           "type": "object",
           "properties": {
-            "port": {
-              "type": "string",
-              "description": "the port on the server providing the Postgres database (default: \"5432\")",
-              "default": ""
-            },
             "externalToCluster": {
               "type": "object",
               "properties": {
@@ -140,6 +135,11 @@
                   "type": "boolean",
                   "description": "If enabled, indicates that the Postgres database is hosted withing the same Kubernetes cluster in which Speckle will be deployed",
                   "default": false
+                },
+                "port": {
+                  "type": "string",
+                  "description": "the port on the server providing the Postgres database (default: \"5432\")",
+                  "default": ""
                 },
                 "kubernetes": {
                   "type": "object",
@@ -273,11 +273,6 @@
         "networkPolicy": {
           "type": "object",
           "properties": {
-            "port": {
-              "type": "string",
-              "description": "the port on the server providing the Redis store (default: \"6379\")",
-              "default": ""
-            },
             "externalToCluster": {
               "type": "object",
               "properties": {
@@ -295,6 +290,11 @@
                   "type": "boolean",
                   "description": "If enabled, indicates that the Redis store is hosted withing the same Kubernetes cluster in which Speckle will be deployed",
                   "default": false
+                },
+                "port": {
+                  "type": "string",
+                  "description": "the port on the server providing the Redis store (default: \"6379\")",
+                  "default": ""
                 },
                 "kubernetes": {
                   "type": "object",

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -130,16 +130,6 @@
                   "type": "boolean",
                   "description": "If enabled, indicates that the Postgres database is hosted externally to the Kubernetes cluster",
                   "default": true
-                },
-                "host": {
-                  "type": "string",
-                  "description": "The domain name at which the Postgres database is hosted.",
-                  "default": ""
-                },
-                "ipv4": {
-                  "type": "string",
-                  "description": "The IP address at which the Postgres database is hosted",
-                  "default": ""
                 }
               }
             },
@@ -295,16 +285,6 @@
                   "type": "boolean",
                   "description": "If enabled, indicates that the Redis store is hosted externally to the Kubernetes cluster",
                   "default": true
-                },
-                "host": {
-                  "type": "string",
-                  "description": "The domain name at which the Redis store is hosted.",
-                  "default": ""
-                },
-                "ipv4": {
-                  "type": "string",
-                  "description": "The IP address at which the Redis store is hosted",
-                  "default": ""
                 }
               }
             },

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -228,16 +228,6 @@ s3:
       ## Only one of externalToCluster or inCluster should be enabled. If both are enabled then inCluster takes precedence and is the only one deployed
       ##
       enabled: true
-      ## @param s3.networkPolicy.externalToCluster.host The domain name at which the s3 compatible storage is hosted.
-      ## This should match the value provided within the connection string.
-      ## Provide the IP address if available (use the `ipv4` parameter), as the IP address takes precedence.
-      ##
-      host: ''
-      ## @param s3.networkPolicy.externalToCluster.ipv4 The IP address at which the s3 compatible storage is hosted
-      ## This should be an IP address not within the Kubernetes Cluster Pod or Service IP ranges.
-      ## If both host and ipv4 parameters are provided, ipv4 takes precedence and host is ignored.
-      ##
-      ipv4: ''
     ## @extra s3.networkPolicy.inCluster Only required if the s3 compatible storage is hosted within the Kubernetes cluster in which Speckle will be deployed.
     ##
     inCluster:

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -132,9 +132,6 @@ db:
   ## @extra db.networkPolicy If networkPolicy is enabled for any service, this provides the NetworkPolicy with the necessary details to allow egress connections to the Postgres database
   ##
   networkPolicy:
-    ## @param db.networkPolicy.port the port on the server providing the Postgres database (default: "5432")
-    ##
-    port: ''
     ## @extra db.networkPolicy.externalToCluster Only required if the Postgres database is not hosted within the Kubernetes cluster in which Speckle will be deployed.
     ##
     externalToCluster:
@@ -149,6 +146,9 @@ db:
       ## Only one of externalToCluster or inCluster should be enabled. If both are enabled then inCluster takes precedence and is the only set of egress network policy rules deployed.
       ##
       enabled: false
+      ## @param db.networkPolicy.inCluster.port the port on the server providing the Postgres database (default: "5432")
+      ##
+      port: ''
       kubernetes:
         ## @param db.networkPolicy.inCluster.kubernetes.podSelector (Kubernetes Network Policy only) The pod Selector yaml object used to uniquely select the postgres compatible database pods within the cluster and given namespace
         ## For Kubernetes Network Policies this is a podSelector object.
@@ -264,9 +264,6 @@ redis:
   ## @extra redis.networkPolicy If networkPolicy is enabled for Speckle server, this provides the NetworkPolicy with the necessary details to allow egress connections to the Redis store
   ##
   networkPolicy:
-    ## @param redis.networkPolicy.port the port on the server providing the Redis store (default: "6379")
-    ##
-    port: ''
     ## @extra redis.networkPolicy.externalToCluster Only required if the Redis store is not hosted within the Kubernetes cluster in which Speckle will be deployed.
     ##
     externalToCluster:
@@ -281,6 +278,9 @@ redis:
       ## Only one of externalToCluster or inCluster should be enabled. If both are enabled then inCluster takes precedence and is the only set of egress network policy rules deployed.
       ##
       enabled: false
+      ## @param redis.networkPolicy.inCluster.port the port on the server providing the Redis store (default: "6379")
+      ##
+      port: ''
       kubernetes:
         ## @param redis.networkPolicy.inCluster.kubernetes.podSelector (Kubernetes Network Policy only) The pod Selector yaml object used to uniquely select the redis store pods within the cluster and given namespace
         ## For Kubernetes Network Policies this is a podSelector object.

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -142,16 +142,6 @@ db:
       ## Only one of externalToCluster or inCluster should be enabled. If both are enabled then inCluster takes precedence and is the only one deployed
       ##
       enabled: true
-      ## @param db.networkPolicy.externalToCluster.host The domain name at which the Postgres database is hosted.
-      ## This should match the value provided within the connection string.
-      ## Provide the IP address if available (use the `ipv4` parameter), as the IP address takes precedence.
-      ##
-      host: ''
-      ## @param db.networkPolicy.externalToCluster.ipv4 The IP address at which the Postgres database is hosted
-      ## This should be an IP address not within the Kubernetes Cluster Pod or Service IP ranges.
-      ## If both host and ipv4 parameters are provided, ipv4 takes precedence and host is ignored.
-      ##
-      ipv4: ''
     ## @extra db.networkPolicy.inCluster Only required if the Postgres database is hosted within the Kubernetes cluster in which Speckle will be deployed.
     ##
     inCluster:
@@ -284,16 +274,6 @@ redis:
       ## Only one of externalToCluster or inCluster should be enabled. If both are enabled then inCluster takes precedence and is the only one deployed
       ##
       enabled: true
-      ## @param redis.networkPolicy.externalToCluster.host The domain name at which the Redis store is hosted.
-      ## This should match the value provided within the connection string.
-      ## Provide the IP address if available (use the `ipv4` parameter), as the IP address takes precedence.
-      ##
-      host: ''
-      ## @param redis.networkPolicy.externalToCluster.ipv4 The IP address at which the Redis store is hosted
-      ## This should be an IP address not within the Kubernetes Cluster Pod or Service IP ranges.
-      ## If both host and ipv4 parameters are provided, ipv4 takes precedence and host is ignored.
-      ##
-      ipv4: ''
     ## @extra redis.networkPolicy.inCluster is only required if the Redis store is hosted within the Kubernetes cluster in which Speckle will be deployed.
     ##
     inCluster:


### PR DESCRIPTION
## Description & motivation

The domain name can be taken from the redis and postgres urls, so we can remove unnecessary values.  The user or service account that deploys helm must have permissions to view the secret.

Due to a copy & paste error, the PR for Cilium Network Policy introduced two additional values that are not being used for s3.  s3 can get the host or IP values from the endpoint.  This commit removes the superfluous values.

## Changes:
- removes `*.networkPolicy.externalToCluster.host` and `*.networkPolicy.externalToCluster.ip` from values.yaml
- fix: matchName for domain instead of matchPattern in speckle-server
- fix: typo in `protocol`
- fix: `"speckle.networkPolicy.domainFromUrl"` now parses domain with a port without error.
- fix: only allow monitoring ingress if monitoring is enabled.

## To-do before merge:


## Screenshots:



## Validation of changes:

Deployed to kubernetes cluster and cilium network policy manually reviewed.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References
