### PR TITLE
feat(frontend): auto-save stream settings

### DIFF
--- a/packages/frontend/src/graphql/generated/graphql.ts
+++ b/packages/frontend/src/graphql/generated/graphql.ts
@@ -361,20 +361,15 @@ export type CommitDeleteInput = {
 export type CommitObjectViewerState = {
   __typename?: 'CommitObjectViewerState';
   addingComment: Scalars['Boolean'];
-  appliedFilter?: Maybe<Scalars['JSONObject']>;
-  colorLegend: Scalars['JSONObject'];
   commentReactions: Array<Scalars['String']>;
+  currentFilterState?: Maybe<Scalars['JSONObject']>;
   emojis: Array<Scalars['String']>;
-  hideCategoryKey?: Maybe<Scalars['String']>;
-  hideCategoryValues: Array<Scalars['String']>;
-  hideKey?: Maybe<Scalars['String']>;
-  hideValues: Array<Scalars['String']>;
-  isolateCategoryKey?: Maybe<Scalars['String']>;
-  isolateCategoryValues: Array<Scalars['String']>;
-  isolateKey?: Maybe<Scalars['String']>;
-  isolateValues: Array<Scalars['String']>;
+  localFilterPropKey?: Maybe<Scalars['String']>;
+  objectProperties?: Maybe<Array<Maybe<Scalars['JSONObject']>>>;
   preventCommentCollapse: Scalars['Boolean'];
+  sectionBox?: Maybe<Scalars['Boolean']>;
   selectedCommentMetaData?: Maybe<SelectedCommentMetaData>;
+  selectedObjects?: Maybe<Array<Maybe<Scalars['JSONObject']>>>;
   viewerBusy: Scalars['Boolean'];
 };
 
@@ -1862,6 +1857,27 @@ export type StreamBranchFirstCommitQueryVariables = Exact<{
 
 export type StreamBranchFirstCommitQuery = { __typename?: 'Query', stream?: { __typename?: 'Stream', id: string, branch?: { __typename?: 'Branch', commits?: { __typename?: 'CommitCollection', totalCount: number, items?: Array<{ __typename?: 'Commit', id: string, referencedObject: string } | null> | null } | null } | null } | null };
 
+export type StreamSettingsQueryVariables = Exact<{
+  id: Scalars['String'];
+}>;
+
+
+export type StreamSettingsQuery = { __typename?: 'Query', stream?: { __typename?: 'Stream', id: string, name: string, description?: string | null, isPublic: boolean, isDiscoverable: boolean, allowPublicComments: boolean, role?: string | null } | null };
+
+export type UpdateStreamSettingsMutationVariables = Exact<{
+  input: StreamUpdateInput;
+}>;
+
+
+export type UpdateStreamSettingsMutation = { __typename?: 'Mutation', streamUpdate: boolean };
+
+export type DeleteStreamMutationVariables = Exact<{
+  id: Scalars['String'];
+}>;
+
+
+export type DeleteStreamMutation = { __typename?: 'Mutation', streamDelete: boolean };
+
 export type CommonUserFieldsFragment = { __typename?: 'User', id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null, profiles?: Record<string, unknown> | null, role?: string | null, streams?: { __typename?: 'StreamCollection', totalCount: number } | null, commits?: { __typename?: 'CommitCollectionUser', totalCount: number, items?: Array<{ __typename?: 'CommitCollectionUserNode', id: string, createdAt?: string | null } | null> | null } | null };
 
 export type UserFavoriteStreamsQueryVariables = Exact<{
@@ -2479,6 +2495,29 @@ export const StreamBranchFirstCommit = gql`
   }
 }
     `;
+export const StreamSettings = gql`
+    query StreamSettings($id: String!) {
+  stream(id: $id) {
+    id
+    name
+    description
+    isPublic
+    isDiscoverable
+    allowPublicComments
+    role
+  }
+}
+    `;
+export const UpdateStreamSettings = gql`
+    mutation UpdateStreamSettings($input: StreamUpdateInput!) {
+  streamUpdate(stream: $input)
+}
+    `;
+export const DeleteStream = gql`
+    mutation DeleteStream($id: String!) {
+  streamDelete(id: $id)
+}
+    `;
 export const UserFavoriteStreams = gql`
     query UserFavoriteStreams($cursor: String) {
   user {
@@ -2718,6 +2757,9 @@ export const LeaveStreamDocument = {"kind":"Document","definitions":[{"kind":"Op
 export const UpdateStreamPermissionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateStreamPermission"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"params"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"StreamUpdatePermissionInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"streamUpdatePermission"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"permissionParams"},"value":{"kind":"Variable","name":{"kind":"Name","value":"params"}}}]}]}}]} as unknown as DocumentNode<UpdateStreamPermissionMutation, UpdateStreamPermissionMutationVariables>;
 export const StreamFirstCommitDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"StreamFirstCommit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"stream"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"commits"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"referencedObject"}}]}}]}}]}}]}}]} as unknown as DocumentNode<StreamFirstCommitQuery, StreamFirstCommitQueryVariables>;
 export const StreamBranchFirstCommitDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"StreamBranchFirstCommit"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"branch"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"stream"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"branch"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"branch"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"commits"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"referencedObject"}}]}}]}}]}}]}}]}}]} as unknown as DocumentNode<StreamBranchFirstCommitQuery, StreamBranchFirstCommitQueryVariables>;
+export const StreamSettingsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"StreamSettings"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"stream"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"isPublic"}},{"kind":"Field","name":{"kind":"Name","value":"isDiscoverable"}},{"kind":"Field","name":{"kind":"Name","value":"allowPublicComments"}},{"kind":"Field","name":{"kind":"Name","value":"role"}}]}}]}}]} as unknown as DocumentNode<StreamSettingsQuery, StreamSettingsQueryVariables>;
+export const UpdateStreamSettingsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateStreamSettings"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"StreamUpdateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"streamUpdate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"stream"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}]}]}}]} as unknown as DocumentNode<UpdateStreamSettingsMutation, UpdateStreamSettingsMutationVariables>;
+export const DeleteStreamDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteStream"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"streamDelete"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteStreamMutation, DeleteStreamMutationVariables>;
 export const UserFavoriteStreamsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserFavoriteStreams"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonUserFields"}},{"kind":"Field","name":{"kind":"Name","value":"favoriteStreams"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"cursor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}}},{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"IntValue","value":"10"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonStreamFields"}}]}}]}}]}}]}},...CommonUserFieldsFragmentDoc.definitions,...CommonStreamFieldsFragmentDoc.definitions]} as unknown as DocumentNode<UserFavoriteStreamsQuery, UserFavoriteStreamsQueryVariables>;
 export const MainUserDataDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MainUserData"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonUserFields"}}]}}]}},...CommonUserFieldsFragmentDoc.definitions]} as unknown as DocumentNode<MainUserDataQuery, MainUserDataQueryVariables>;
 export const ExtraUserDataDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ExtraUserData"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonUserFields"}},{"kind":"Field","name":{"kind":"Name","value":"totalOwnedStreamsFavorites"}}]}}]}},...CommonUserFieldsFragmentDoc.definitions]} as unknown as DocumentNode<ExtraUserDataQuery, ExtraUserDataQueryVariables>;

--- a/packages/frontend/src/graphql/streams.js
+++ b/packages/frontend/src/graphql/streams.js
@@ -161,3 +161,29 @@ export const streamBranchFirstCommitQuery = gql`
     }
   }
 `
+
+export const streamSettingsQuery = gql`
+  query StreamSettings($id: String!) {
+    stream(id: $id) {
+      id
+      name
+      description
+      isPublic
+      isDiscoverable
+      allowPublicComments
+      role
+    }
+  }
+`
+
+export const updateStreamSettingsMutation = gql`
+  mutation UpdateStreamSettings($input: StreamUpdateInput!) {
+    streamUpdate(stream: $input)
+  }
+`
+
+export const deleteStreamMutation = gql`
+  mutation DeleteStream($id: String!) {
+    streamDelete(id: $id)
+  }
+`

--- a/packages/frontend/src/main/lib/common/general/helpers/errorHelper.ts
+++ b/packages/frontend/src/main/lib/common/general/helpers/errorHelper.ts
@@ -1,0 +1,14 @@
+import { BaseError } from '@/helpers/errorHelper'
+
+class UnexpectedErrorStructureError extends BaseError {
+  static defaultMessage = 'An unexpected error type was thrown'
+}
+
+/**
+ * In JS catch clauses can receive not only Errors, but pretty much any other kind of data type, so
+ * you can use this helper to ensure that whatever is passed in is a real error
+ */
+export function ensureError(e: Error | unknown, fallbackMessage?: string): Error {
+  if (e instanceof Error) return e
+  return new UnexpectedErrorStructureError(fallbackMessage)
+}

--- a/packages/frontend/src/main/pages/stream/TheSettings.vue
+++ b/packages/frontend/src/main/pages/stream/TheSettings.vue
@@ -20,7 +20,7 @@
       </div>
     </portal>
     <v-row v-if="stream">
-      <v-col v-if="stream.role !== 'stream:owner'" cols="12">
+      <v-col v-if="isEditNotAuthorized" cols="12">
         <v-alert type="warning">
           Your permission level ({{ stream.role ? stream.role : 'none' }}) is not high
           enough to edit this stream's details.
@@ -36,44 +36,44 @@
             <v-form ref="form" v-model="valid" class="px-2" @submit.prevent="save">
               <h2>Name and description</h2>
               <v-text-field
-                v-model="name"
+                v-model="model.name"
                 :rules="validation.nameRules"
                 label="Name"
                 hint="The name of this stream."
                 class="mt-5"
-                :disabled="stream.role !== 'stream:owner'"
+                :disabled="isEditDisabled"
               />
               <v-text-field
-                v-model="description"
+                v-model="model.description"
                 label="Description"
                 hint="The description of this stream."
                 class="mt-5"
-                :disabled="stream.role !== 'stream:owner'"
+                :disabled="isEditDisabled"
               />
               <h2>Privacy</h2>
               <stream-visibility-toggle
                 :disabled="isEditDisabled"
-                :is-public.sync="isPublic"
-                :is-discoverable.sync="isDiscoverable"
+                :is-public.sync="model.isPublic"
+                :is-discoverable.sync="model.isDiscoverable"
               />
               <br />
               <h2>Comments</h2>
               <v-switch
-                v-model="allowPublicComments"
+                v-model="model.allowPublicComments"
                 inset
                 class="mt-5"
                 :label="
-                  allowPublicComments
+                  model.allowPublicComments
                     ? 'Anyone can comment'
                     : 'Only collaborators can comment'
                 "
                 :hint="
-                  allowPublicComments
+                  model.allowPublicComments
                     ? 'Any signed in user can leave a comment; the stream needs to be public.'
                     : 'Only collaborators can comment.'
                 "
                 persistent-hint
-                :disabled="stream.role !== 'stream:owner'"
+                :disabled="isEditDisabled"
               />
             </v-form>
           </v-card-text>
@@ -91,7 +91,7 @@
           </v-card-actions>
         </section-card>
       </v-col>
-      <v-col cols="12">
+      <v-col v-if="!isEditNotAuthorized" cols="12">
         <section-card :expand="true">
           <template #header>Danger Zone</template>
 
@@ -102,7 +102,7 @@
                 fab
                 dark
                 small
-                :disabled="stream.role !== 'stream:owner'"
+                :disabled="isEditDisabled"
                 @click="deleteDialog = true"
               >
                 <v-icon>mdi-delete-forever</v-icon>
@@ -147,7 +147,6 @@
               ></v-text-field>
             </v-card-text>
             <v-card-actions>
-              <!-- <v-btn text color="primary" @click="deleteDialog = false">Cancel</v-btn> -->
               <v-btn
                 block
                 class="mr-3"
@@ -165,157 +164,272 @@
   </v-container>
 </template>
 
-<script>
-import { gql } from '@apollo/client/core'
-import {
-  STANDARD_PORTAL_KEYS,
-  buildPortalStateMixin
-} from '@/main/utils/portalStateManager'
+<script lang="ts">
+import { STANDARD_PORTAL_KEYS, usePortalState } from '@/main/utils/portalStateManager'
 import SectionCard from '@/main/components/common/SectionCard.vue'
 import StreamVisibilityToggle from '@/main/components/stream/editor/StreamVisibilityToggle.vue'
+import { required } from '@/main/lib/common/vuetify/validators'
+import { computed, defineComponent, ref, watch } from 'vue'
+import { Nullable } from '@/helpers/typeHelpers'
+import {
+  StreamSettingsDocument,
+  StreamSettingsQuery,
+  UpdateStreamSettingsDocument,
+  DeleteStreamDocument
+} from '@/graphql/generated/graphql'
+import { useApolloClient, useQuery } from '@vue/apollo-composable'
+import { useRoute, useRouter } from '@/main/lib/core/composables/router'
+import type { Get } from 'type-fest'
+import { debounce } from 'lodash'
+import { Roles } from '@/helpers/mainConstants'
+import { useMixpanel } from '@/main/lib/core/composables/core'
+import { useGlobalToast } from '@/main/lib/core/composables/notifications'
+import {
+  convertThrowIntoFetchResult,
+  getCacheId,
+  getFirstErrorMessage,
+  updateCacheByFilter
+} from '@/main/lib/common/apollo/helpers/apolloOperationHelper'
 
-export default {
+type ModelType = {
+  name: string
+  description: Nullable<string>
+  isPublic: boolean
+  isDiscoverable: boolean
+  allowPublicComments: boolean
+}
+
+type StreamType = Get<StreamSettingsQuery, 'stream'>
+
+export default defineComponent({
   name: 'TheSettings',
   components: {
     SectionCard,
     StreamVisibilityToggle
   },
-  mixins: [buildPortalStateMixin([STANDARD_PORTAL_KEYS.Toolbar], 'stream-settings', 1)],
-  apollo: {
-    stream: {
-      query: gql`
-        query Stream($id: String!) {
-          stream(id: $id) {
-            id
-            name
-            description
-            isPublic
-            isDiscoverable
-            allowPublicComments
-            role
-          }
-        }
-      `,
-      variables() {
+  setup() {
+    const router = useRouter()
+    const route = useRoute()
+    const mixpanel = useMixpanel()
+    const apollo = useApolloClient().client
+    const { triggerNotification } = useGlobalToast()
+
+    const { canRenderToolbarPortal } = usePortalState(
+      [STANDARD_PORTAL_KEYS.Toolbar],
+      'stream-settings',
+      1
+    )
+
+    const buildModelFromStream = (stream: StreamType): ModelType => {
+      if (!stream)
         return {
-          id: this.$route.params.streamId
+          name: '',
+          description: null,
+          isPublic: true,
+          isDiscoverable: false,
+          allowPublicComments: true
         }
-      },
 
-      update(data) {
-        const stream = data.stream
-        if (stream)
-          ({
-            name: this.name,
-            description: this.description,
-            isPublic: this.isPublic,
-            isDiscoverable: this.isDiscoverable,
-            allowPublicComments: this.allowPublicComments
-          } = stream)
-
-        return stream
+      return {
+        name: stream.name,
+        description: stream.description || '',
+        isPublic: stream.isPublic,
+        isDiscoverable: stream.isDiscoverable,
+        allowPublicComments: stream.allowPublicComments
       }
     }
-  },
-  data: () => ({
-    snackbar: false,
-    loading: false,
-    loadingDelete: false,
-    valid: false,
-    name: null,
-    deleteDialog: false,
-    streamNameConfirm: '',
-    description: null,
-    isPublic: true,
-    isDiscoverable: false,
-    allowPublicComments: true,
-    validation: {
-      nameRules: [(v) => !!v || 'A stream must have a name!']
-    }
-  }),
-  computed: {
-    canSave() {
-      return (
-        !this.isEditDisabled &&
-        this.valid &&
-        (this.name !== this.stream.name ||
-          this.description !== this.stream.description ||
-          this.isPublic !== this.stream.isPublic ||
-          this.allowPublicComments !== this.stream.allowPublicComments ||
-          this.isDiscoverable !== this.stream.isDiscoverable)
-      )
-    },
-    isEditDisabled() {
-      return this.stream?.role !== 'stream:owner'
-    }
-  },
-  watch: {
-    allowPublicComments(newVal) {
-      if (newVal && !this.isPublic) this.isPublic = true
-    },
-    isPublic(newVal) {
-      if (!newVal && this.allowPublicComments) this.allowPublicComments = false
-    }
-  },
-  methods: {
-    async save() {
-      this.loading = true
-      this.$mixpanel.track('Stream Action', { type: 'action', name: 'update' })
-      try {
-        await this.$apollo.mutate({
-          mutation: gql`
-            mutation editDescription($input: StreamUpdateInput!) {
-              streamUpdate(stream: $input)
-            }
-          `,
+
+    const save = async () => {
+      if (!stream.value || !canSave.value) return
+
+      const streamId = stream.value.id
+      loading.value = true
+      mixpanel.track('Stream Action', { type: 'action', name: 'update' })
+
+      const result = await apollo
+        .mutate({
+          mutation: UpdateStreamSettingsDocument,
           variables: {
             input: {
-              id: this.stream.id,
-              name: this.name,
-              description: this.description,
-              isPublic: this.isPublic,
-              allowPublicComments: this.allowPublicComments,
-              isDiscoverable: this.isDiscoverable
+              id: streamId,
+              ...model.value
             }
+          },
+          update: (cache, { data }) => {
+            if (!data?.streamUpdate) return
+
+            updateCacheByFilter(
+              cache,
+              {
+                query: {
+                  query: StreamSettingsDocument,
+                  variables: { id: streamId }
+                }
+              },
+              (res) => {
+                if (!res.stream) return
+
+                return {
+                  ...res,
+                  stream: {
+                    ...res.stream,
+                    ...model.value
+                  }
+                }
+              }
+            )
           }
         })
-        this.$eventHub.$emit('notification', {
-          text: 'Stream updated.'
-        })
-      } catch (e) {
-        this.$eventHub.$emit('notification', {
-          text: e.message
+        .catch(convertThrowIntoFetchResult)
+
+      if (result.data?.streamUpdate) {
+        triggerNotification({ text: 'Stream updated' })
+      } else {
+        triggerNotification({
+          text: getFirstErrorMessage(result.errors),
+          type: 'error'
         })
       }
 
-      this.$apollo.queries.stream.refetch()
-      this.loading = false
-    },
-    async deleteStream() {
-      this.$mixpanel.track('Stream Action', { type: 'action', name: 'delete' })
-      this.loadingDelete = true
-      try {
-        await this.$apollo.mutate({
-          mutation: gql`
-            mutation deleteStream($id: String!) {
-              streamDelete(id: $id)
-            }
-          `,
+      loading.value = false
+    }
+
+    const deleteStream = async () => {
+      if (!stream.value || isEditDisabled.value) return
+
+      mixpanel.track('Stream Action', { type: 'action', name: 'delete' })
+      loading.value = true
+      const streamId = stream.value.id
+
+      const result = await apollo
+        .mutate({
+          mutation: DeleteStreamDocument,
           variables: {
-            id: this.stream.id
+            id: streamId
+          },
+          update: (cache, { data }) => {
+            if (!data?.streamDelete) return
+
+            cache.evict({
+              id: getCacheId('Stream', streamId)
+            })
           }
         })
-        this.$eventHub.$emit('notification', {
+        .catch(convertThrowIntoFetchResult)
+
+      if (result.data?.streamDelete) {
+        triggerNotification({
           text: 'Stream deleted.'
         })
-      } catch (e) {
-        this.$eventHub.$emit('notification', {
-          text: e.message
+      } else {
+        triggerNotification({
+          text: getFirstErrorMessage(result.errors),
+          type: 'error'
         })
       }
-      this.deleteDialog = false
-      this.$router.push({ path: '/streams?refresh=true' })
+
+      loading.value = false
+      deleteDialog.value = false
+      router.push({ path: '/streams?refresh=true' })
+    }
+
+    const model = ref<ModelType>({
+      name: '',
+      description: null,
+      isPublic: true,
+      isDiscoverable: false,
+      allowPublicComments: true
+    })
+    const snackbar = ref(false)
+    const loading = ref(false)
+    const valid = ref(false)
+    const deleteDialog = ref(false)
+    const streamNameConfirm = ref('')
+    const validation = {
+      nameRules: [required('A stream must have a name!')]
+    }
+
+    const { result: streamSettingsResult } = useQuery(StreamSettingsDocument, () => ({
+      id: route.params.streamId as string
+    }))
+
+    const stream = computed(
+      (): StreamType => streamSettingsResult.value?.stream || null
+    )
+    const oldModel = computed(() => buildModelFromStream(stream.value))
+    const isEditNotAuthorized = computed(
+      () => stream.value?.role !== Roles.Stream.Owner
+    )
+    const isEditDisabled = computed(() => isEditNotAuthorized.value || loading.value)
+    const changesExist = computed(() => {
+      const keys = Object.keys(model.value) as Array<keyof ModelType>
+      for (const key of keys) {
+        const oldVal = oldModel.value[key]
+        const newVal = model.value[key]
+
+        if (oldVal !== newVal) return true
+      }
+
+      return false
+    })
+    const canSave = computed(
+      () => !isEditDisabled.value && valid.value && changesExist.value
+    )
+
+    // re-init form when stream refreshed
+    watch(
+      stream,
+      (newStream) => {
+        model.value = buildModelFromStream(newStream)
+      },
+      { immediate: true }
+    )
+
+    // if public comments enabled, enable isPublic as well
+    watch(
+      () => model.value.allowPublicComments,
+      (allowComments) => {
+        if (allowComments && !model.value.isPublic) model.value.isPublic = true
+      }
+    )
+
+    // if isPublic disabled, disabled allowPublicComments as well
+    watch(
+      () => model.value.isPublic,
+      (isPublic) => {
+        if (!isPublic && model.value.allowPublicComments)
+          model.value.allowPublicComments = false
+      }
+    )
+
+    // auto-save
+    watch(
+      model,
+      debounce(() => {
+        save()
+      }, 1000),
+      { deep: true }
+    )
+
+    return {
+      canRenderToolbarPortal,
+      stream,
+      model,
+      buildModelFromStream,
+      snackbar,
+      loading,
+      valid,
+      deleteDialog,
+      streamNameConfirm,
+      validation,
+      changesExist,
+      oldModel,
+      canSave,
+      isEditNotAuthorized,
+      isEditDisabled,
+      save,
+      deleteStream
     }
   }
-}
+})
 </script>


### PR DESCRIPTION
closes #981 
closes #838 

- refactored TheSettings.vue and optimized Apollo Cache usage to cut down on HTTP requests
- made the settings page auto-save pages