### PR TITLE
fix(circleci): builds commits on detached branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,9 +193,9 @@ jobs:
     docker:
       - image: cimg/base:2022.08
     working_directory: *work-dir
-    environment:
-      # £ delimited strings of regex for matches which should be published
+    environment: &publishable-tags-branches
       PUBLISHABLE_TAGS: '^[0-9]+\.[0-9]+\.[0-9]+$'
+      # £ delimited strings of regex for matches which should be published
       PUBLISHABLE_BRANCHES: '^main$£^hotfix.*£^alpha.*'
     steps:
       - checkout
@@ -215,6 +215,7 @@ jobs:
     docker:
       - image: cimg/base:2022.08
     working_directory: *work-dir
+    environment: *publishable-tags-branches
     steps:
       - checkout
       - run: mkdir -p workspace

--- a/.circleci/should_build.sh
+++ b/.circleci/should_build.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -eo pipefail
 
+IFS='£' read -r -a PUB_TAGS <<< "${PUBLISHABLE_TAGS}"
+# shellcheck disable=SC2068
+for item in ${PUB_TAGS[@]}; do
+    [[ "${CIRCLE_TAG}" =~ ${item} ]] && echo "true" && exit 0
+done
+
 # it's on the main branch
 [[ "${CIRCLE_BRANCH}" == "main" ]] && echo "true" && exit 0
 


### PR DESCRIPTION
## Description & motivation

CircleCI failed to build tagged commit as it was checked out in an orphaned state without a branch.
This commit allows tagged commits to be built.

## Changes:

- should build script will allow a build on semver tagged commits.

## To-do before merge:

None

## Screenshots:


## Validation of changes:



## Checklist:


- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

