### PR TITLE
fix(server prometheus metrics): speckle_server_apollo_calls prometheus metric should be published

### DIFF
--- a/packages/server/app.ts
+++ b/packages/server/app.ts
@@ -29,7 +29,6 @@ import { buildErrorFormatter } from '@/modules/core/graph/setup'
 import { isDevEnv, isTestEnv } from '@/modules/shared/helpers/envHelper'
 import * as ModulesSetup from '@/modules'
 import { Optional } from '@/modules/shared/helpers/typeHelper'
-import apolloPlugin from '@/logging/apolloPlugin'
 
 import { get, has, isString, toNumber } from 'lodash'
 
@@ -100,7 +99,7 @@ export function buildApolloServer(
         metricConnectedClients.dec()
       }
     },
-    plugins: [apolloPlugin],
+    plugins: [require('@/logging/apolloPlugin')],
     tracing: debug,
     introspection: true,
     playground: true,


### PR DESCRIPTION
## Description & motivation

The move from app.js to app.ts had broken `speckle_server_apollo_calls` prometheus metric and this metric was not being published.  This PR reverts the import of apolloPlugin to use the previous inline require.

## Changes:

- require apolloPlugin in server app.ts in an inline `require` call

## To-do before merge:



## Screenshots:


## Validation of changes:



## Checklist:



- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

