### PR TITLE
fix(helm chart): allow egress from server to email server

### DIFF
--- a/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
@@ -56,6 +56,10 @@ spec:
               # DNS lookup for sentry
               - matchPattern: "*.ingest.sentry.io"
 {{- end }}
+{{- if .Values.server.email.enabled }}
+              # email server
+{{ include "speckle.networkpolicy.dns.email.cilium" $ | indent 14 }}
+{{- end }}
 {{ include "speckle.networkpolicy.dns.postgres.cilium" $ | indent 14 }}
 {{ include "speckle.networkpolicy.dns.redis.cilium" $ | indent 14 }}
 {{ include  "speckle.networkpolicy.dns.blob_storage.cilium" $ | indent 14 }}
@@ -75,6 +79,10 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+{{- end }}
+{{- if .Values.server.email.enabled }}
+    # email server
+{{ include "speckle.networkpolicy.egress.email.cilium" $ | indent 4 }}
 {{- end }}
     # postgres
 {{ include "speckle.networkpolicy.egress.postgres.cilium" $ | indent 4 }}

--- a/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
@@ -41,6 +41,10 @@ spec:
       ports:
         - port: 443
 {{- end }}
+{{- if .Values.server.email.enabled }}
+    # email server
+{{ include "speckle.networkpolicy.egress.email" $ | indent 4 }}
+{{- end }}
     # redis
 {{ include "speckle.networkpolicy.egress.redis" $ | indent 4 }}
     # postgres

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -437,6 +437,61 @@
               "type": "string",
               "description": "The username with which Speckle will authenticate with the email service.",
               "default": ""
+            },
+            "networkPolicy": {
+              "type": "object",
+              "properties": {
+                "externalToCluster": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "If enabled, indicates that the email server is hosted externally to the Kubernetes cluster",
+                      "default": true
+                    }
+                  }
+                },
+                "inCluster": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "description": "If enabled, indicates that the email server is hosted withing the same Kubernetes cluster in which Speckle will be deployed",
+                      "default": false
+                    },
+                    "kubernetes": {
+                      "type": "object",
+                      "properties": {
+                        "podSelector": {
+                          "type": "object",
+                          "description": "(Kubernetes Network Policy only) The pod Selector yaml object used to uniquely select the email server pods within the cluster and given namespace",
+                          "default": {}
+                        },
+                        "namespaceSelector": {
+                          "type": "object",
+                          "description": "(Kubernetes Network Policy only) The namespace selector yaml object used to uniquely select the namespace in which the email server pods are deployed",
+                          "default": {}
+                        }
+                      }
+                    },
+                    "cilium": {
+                      "type": "object",
+                      "properties": {
+                        "endpointSelector": {
+                          "type": "object",
+                          "description": "(Cilium Network Policy only) The endpoint selector yaml object used to uniquely select the in-cluster endpoint in which the email server pods are deployed",
+                          "default": {}
+                        },
+                        "serviceSelector": {
+                          "type": "object",
+                          "description": "(Cilium Network Policy only) The service selector yaml object used to uniquely select the in-cluster service providing the email server",
+                          "default": {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         },

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -388,6 +388,49 @@ server:
     ## Note that the `email_password` is expected to be provided in the Kubernetes Secret with the name provided in the `secretName` parameter.
     ##
     username: ''
+    ## @extra server.email.networkPolicy If networkPolicy is enabled for Speckle server, this provides the Network Policy with the necessary details to allow egress connections to the email server
+    ##
+    networkPolicy:
+      ## @extra server.email.networkPolicy.externalToCluster Only required if the Redis store is not hosted within the Kubernetes cluster in which Speckle will be deployed.
+      ##
+      externalToCluster:
+        ## @param server.email.networkPolicy.externalToCluster.enabled If enabled, indicates that the email server is hosted externally to the Kubernetes cluster
+        ## Only one of externalToCluster or inCluster should be enabled. If both are enabled then inCluster takes precedence and is the only one deployed
+        ##
+        enabled: true
+      ## @extra server.email.networkPolicy.inCluster is only required if the email server is hosted within the Kubernetes cluster in which Speckle will be deployed.
+      ##
+      inCluster:
+        ## @param server.email.networkPolicy.inCluster.enabled If enabled, indicates that the email server is hosted withing the same Kubernetes cluster in which Speckle will be deployed
+        ## Only one of externalToCluster or inCluster should be enabled. If both are enabled then inCluster takes precedence and is the only set of egress network policy rules deployed.
+        ##
+        enabled: false
+        kubernetes:
+          ## @param server.email.networkPolicy.inCluster.kubernetes.podSelector (Kubernetes Network Policy only) The pod Selector yaml object used to uniquely select the email server pods within the cluster and given namespace
+          ## For Kubernetes Network Policies this is a podSelector object.
+          ## For Cilium Network Policies this is ignored.
+          ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
+          ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+          ##
+          podSelector: {}
+          ## @param server.email.networkPolicy.inCluster.kubernetes.namespaceSelector  (Kubernetes Network Policy only) The namespace selector yaml object used to uniquely select the namespace in which the email server pods are deployed
+          ## This is a Kubernetes namespaceSelector object.
+          ## For Cilium Network Policies, this is ignored
+          ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
+          ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+          ##
+          namespaceSelector: {}
+        cilium:
+          ## @param server.email.networkPolicy.inCluster.cilium.endpointSelector (Cilium Network Policy only) The endpoint selector yaml object used to uniquely select the in-cluster endpoint in which the email server pods are deployed
+          ## For Kubernetes Network Policies, this is ignored.
+          ## ref: https://docs.cilium.io/en/v1.9/policy/language/#egress
+          ## ref: https://github.com/cilium/cilium/blob/master/pkg/policy/api/selector.go
+          endpointSelector: {}
+          ## @param server.email.networkPolicy.inCluster.cilium.serviceSelector (Cilium Network Policy only) The service selector yaml object used to uniquely select the in-cluster service providing the email server
+          ## For Kubernetes Network Policies this is ignored.
+          ## ref: https://docs.cilium.io/en/v1.9/policy/language/#egress
+          ## ref: https://github.com/cilium/cilium/blob/master/pkg/policy/api/service.go
+          serviceSelector: {}
   requests:
     ## @param server.requests.cpu The CPU that should be available on a node when scheduling this pod.
     ## ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/


### PR DESCRIPTION
Network Policies omitted to allow egress to email.  This PR allows egress to email.

## Description & motivation

- fix: if email is enabled, egress is allowed through kubernetes and cilium network policies

## Changes:


## To-do before merge:



## Screenshots:



## Validation of changes:



## Checklist:


- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

