### PR TITLE
Only create configmap for DB certificate if certificate is provided in helm chart

### DIFF
--- a/utils/helm/speckle-server/templates/configmap-db-certificate.yml
+++ b/utils/helm/speckle-server/templates/configmap-db-certificate.yml
@@ -1,4 +1,4 @@
-{{ if .Values.db.useCertificate }}
+{{ if ( and .Values.db.useCertificate .Values.db.certificate ) }}
 
 apiVersion: v1
 kind: ConfigMap

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -117,8 +117,7 @@ db:
   ## @param db.maxConnectionsServer The number of connections to the Postgres database to provide in the connection pool
   ##
   maxConnectionsServer: 4
-  ## @param db.certificate The x509 public certificate for SSL connections to the Postgres database
-  ## Use of this certificate requires db.useCertificate to be enabled and an appropriate value for db.PGSSLMODE provided.
+  ## @param db.certificate The x509 public certificate for SSL connections to the Postgres database. Use of this certificate requires db.useCertificate to be enabled and an appropriate value for db.PGSSLMODE provided.
   ## The value must be formatted as a multi-line string.  We recommend using the pipe-symbol and taking care to
   ##  indent all lines of the value correctly.
   ## ref: https://helm.sh/docs/chart_template_guide/yaml_techniques/#strings-in-yaml


### PR DESCRIPTION
## Description & motivation

In some conditions we may wish to deploy to DB Certificate ConfigMap prior to the helm release.  In this case the `db.useCertificate` will be `true` as we wish the connection to the database to use it, but we do not wish to create the ConfigMap within the helm release.

If `db.useCertificate` is `true` and a value is provided for `db.certificate`, then a ConfigMap is created.

If `db.useCertificate` is `true` but no value is provided in the helm chart of `db.certificate`, then no ConfigMap should be created by the Helm Chart.

## Changes:

- additional logic for determining when to create the DB CA Certificate ConfigMap

## Screenshots:


## Validation of changes:

Manually tested by deploying to server with and without the `db.certificate` field being empty.
ConfigMap was deployed when field was set with a value.
ConfigMap was not deployed when the field was empty.

## Checklist:


- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

