### PR TITLE
fix(helm chart): allow egress to auth providers

### DIFF
--- a/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
@@ -72,6 +72,17 @@ spec:
 {{- end }}
 {{- if .Values.server.auth.azure_ad.enabled }}
               # azure ad auth
+              - matchName: '*.login.microsoftonline.com'
+              - matchName: '*.aadcdn.msftauth.net'
+              - matchName: '*.logincdn.msftauth.net'
+              - matchName: '*.login.live.com'
+              - matchName: '*.msauth.net'
+              - matchName: '*.aadcdn.microsoftonline-p.com'
+              - matchName: '*.microsoftonline-p.com'
+              - matchName: '*.account.microsoft.com'
+              - matchName: '*.bmx.azure.com'
+              - matchName: '*.subscriptionrp.trafficmanager.net'
+              - matchName: '*.signup.azure.com'
               - matchName: 'login.microsoftonline.com'
               - matchName: 'login.windows.net'
 {{- end }}
@@ -122,6 +133,17 @@ spec:
 {{- if .Values.server.auth.azure_ad.enabled }}
     # azure ad auth
     - toFQDNs:
+        - matchName: '*.login.microsoftonline.com'
+        - matchName: '*.aadcdn.msftauth.net'
+        - matchName: '*.logincdn.msftauth.net'
+        - matchName: '*.login.live.com'
+        - matchName: '*.msauth.net'
+        - matchName: '*.aadcdn.microsoftonline-p.com'
+        - matchName: '*.microsoftonline-p.com'
+        - matchName: '*.account.microsoft.com'
+        - matchName: '*.bmx.azure.com'
+        - matchName: '*.subscriptionrp.trafficmanager.net'
+        - matchName: '*.signup.azure.com'
         - matchName: 'login.microsoftonline.com'
         - matchName: 'login.windows.net'
       toPorts:

--- a/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
@@ -72,19 +72,20 @@ spec:
 {{- end }}
 {{- if .Values.server.auth.azure_ad.enabled }}
               # azure ad auth
-              - matchName: '*.login.microsoftonline.com'
-              - matchName: '*.aadcdn.msftauth.net'
-              - matchName: '*.logincdn.msftauth.net'
-              - matchName: '*.login.live.com'
-              - matchName: '*.msauth.net'
-              - matchName: '*.aadcdn.microsoftonline-p.com'
-              - matchName: '*.microsoftonline-p.com'
-              - matchName: '*.account.microsoft.com'
-              - matchName: '*.bmx.azure.com'
-              - matchName: '*.subscriptionrp.trafficmanager.net'
-              - matchName: '*.signup.azure.com'
+              - matchPattern: '*.login.microsoftonline.com'
+              - matchPattern: '*.aadcdn.msftauth.net'
+              - matchPattern: '*.logincdn.msftauth.net'
+              - matchPattern: '*.login.live.com'
+              - matchPattern: '*.msauth.net'
+              - matchPattern: '*.aadcdn.microsoftonline-p.com'
+              - matchPattern: '*.microsoftonline-p.com'
+              - matchPattern: '*.account.microsoft.com'
+              - matchPattern: '*.bmx.azure.com'
+              - matchPattern: '*.subscriptionrp.trafficmanager.net'
+              - matchPattern: '*.signup.azure.com'
               - matchName: 'login.microsoftonline.com'
               - matchName: 'login.windows.net'
+{{ include "speckle.renderTpl" (dict "value" .Values.server.auth.azure_ad.networkPolicy.domains "context" $ ) | indent 14 }}
 {{- end }}
 {{ include "speckle.networkpolicy.dns.postgres.cilium" $ | indent 14 }}
 {{ include "speckle.networkpolicy.dns.redis.cilium" $ | indent 14 }}
@@ -133,22 +134,22 @@ spec:
 {{- if .Values.server.auth.azure_ad.enabled }}
     # azure ad auth
     - toFQDNs:
-        - matchName: '*.login.microsoftonline.com'
-        - matchName: '*.aadcdn.msftauth.net'
-        - matchName: '*.logincdn.msftauth.net'
-        - matchName: '*.login.live.com'
-        - matchName: '*.msauth.net'
-        - matchName: '*.aadcdn.microsoftonline-p.com'
-        - matchName: '*.microsoftonline-p.com'
-        - matchName: '*.account.microsoft.com'
-        - matchName: '*.bmx.azure.com'
-        - matchName: '*.subscriptionrp.trafficmanager.net'
-        - matchName: '*.signup.azure.com'
+        - matchPattern: '*.login.microsoftonline.com'
+        - matchPattern: '*.aadcdn.msftauth.net'
+        - matchPattern: '*.logincdn.msftauth.net'
+        - matchPattern: '*.login.live.com'
+        - matchPattern: '*.msauth.net'
+        - matchPattern: '*.aadcdn.microsoftonline-p.com'
+        - matchPattern: '*.microsoftonline-p.com'
+        - matchPattern: '*.account.microsoft.com'
+        - matchPattern: '*.bmx.azure.com'
+        - matchPattern: '*.subscriptionrp.trafficmanager.net'
+        - matchPattern: '*.signup.azure.com'
         - matchName: 'login.microsoftonline.com'
         - matchName: 'login.windows.net'
+{{ include "speckle.renderTpl" (dict "value" .Values.server.auth.azure_ad.additional_domains "context" $ ) | indent 8 }}
       toPorts:
-        - ports:
-            - port: '443'
+            - port: {{ default 443 .Values.server.auth.azure_ad.port | quote }}
               protocol: TCP
 {{- end }}
     # postgres

--- a/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.cilium.yml
@@ -60,6 +60,21 @@ spec:
               # email server
 {{ include "speckle.networkpolicy.dns.email.cilium" $ | indent 14 }}
 {{- end }}
+{{- if .Values.server.auth.google.enabled }}
+              # google auth
+              - matchName: 'accounts.google.com'
+              - matchName: 'www.googleapis.com'
+{{- end }}
+{{- if .Values.server.auth.github.enabled }}
+              # github auth
+              - matchName: 'github.com'
+              - matchName: 'api.github.com'
+{{- end }}
+{{- if .Values.server.auth.azure_ad.enabled }}
+              # azure ad auth
+              - matchName: 'login.microsoftonline.com'
+              - matchName: 'login.windows.net'
+{{- end }}
 {{ include "speckle.networkpolicy.dns.postgres.cilium" $ | indent 14 }}
 {{ include "speckle.networkpolicy.dns.redis.cilium" $ | indent 14 }}
 {{ include  "speckle.networkpolicy.dns.blob_storage.cilium" $ | indent 14 }}
@@ -83,6 +98,36 @@ spec:
 {{- if .Values.server.email.enabled }}
     # email server
 {{ include "speckle.networkpolicy.egress.email.cilium" $ | indent 4 }}
+{{- end }}
+{{- if .Values.server.auth.google.enabled }}
+    # google auth
+    - toFQDNs:
+        - matchName: 'accounts.google.com'
+        - matchName: 'www.googleapis.com'
+      toPorts:
+        - ports:
+            - port: '443'
+              protocol: TCP
+{{- end }}
+{{- if .Values.server.auth.github.enabled }}
+    # github auth
+    - toFQDNs:
+        - matchName: 'github.com'
+        - matchName: 'api.github.com'
+      toPorts:
+        - ports:
+            - port: '443'
+              protocol: TCP
+{{- end }}
+{{- if .Values.server.auth.azure_ad.enabled }}
+    # azure ad auth
+    - toFQDNs:
+        - matchName: 'login.microsoftonline.com'
+        - matchName: 'login.windows.net'
+      toPorts:
+        - ports:
+            - port: '443'
+              protocol: TCP
 {{- end }}
     # postgres
 {{ include "speckle.networkpolicy.egress.postgres.cilium" $ | indent 4 }}

--- a/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
@@ -33,6 +33,16 @@ spec:
       ports:
         - port: 443
 {{- end }}
+{{- if ( or .Values.server.auth.google.enabled .Values.server.auth.github.enabled .Values.server.auth.azure_ad.enabled ) }}
+    - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          # except to kubernetes pods or services
+          except:
+            - 10.0.0.0/8
+      ports:
+        - port: 443
+{{- end }}
 {{- if .Values.server.sentry_dns }}
     # sentry.io https://docs.sentry.io/product/security/ip-ranges/#event-ingestion
     - to:

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -369,6 +369,12 @@ server:
       ## @param server.auth.azure_ad.client_id This is the ID for Speckle that you have registered with Azure
       ##
       client_id: ''
+      ## @param server.auth.azure_ad.additional_domains List of `matchName` or `matchPattern` maps for domains that should be allow-listed for egress in Network Policy. https://docs.microsoft.com/en-us/azure/azure-portal/azure-portal-safelist-urls?tabs=public-cloud are enabled by default.
+      ##
+      additional_domains: []
+      ## @param server.auth.azure_ad.port Port on server to connect to. Used to allow egress in Network Policy. Defaults to 443
+      ##
+      port: 443
   ## @extra server.email Speckle can communicate with users via email, providing account verification and notification.
   ##
   email:


### PR DESCRIPTION
## Description & motivation

Helm Chart Network Policies for server are not currently allowing egress to auth providers

## Changes:

- added egress to Cilium & Kubernetes Network Policies for the server to google, github and azure_ad

## To-do before merge:

## Screenshots:


## Validation of changes:


## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References
