### PR TITLE
fix(helm chart server kubernetes network policy): update CIDR for Apollo

### DIFF
--- a/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
@@ -26,10 +26,7 @@ spec:
 {{- if .Values.server.monitoring.apollo.enabled }}
     - to:
       - ipBlock:
-          cidr: 0.0.0.0/0
-          # except to kubernetes pods or services
-          except:
-            - 10.0.0.0/8
+          cidr:  34.120.83.176/32
       ports:
         - port: 443
 {{- end }}


### PR DESCRIPTION
## Description & motivation

Apollo responded to our support question, they confirmed that 34.120.83.176/32 is sufficient for
egress to usage-reporting.api.apollographql.com

## Changes:

- fix: CIDR for egress to Apollo

## To-do before merge:



## Screenshots:



## Validation of changes:



## Checklist:



- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

Support request 5645