### PR TITLE
Vsm artifacts

### DIFF
--- a/packages/viewer-sandbox/src/Sandbox.ts
+++ b/packages/viewer-sandbox/src/Sandbox.ts
@@ -389,6 +389,30 @@ export default class Sandbox {
         this.viewer.setLightConfiguration(Sandbox.lightParams)
       })
 
+    directLightFolder
+      .addInput({bias: -0.001}, 'bias', {
+        label: 'Shadow Bias',
+        min: -0.001,
+        max: 0
+      })
+      .on('change', (value) => {
+        this.viewer.getRenderer().sunLight.shadow.bias = value.value
+        this.viewer.requestRenderShadowmap()
+        this.viewer.requestRender()
+      })
+
+    directLightFolder
+      .addInput({radius: 2}, 'radius', {
+        label: 'Shadow Radius',
+        min: 0,
+        max: 6
+      })
+      .on('change', (value) => {
+        this.viewer.getRenderer().sunLight.shadow.radius = value.value
+        this.viewer.requestRenderShadowmap()
+        this.viewer.requestRender()
+      })
+
     const indirectLightsFolder = lightsFolder.addFolder({
       title: 'Indirect',
       expanded: true

--- a/packages/viewer-sandbox/src/Sandbox.ts
+++ b/packages/viewer-sandbox/src/Sandbox.ts
@@ -390,10 +390,11 @@ export default class Sandbox {
       })
 
     directLightFolder
-      .addInput({bias: -0.001}, 'bias', {
+      .addInput({ bias: -0.001 }, 'bias', {
         label: 'Shadow Bias',
         min: -0.001,
-        max: 0
+        max: 0,
+        step: 0.00001
       })
       .on('change', (value) => {
         this.viewer.getRenderer().sunLight.shadow.bias = value.value
@@ -402,10 +403,11 @@ export default class Sandbox {
       })
 
     directLightFolder
-      .addInput({radius: 2}, 'radius', {
+      .addInput({ radius: 2 }, 'radius', {
         label: 'Shadow Radius',
         min: 0,
-        max: 6
+        max: 6,
+        step: 1
       })
       .on('change', (value) => {
         this.viewer.getRenderer().sunLight.shadow.radius = value.value

--- a/packages/viewer/src/modules/DebugViewer.ts
+++ b/packages/viewer/src/modules/DebugViewer.ts
@@ -7,4 +7,7 @@ export class DebugViewer extends Viewer {
   requestRender() {
     this.needsRender = true
   }
+  requestRenderShadowmap() {
+    this.getRenderer().updateDirectLights()
+  }
 }

--- a/packages/viewer/src/modules/SpeckleRenderer.ts
+++ b/packages/viewer/src/modules/SpeckleRenderer.ts
@@ -102,6 +102,10 @@ export default class SpeckleRenderer {
     return this.sceneBox.getCenter(new Vector3())
   }
 
+  public get sunLight() {
+    return this.sun
+  }
+
   public constructor(viewer: Viewer /** TEMPORARY */) {
     this.scene = new Scene()
     this.rootGroup = new Group()
@@ -345,10 +349,10 @@ export default class SpeckleRenderer {
     this.sun.shadow.camera.right = d
     this.sun.shadow.camera.top = d
     this.sun.shadow.camera.bottom = -d
-    this.sun.shadow.bias = 0.5
     this.sun.shadow.camera.near = 5
     this.sun.shadow.camera.far = 350
-    this.sun.shadow.bias = -0.0001
+    this.sun.shadow.bias = -0.001
+    this.sun.shadow.radius = 2
 
     this.sunTarget = new Object3D()
     this.scene.add(this.sunTarget)


### PR DESCRIPTION
# Fix for the VSM artifacts

## Description & motivation

This fixes VSM artifacts visible on some GPUs

## Changes:

- Increased the shadowmap bias
- Added slider for shadowmap bias for testing purposes
- Added slider for shadomap radius (smoothness)


## Screenshots:


## Validation of changes:

Artifacts are no longer visible on devices where they were previously visible. Needs to be checked on more devices where the artifacts were visible

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
