### PR TITLE
Helm Chart: Network Policies allow server egress to apollo

### DIFF
--- a/utils/helm/speckle-server/templates/frontend/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/frontend/networkpolicy.cilium.yml
@@ -14,7 +14,7 @@ spec:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: {{ .Values.ingress.namespace }}
-{{ include  "speckle.ingress.selector.pod" $ | indent 12 }}
+{{ include "speckle.ingress.selector.pod" $ | indent 12 }}
       toPorts:
         - ports:
             - port: "www"

--- a/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
@@ -49,6 +49,9 @@ spec:
             dns:
               # TODO: remove egress to domain once https://github.com/specklesystems/speckle-server/issues/959 is fixed
               - matchName: {{ .Values.domain }}
+{{- if .Values.server.monitoring.apollo.enabled }}
+              - matchPattern: "*.api.apollographql.com"
+{{- end }}
 {{- if .Values.server.sentry_dns }}
               # DNS lookup for sentry
               - matchPattern: "*.ingest.sentry.io"
@@ -56,6 +59,14 @@ spec:
 {{ include "speckle.networkpolicy.dns.postgres.cilium" $ | indent 14 }}
 {{ include "speckle.networkpolicy.dns.redis.cilium" $ | indent 14 }}
 {{ include  "speckle.networkpolicy.dns.blob_storage.cilium" $ | indent 14 }}
+{{- if .Values.server.monitoring.apollo.enabled }}
+    - toFQDNs:
+        - matchPattern: "*.api.apollographql.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+{{- end }}
 {{- if .Values.server.sentry_dns }}
     # egress to sentry
     - toCIDRSet:
@@ -63,6 +74,7 @@ spec:
       toPorts:
         - ports:
             - port: "443"
+              protocol: TCP
 {{- end }}
     # postgres
 {{ include "speckle.networkpolicy.egress.postgres.cilium" $ | indent 4 }}
@@ -73,7 +85,7 @@ spec:
     # allow egress to the ingress for speckle-server, so it can call itself
     # TODO: remove egress to domain once https://github.com/specklesystems/speckle-server/issues/959 is fixed
     - toFQDNs:
-        - matchPattern: {{ .Values.domain }}
+        - matchName: {{ .Values.domain }}
       toPorts:
         - ports:
           - port: "443"

--- a/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
@@ -23,6 +23,16 @@ spec:
       ports:
         - port: 53
           protocol: UDP
+{{- if .Values.server.monitoring.apollo.enabled }}
+    - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          # except to kubernetes pods or services
+          except:
+            - 10.0.0.0/8
+      ports:
+        - port: 443
+{{- end }}
 {{- if .Values.server.sentry_dns }}
     # sentry.io https://docs.sentry.io/product/security/ip-ranges/#event-ingestion
     - to:


### PR DESCRIPTION
## Description & motivation

Server Egress to Apollo was blocked even if it was enabled.

## Changes:

- fix: Cilium Network Policy allows DNS lookup of Apollo studio API.
- fix: Cilium Network Policy allows egress to FQDN for apollo
- fix: Kubernetes Network Policy allows egress to everywhere if apollo is enabled.  This is because apollo do not document which CIDR or IP address their service is available at, and kubernetes network policies do not support domain names.  We have an open support ticket with Apollo to get their CIDR, if any, so this can be limited.
- fix: explicitly define use of TCP protocol for sentry
- fix: domain should match on name, not pattern.
- tidy: remove unnecessary whitespace.

## To-do before merge:



## Screenshots:



## Validation of changes:


## Checklist:


- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References
