### PR TITLE
feat(helm chart): secrets can be referenced from different kubernetes Secret resources

### DIFF
--- a/utils/helm/speckle-server/templates/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/_helpers.tpl
@@ -104,7 +104,7 @@ Expects the global context "$" to be passed as the parameter
   {{- $port := (default "6379" .Values.redis.networkPolicy.inCluster.port ) -}}
 {{ include "speckle.networkpolicy.egress.internal" (dict "podSelector" .Values.redis.networkPolicy.inCluster.kubernetes.podSelector "namespaceSelector" .Values.redis.networkPolicy.inCluster.kubernetes.namespaceSelector "port" $port) }}
 {{- else if .Values.redis.networkPolicy.externalToCluster.enabled -}}
-  {{- $secret := ( include "speckle.getSecret" (dict "secret_key" "redis_url" "context" . ) ) -}}
+  {{- $secret := ( include "speckle.getSecret" (dict "secret_name" (default .Values.secretName .Values.redis.connectionString.secretName) "secret_key" (default "redis_url" .Values.redis.connectionString.secretKey) "context" . ) ) -}}
   {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
   {{- $port := ( default "6379" ( include "speckle.networkPolicy.portFromUrl" $secret ) ) -}}
 {{ include "speckle.networkpolicy.egress.external" (dict "ip" $domain "port" $port) }}
@@ -121,7 +121,7 @@ Expects the global context "$" to be passed as the parameter
   {{- $port := (default "6379" .Values.redis.networkPolicy.inCluster.port ) -}}
 {{ include "speckle.networkpolicy.egress.internal.cilium" (dict "endpointSelector" .Values.redis.networkPolicy.inCluster.cilium.endpointSelector "serviceSelector" .Values.redis.networkPolicy.inCluster.cilium.serviceSelector "port" $port) }}
 {{- else if .Values.redis.networkPolicy.externalToCluster.enabled -}}
-  {{- $secret := ( include "speckle.getSecret" (dict "secret_key" "redis_url" "context" . ) ) -}}
+  {{- $secret := ( include "speckle.getSecret" (dict "secret_name" (default .Values.secretName .Values.redis.connectionString.secretName) "secret_key" (default "redis_url" .Values.redis.connectionString.secretKey) "context" . ) ) -}}
   {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
   {{- $port := ( default "6379" ( include "speckle.networkPolicy.portFromUrl" $secret ) ) -}}
 {{ include "speckle.networkpolicy.egress.external.cilium" (dict "ip" $domain "port" $port) }}
@@ -136,7 +136,7 @@ Creates a Kubernetes Network Policy egress definition for connecting to Postgres
   {{- $port := (default "5432" .Values.db.networkPolicy.inCluster.port ) -}}
 {{ include "speckle.networkpolicy.egress.internal" (dict "podSelector" .Values.db.networkPolicy.inCluster.kubernetes.podSelector "namespaceSelector" .Values.db.networkPolicy.inCluster.kubernetes.namespaceSelector "port" $port) }}
 {{- else if .Values.db.networkPolicy.externalToCluster.enabled -}}
-  {{- $secret := ( include "speckle.getSecret" (dict "secret_key" "postgres_url" "context" . ) ) -}}
+  {{- $secret := ( include "speckle.getSecret" (dict "secret_name" (default .Values.secretName .Values.db.connectionString.secretName) "secret_key" (default "postgres_url" .Values.db.connectionString.secretKey) "context" . ) ) -}}
   {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
   {{- $port := ( default "5432" ( include "speckle.networkPolicy.portFromUrl" $secret ) ) -}}
 {{ include "speckle.networkpolicy.egress.external" (dict "ip" $domain "port" $port) }}
@@ -151,7 +151,7 @@ Creates a Cilium network policy egress definition for connecting to Postgres
   {{- $port := (default "5432" .Values.db.networkPolicy.inCluster.port ) -}}
 {{ include "speckle.networkpolicy.egress.internal.cilium" (dict "endpointSelector" .Values.db.networkPolicy.inCluster.cilium.endpointSelector "serviceSelector" .Values.db.networkPolicy.inCluster.cilium.serviceSelector "port" $port) }}
 {{- else if .Values.db.networkPolicy.externalToCluster.enabled -}}
-  {{- $secret := ( include "speckle.getSecret" (dict "secret_key" "postgres_url" "context" . ) ) -}}
+  {{- $secret := ( include "speckle.getSecret" (dict "secret_name" (default .Values.secretName .Values.db.connectionString.secretName) "secret_key" (default "postgres_url" .Values.db.connectionString.secretKey) "context" . ) ) -}}
   {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
   {{- $port := ( default "5432" ( include "speckle.networkPolicy.portFromUrl" $secret ) ) -}}
 {{ include "speckle.networkpolicy.egress.external.cilium" (dict "ip" $domain "port" $port) }}
@@ -223,7 +223,7 @@ Params:
   - context - Required, global context should be provided.
 */}}
 {{- define "speckle.networkpolicy.dns.postgres.cilium" -}}
-{{- $secret := ( include "speckle.getSecret" (dict "secret_key" "postgres_url" "context" . ) ) -}}
+{{- $secret := ( include "speckle.getSecret" (dict "secret_name" (default .Values.secretName .Values.db.connectionString.secretName) "secret_key" (default "postgres_url" .Values.db.connectionString.secretKey) "context" . ) ) -}}
 {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
   {{- if (and .Values.db.networkPolicy.externalToCluster.enabled ( ne ( include "speckle.isIPv4" $domain ) "true" ) ) -}}
 {{ include "speckle.networkpolicy.matchNameOrPattern" $domain }}
@@ -240,7 +240,7 @@ Params:
   - context - Required, global context should be provided.
 */}}
 {{- define "speckle.networkpolicy.dns.redis.cilium" -}}
-{{- $secret := ( include "speckle.getSecret" (dict "secret_key" "redis_url" "context" . ) ) -}}
+{{- $secret := ( include "speckle.getSecret" (dict "secret_name" (default .Values.secretName .Values.db.connectionString.secretName) "secret_key" (default "postgres_url" .Values.db.connectionString.secretKey) "context" . ) ) -}}
 {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
   {{- if (and .Values.redis.networkPolicy.externalToCluster.enabled ( ne ( include "speckle.isIPv4" $domain ) "true" ) ) -}}
 {{ include "speckle.networkpolicy.matchNameOrPattern" $domain }}
@@ -504,14 +504,14 @@ app.kubernetes.io/name: {{ .Values.ingress.controllerName }}
 Retrieves an existing secret
 
 Usage:
-{{ include "speckle.getSecret" (dict "secret_key" "postgres_url" "context" $ )}}
+{{ include "speckle.getSecret" (dict  "secret_name" "server-vars" "secret_key" "postgres_url" "context" $ )}}
 
 Params:
   - secret_key - Required, the key within the secret.
   - context - Required, must be global context.  Values of global context must include 'namespace' and 'secretName' keys.
 */}}
 {{- define "speckle.getSecret" -}}
-{{- $secretResource := (lookup "v1" "Secret" .context.Values.namespace .context.Values.secretName ) -}}
+{{- $secretResource := (lookup "v1" "Secret" .context.Values.namespace .secret_name ) -}}
 {{- $secret := ( index $secretResource.data .secret_key ) -}}
 {{- $secretDecoded := (b64dec $secret) -}}
 {{- printf "%s" $secretDecoded }}

--- a/utils/helm/speckle-server/templates/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/_helpers.tpl
@@ -240,7 +240,7 @@ Params:
   - context - Required, global context should be provided.
 */}}
 {{- define "speckle.networkpolicy.dns.redis.cilium" -}}
-{{- $secret := ( include "speckle.getSecret" (dict "secret_name" (default .Values.secretName .Values.db.connectionString.secretName) "secret_key" (default "postgres_url" .Values.db.connectionString.secretKey) "context" . ) ) -}}
+{{- $secret := ( include "speckle.getSecret" (dict "secret_name" (default .Values.secretName .Values.redis.connectionString.secretName) "secret_key" (default "redis_url" .Values.redis.connectionString.secretKey) "context" . ) ) -}}
 {{- $domain := ( include "speckle.networkPolicy.domainFromUrl" $secret ) -}}
   {{- if (and .Values.redis.networkPolicy.externalToCluster.enabled ( ne ( include "speckle.isIPv4" $domain ) "true" ) ) -}}
 {{ include "speckle.networkpolicy.matchNameOrPattern" $domain }}

--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -71,8 +71,8 @@ spec:
           - name: PG_CONNECTION_STRING
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: postgres_url
+                name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
+                key: {{ default "postgres_url" .Values.db.connectionString.secretKey }}
 
           - name: DEBUG
             value: "fileimport-service:*"

--- a/utils/helm/speckle-server/templates/fileimport_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/serviceaccount.yml
@@ -10,5 +10,5 @@ metadata:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
 secrets:
-  - name: {{ .Values.secretName }}
+  - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
 {{- end -}}

--- a/utils/helm/speckle-server/templates/monitoring/deployment.yml
+++ b/utils/helm/speckle-server/templates/monitoring/deployment.yml
@@ -56,8 +56,8 @@ spec:
           - name: PG_CONNECTION_STRING
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: postgres_url
+                name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
+                key: {{ default "postgres_url" .Values.db.connectionString.secretKey }}
 
           {{- if .Values.db.useCertificate }}
           - name: NODE_EXTRA_CA_CERTS

--- a/utils/helm/speckle-server/templates/monitoring/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/monitoring/serviceaccount.yml
@@ -10,5 +10,5 @@ metadata:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
 secrets:
-  - name: {{ .Values.secretName }}
+  - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
 {{- end -}}

--- a/utils/helm/speckle-server/templates/preview_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/preview_service/deployment.yml
@@ -67,8 +67,8 @@ spec:
           - name: PG_CONNECTION_STRING
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: postgres_url
+                name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
+                key: {{ default "postgres_url" .Values.db.connectionString.secretKey }}
 
           - name: DEBUG
             value: "preview-service:*"

--- a/utils/helm/speckle-server/templates/preview_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/preview_service/serviceaccount.yml
@@ -10,5 +10,5 @@ metadata:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
 secrets:
-  - name: {{ .Values.secretName }}
+  - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
 {{- end -}}

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -109,7 +109,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ default .Values.secretName .Values.redis.connectionString.secretName }}
-                key: {{ default "redis_url" .Values.redis.connectionString.secretName }}
+                key: {{ default "redis_url" .Values.redis.connectionString.secretKey }}
 
           # *** PostgreSQL Database ***
           - name: POSTGRES_URL

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -98,8 +98,8 @@ spec:
           - name: SESSION_SECRET
             valueFrom:
               secretKeyRef:
-                name: "{{ .Values.secretName }}"
-                key: session_secret
+                name: "{{ default .Values.secretName .Values.server.sessionSecret.secretName }}"
+                key: {{ default "session_secret" .Values.server.sessionSecret.secretKey }}
 
           - name: FILE_SIZE_LIMIT_MB
             value: {{ .Values.file_size_limit_mb | quote }}
@@ -108,15 +108,15 @@ spec:
           - name: REDIS_URL
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: redis_url
+                name: {{ default .Values.secretName .Values.redis.connectionString.secretName }}
+                key: {{ default "redis_url" .Values.redis.connectionString.secretName }}
 
           # *** PostgreSQL Database ***
           - name: POSTGRES_URL
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: postgres_url
+                name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
+                key: {{ default "postgres_url" .Values.db.connectionString.secretKey }}
           - name: POSTGRES_MAX_CONNECTIONS_SERVER
             value: {{ .Values.db.maxConnectionsServer | quote }}
 
@@ -139,8 +139,8 @@ spec:
           - name: S3_SECRET_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: s3_secret_key
+                name: {{ default .Values.secretName .Values.s3.secret_key.secretName }}
+                key: {{ default "s3_secret_key" .Values.s3.secret_key.secretKey }}
           - name: S3_CREATE_BUCKET
             value: "{{ .Values.s3.create_bucket }}"
           - name: S3_REGION
@@ -151,13 +151,8 @@ spec:
           # *** Authentication ***
 
           # Local Auth
-          {{- if .Values.server.auth.local.enabled }}
           - name: STRATEGY_LOCAL
-            value: "true"
-          {{- else }}
-          - name: STRATEGY_LOCAL
-            value: "false"
-          {{- end }}
+            value: "{{ .Values.server.auth.local.enabled }}"
 
           # Google Auth
           {{- if .Values.server.auth.google.enabled }}
@@ -168,8 +163,8 @@ spec:
           - name: GOOGLE_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: google_client_secret
+                name: {{ default .Values.secretName .Values.server.auth.google.clientSecret.secretName }}
+                key: {{ default "google_client_secret" .Values.server.auth.google.clientSecret.secretKey }}
           {{- end }}
 
           # Github Auth
@@ -181,8 +176,8 @@ spec:
           - name: GITHUB_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: github_client_secret
+                name: {{ default .Values.secretName .Values.server.auth.github.clientSecret.secretName }}
+                key: {{ default "github_client_secret" .Values.server.auth.github.clientSecret.secretKey }}
           {{- end }}
 
           # AzureAD Auth
@@ -200,8 +195,8 @@ spec:
           - name: AZURE_AD_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: azure_ad_client_secret
+                name: {{ default .Values.secretName .Values.server.auth.azure_ad.clientSecret.secretName }}
+                key: {{ default "azure_ad_client_secret" .Values.server.auth.azure_ad.clientSecret.secretKey }}
           {{- end }}
 
 
@@ -219,8 +214,8 @@ spec:
           - name: EMAIL_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: email_password
+                name: {{ default .Values.secretName .Values.server.email.password.secretName }}
+                key: {{ default "email_password" .Values.server.email.password.secretKey }}
           {{- end }}
 
           # *** Tracking / Tracing ***
@@ -254,8 +249,8 @@ spec:
           - name: APOLLO_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: apollo_key
+                name: {{ default .Values.secretName .Values.server.monitoring.apollo.key.secretName }}
+                key: {{ default "apollo_key" .Values.server.monitoring.apollo.key.secretKey }}
           {{- end }}
       {{- if .Values.server.affinity }}
       affinity: {{- include "speckle.renderTpl" (dict "value" .Values.server.affinity "context" $) | nindent 8 }}

--- a/utils/helm/speckle-server/templates/server/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/server/serviceaccount.yml
@@ -14,10 +14,20 @@ secrets:
   - name: {{ default .Values.secretName .Values.redis.connectionString.secretName }}
   - name: {{ default .Values.secretName .Values.s3.secret_key.secretName }}
   - name: {{ default .Values.secretName .Values.server.sessionSecret.secretName }}
+{{- if .Values.server.auth.google.enabled }}
   - name: {{ default .Values.secretName .Values.server.auth.google.clientSecret.secretName }}
+{{- end }}
+{{- if .Values.server.auth.github.enabled }}
   - name: {{ default .Values.secretName .Values.server.auth.github.clientSecret.secretName }}
+{{- end }}
+{{- if .Values.server.auth.azure_ad.enabled }}
   - name: {{ default .Values.secretName .Values.server.auth.azure_ad.clientSecret.secretName }}
+{{- end }}
+{{- if .Values.server.email.enabled }}
   - name: {{ default .Values.secretName .Values.server.email.password.secretName }}
+{{- end }}
+{{- if .Values.server.monitoring.apollo.enabled }}
   - name: {{ default .Values.secretName .Values.server.monitoring.apollo.key.secretName }}
+{{- end }}
 
 {{- end -}}

--- a/utils/helm/speckle-server/templates/server/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/server/serviceaccount.yml
@@ -10,5 +10,14 @@ metadata:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
 secrets:
-  - name: {{ .Values.secretName }}
+  - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
+  - name: {{ default .Values.secretName .Values.redis.connectionString.secretName }}
+  - name: {{ default .Values.secretName .Values.s3.secret_key.secretName }}
+  - name: {{ default .Values.secretName .Values.server.sessionSecret.secretName }}
+  - name: {{ default .Values.secretName .Values.server.auth.google.clientSecret.secretName }}
+  - name: {{ default .Values.secretName .Values.server.auth.github.clientSecret.secretName }}
+  - name: {{ default .Values.secretName .Values.server.auth.azure_ad.clientSecret.secretName }}
+  - name: {{ default .Values.secretName .Values.server.email.password.secretName }}
+  - name: {{ default .Values.secretName .Values.server.monitoring.apollo.key.secretName }}
+
 {{- end -}}

--- a/utils/helm/speckle-server/templates/webhook_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/deployment.yml
@@ -67,8 +67,8 @@ spec:
           - name: PG_CONNECTION_STRING
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secretName }}
-                key: postgres_url
+                name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
+                key: {{ default "postgres_url" .Values.db.connectionString.secretKey }}
 
           - name: DEBUG
             value: "webhook-service:*"

--- a/utils/helm/speckle-server/templates/webhook_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/serviceaccount.yml
@@ -10,5 +10,5 @@ metadata:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
 secrets:
-  - name: {{ .Values.secretName }}
+  - name: {{ ( default .Values.secretName .Values.db.connectionString.secretName ) }}
 {{- end -}}

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -64,7 +64,7 @@
     },
     "secretName": {
       "type": "string",
-      "description": "This is the name of the Kubernetes Secret resource in which secrets for Speckle are stored.",
+      "description": "Deprecated, please use individual secret parameters.  This is the name of the Kubernetes Secret resource in which secrets for Speckle are stored. Secrets within this Secret resource may include Postgres and Redis connectin strings, S3 secret values, email server passwords, etc..",
       "default": "server-vars"
     },
     "file_size_limit_mb": {
@@ -107,13 +107,28 @@
         },
         "certificate": {
           "type": "string",
-          "description": "The x509 public certificate for SSL connections to the Postgres database",
+          "description": "The x509 public certificate for SSL connections to the Postgres database. Use of this certificate requires db.useCertificate to be enabled and an appropriate value for db.PGSSLMODE provided.",
           "default": ""
         },
         "PGSSLMODE": {
           "type": "string",
           "description": "This defines the level of security used when connecting to the Postgres database",
           "default": "require"
+        },
+        "connectionString": {
+          "type": "object",
+          "properties": {
+            "secretName": {
+              "type": "string",
+              "description": "Required. A secret containing the full connection string to the Postgres database (e.g. in format of `protocol://username:password@host:port/database`) stored within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets",
+              "default": "server-vars"
+            },
+            "secretKey": {
+              "type": "string",
+              "description": "Required. The key within the Kubernetes Secret holding the connection string.",
+              "default": "postgres_url"
+            }
+          }
         },
         "networkPolicy": {
           "type": "object",
@@ -195,6 +210,21 @@
           "description": "The key of the access key used to authenticate with the s3 compatible storage",
           "default": ""
         },
+        "secret_key": {
+          "type": "object",
+          "properties": {
+            "secretName": {
+              "type": "string",
+              "description": "Required. A Kubernetes secret containing the s3 secret_key.  This is expected to be the name of an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets",
+              "default": "server-vars"
+            },
+            "secretKey": {
+              "type": "string",
+              "description": "Required. The key within the Kubernetes Secret, the value of which is the s3 secret.",
+              "default": "s3_secret_key"
+            }
+          }
+        },
         "create_bucket": {
           "type": "string",
           "description": "If enabled, will create a bucket with the given bucket name at this endpoint",
@@ -270,6 +300,21 @@
     "redis": {
       "type": "object",
       "properties": {
+        "connectionString": {
+          "type": "object",
+          "properties": {
+            "secretName": {
+              "type": "string",
+              "description": "Required. A secret containing the full connection string to the Redis store (e.g. in format of `protocol://username:password@host:port/database`) stored within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets",
+              "default": "server-vars"
+            },
+            "secretKey": {
+              "type": "string",
+              "description": "Required. The key within the Kubernetes Secret holding the Redis connection string.",
+              "default": "redis_url"
+            }
+          }
+        },
         "networkPolicy": {
           "type": "object",
           "properties": {
@@ -340,6 +385,21 @@
           "description": "The number of instances of the Server pod to be deployed within the cluster.",
           "default": 1
         },
+        "sessionSecret": {
+          "type": "object",
+          "properties": {
+            "secretName": {
+              "type": "string",
+              "description": "The name of the Kubernetes Secret containing the Session secret.  This is a unique value (can be generated randomly). This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets",
+              "default": "server-vars"
+            },
+            "secretKey": {
+              "type": "string",
+              "description": "The key within the Kubernetes Secret holding the Session secret as its value.",
+              "default": "session_secret"
+            }
+          }
+        },
         "auth": {
           "type": "object",
           "properties": {
@@ -358,13 +418,28 @@
               "properties": {
                 "enabled": {
                   "type": "boolean",
-                  "description": "If enabled, users can authenticate via Google with their Google account credentials.",
+                  "description": "If enabled, users can authenticate via Google with their Google account credentials. If enabling Google, the `server.auth.google.client_id` parameter is required, and a secret must be provided via the Kubernetes secret referenced in `server.auth.google.clientSecret`.",
                   "default": false
                 },
                 "client_id": {
                   "type": "string",
                   "description": "This is the ID for Speckle that you have registered with Google.",
                   "default": ""
+                },
+                "clientSecret": {
+                  "type": "object",
+                  "properties": {
+                    "secretName": {
+                      "type": "string",
+                      "description": "The name of the Kubernetes Secret containing the Google client secret. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets",
+                      "default": "server-vars"
+                    },
+                    "secretKey": {
+                      "type": "string",
+                      "description": "The key within the Kubernetes Secret holding the Google client secret as its value.",
+                      "default": "google_client_secret"
+                    }
+                  }
                 }
               }
             },
@@ -373,13 +448,28 @@
               "properties": {
                 "enabled": {
                   "type": "boolean",
-                  "description": "If enabled, users can authenticate via Github with their Github account credentials.",
+                  "description": "If enabled, users can authenticate via Github with their Github account credentials. If enabling Github authentication, the `server.auth.github.client_id` parameter is required.",
                   "default": false
                 },
                 "client_id": {
                   "type": "string",
                   "description": "This is the ID for Speckle that you have registered with Github",
                   "default": ""
+                },
+                "clientSecret": {
+                  "type": "object",
+                  "properties": {
+                    "secretName": {
+                      "type": "string",
+                      "description": "The name of the Kubernetes Secret containing the GitHub client secret. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets",
+                      "default": "server-vars"
+                    },
+                    "secretKey": {
+                      "type": "string",
+                      "description": "The key within the Kubernetes Secret holding the GitHub client secret as its value.",
+                      "default": "github_client_secret"
+                    }
+                  }
                 }
               }
             },
@@ -410,6 +500,34 @@
                   "type": "string",
                   "description": "This is the ID for Speckle that you have registered with Azure",
                   "default": ""
+                },
+                "clientSecret": {
+                  "type": "object",
+                  "properties": {
+                    "secretName": {
+                      "type": "string",
+                      "description": "The name of the Kubernetes Secret containing the Azure AD client secret. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets",
+                      "default": "server-vars"
+                    },
+                    "secretKey": {
+                      "type": "string",
+                      "description": "The key within the Kubernetes Secret holding the Azure AD client secret as its value.",
+                      "default": "azure_ad_client_secret"
+                    }
+                  }
+                },
+                "additional_domains": {
+                  "type": "array",
+                  "description": "List of `matchName` or `matchPattern` maps for domains that should be allow-listed for egress in Network Policy. https://docs.microsoft.com/en-us/azure/azure-portal/azure-portal-safelist-urls?tabs=public-cloud are enabled by default.",
+                  "default": [],
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "port": {
+                  "type": "number",
+                  "description": "Port on server to connect to. Used to allow egress in Network Policy. Defaults to 443",
+                  "default": 443
                 }
               }
             }
@@ -437,6 +555,21 @@
               "type": "string",
               "description": "The username with which Speckle will authenticate with the email service.",
               "default": ""
+            },
+            "password": {
+              "type": "object",
+              "properties": {
+                "secretName": {
+                  "type": "string",
+                  "description": "The name of the Kubernetes Secret containing the email password. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets",
+                  "default": "server-vars"
+                },
+                "secretKey": {
+                  "type": "string",
+                  "description": "The key within the Kubernetes Secret holding the email password as its value.",
+                  "default": "email_password"
+                }
+              }
             },
             "networkPolicy": {
               "type": "object",
@@ -550,6 +683,21 @@
                   "type": "string",
                   "description": "The ID for Speckle that you registered in Apollo Graphql Studio.",
                   "default": ""
+                },
+                "key": {
+                  "type": "object",
+                  "properties": {
+                    "secretName": {
+                      "type": "string",
+                      "description": "The name of the Kubernetes Secret containing the Apollo monitoring key. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets",
+                      "default": "server-vars"
+                    },
+                    "secretKey": {
+                      "type": "string",
+                      "description": "The key within the Kubernetes Secret holding the Apollo monitoring key as its value.",
+                      "default": "apollo_key"
+                    }
+                  }
                 }
               }
             }

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -127,10 +127,10 @@ db:
   connectionString:
     ## @param db.connectionString.secretName Required. A secret containing the full connection string to the Postgres database (e.g. in format of `protocol://username:password@host:port/database`) stored within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
     ##
-    secretName: server-vars
+    secretName: ''
     ## @param db.connectionString.secretKey Required. The key within the Kubernetes Secret holding the connection string.
     ##
-    secretKey: postgres_url
+    secretKey: ''
   ## @extra db.networkPolicy If networkPolicy is enabled for any service, this provides the NetworkPolicy with the necessary details to allow egress connections to the Postgres database
   ##
   networkPolicy:
@@ -199,10 +199,10 @@ s3:
   secret_key:
     ## @param s3.secret_key.secretName Required. A Kubernetes secret containing the s3 secret_key.  This is expected to be the name of an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
     ##
-    secretName: server-vars
+    secretName: ''
     ## @param s3.secret_key.secretKey Required. The key within the Kubernetes Secret, the value of which is the s3 secret.
     ##
-    secretKey: s3_secret_key
+    secretKey: ''
   ## @param s3.create_bucket If enabled, will create a bucket with the given bucket name at this endpoint
   ## If enabled, the access_key must be granted the appropriate bucket creation privileges
   ##
@@ -267,10 +267,10 @@ redis:
   connectionString:
     ## @param redis.connectionString.secretName Required. A secret containing the full connection string to the Redis store (e.g. in format of `protocol://username:password@host:port/database`) stored within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
     ##
-    secretName: server-vars
+    secretName: ''
     ## @param redis.connectionString.secretKey Required. The key within the Kubernetes Secret holding the Redis connection string.
     ##
-    secretKey: redis_url
+    secretKey: ''
   ## @extra redis.networkPolicy If networkPolicy is enabled for Speckle server, this provides the NetworkPolicy with the necessary details to allow egress connections to the Redis store
   ##
   networkPolicy:
@@ -330,10 +330,10 @@ server:
   sessionSecret:
     ## @param server.sessionSecret.secretName The name of the Kubernetes Secret containing the Session secret.  This is a unique value (can be generated randomly). This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
     ##
-    secretName: server-vars
+    secretName: ''
     ## @param server.sessionSecret.secretKey The key within the Kubernetes Secret holding the Session secret as its value.
     ##
-    secretKey: session_secret
+    secretKey: ''
   ## @extra server.auth Speckle provides a number of different mechanisms for authenticating users.  Each available option must be configured here.
   ##
   auth:
@@ -352,10 +352,10 @@ server:
       clientSecret:
         ## @param server.auth.google.clientSecret.secretName The name of the Kubernetes Secret containing the Google client secret. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
         ##
-        secretName: server-vars
+        secretName: ''
         ## @param server.auth.google.clientSecret.secretKey The key within the Kubernetes Secret holding the Google client secret as its value.
         ##
-        secretKey: google_client_secret
+        secretKey: ''
     github:
       ## @param server.auth.github.enabled If enabled, users can authenticate via Github with their Github account credentials. If enabling Github authentication, the `server.auth.github.client_id` parameter is required.
       ##
@@ -366,10 +366,10 @@ server:
       clientSecret:
         ## @param server.auth.github.clientSecret.secretName The name of the Kubernetes Secret containing the GitHub client secret. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
         ##
-        secretName: server-vars
+        secretName: ''
         ## @param server.auth.github.clientSecret.secretKey The key within the Kubernetes Secret holding the GitHub client secret as its value.
         ##
-        secretKey: github_client_secret
+        secretKey: ''
     azure_ad:
       ## @param server.auth.azure_ad.enabled If enabled, users can authenticate via Azure Active Directory.
       ##
@@ -389,10 +389,10 @@ server:
       clientSecret:
         ## @param server.auth.azure_ad.clientSecret.secretName The name of the Kubernetes Secret containing the Azure AD client secret. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
         ##
-        secretName: server-vars
+        secretName: ''
         ## @param server.auth.azure_ad.clientSecret.secretKey The key within the Kubernetes Secret holding the Azure AD client secret as its value.
         ##
-        secretKey: azure_ad_client_secret
+        secretKey: ''
       ## @param server.auth.azure_ad.additional_domains List of `matchName` or `matchPattern` maps for domains that should be allow-listed for egress in Network Policy. https://docs.microsoft.com/en-us/azure/azure-portal/azure-portal-safelist-urls?tabs=public-cloud are enabled by default.
       ##
       additional_domains: []
@@ -403,9 +403,6 @@ server:
   ##
   email:
     ## @param server.email.enabled If enabled, Speckle can send email to users - for example, email verification for account registration.
-    ## If enabling Email, a secret containing the password to the email server must stored within the Kubernetes cluster as an opaque Kubernetes Secret.
-    ## The name of the Kubernetes Secret resource must match the `secretName` parameter, and the key within this Kubernetes Secret must be `email_password`.
-    ## ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
     ##
     enabled: false
     ## @param server.email.host The domain name or IP address of the server hosting the email service.
@@ -421,10 +418,10 @@ server:
     password:
       ## @param server.email.password.secretName The name of the Kubernetes Secret containing the email password. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
       ##
-      secretName: server-vars
+      secretName: ''
       ## @param server.email.password.secretKey The key within the Kubernetes Secret holding the email password as its value.
       ##
-      secretKey: email_password
+      secretKey: ''
     ## @extra server.email.networkPolicy If networkPolicy is enabled for Speckle server, this provides the Network Policy with the necessary details to allow egress connections to the email server
     ##
     networkPolicy:
@@ -511,10 +508,10 @@ server:
       key:
         ## @param server.monitoring.apollo.key.secretName The name of the Kubernetes Secret containing the Apollo monitoring key. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
         ##
-        secretName: server-vars
+        secretName: ''
         ## @param server.monitoring.apollo.key.secretKey The key within the Kubernetes Secret holding the Apollo monitoring key as its value.
         ##
-        secretKey: apollo_key
+        secretKey: ''
 
   ## @param server.sentry_dns (Optional) The Data Source Name that was provided by Sentry.io
   ## Sentry.io allows events within Speckle to be monitored

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -181,9 +181,6 @@ db:
 ## @section S3 Compatible Storage
 ## @descriptionStart
 ## Defines parameters related to connecting to the S3 compatible storage.
-## A secret containing the secret key must stored within the Kubernetes cluster as an opaque Kubernetes Secret.
-## The name of the Kubernetes Secret resource must match the `secretName` parameter, and the key within this Kubernetes Secret must be `s3_secret_key`.
-## ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
 ## @descriptionEnd
 ##
 s3:

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -60,10 +60,10 @@ docker_image_tag: v2.3.3
 ##
 imagePullPolicy: IfNotPresent
 
-## @param secretName This is the name of the Kubernetes Secret resource in which secrets for Speckle are stored.
-## Secrets within this Secret resource may include Postgres and Redis connectin strings, S3 secret values, email server passwords, etc..
+## @param secretName Deprecated, please use individual secret parameters.  This is the name of the Kubernetes Secret resource in which secrets for Speckle are stored. Secrets within this Secret resource may include Postgres and Redis connectin strings, S3 secret values, email server passwords, etc..
 ## The expected key within the Secret resource is indicated elsewhere in this values.yaml file.
 ## This is expected to be an opaque Secret resource type.
+## If component secrets are provided, they will take precedence.
 ## ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
 ##
 secretName: server-vars
@@ -104,13 +104,9 @@ prometheusMonitoring:
 ## @section Postgres Database
 ## @descriptionStart
 ## Defines parameters related to connections to the Postgres database.
-## A secret containing the connection string to the Postgres database must stored within the Kubernetes cluster as an opaque Kubernetes Secret.
-## The name of the secret must match the `secretName` parameter, and the key within this secret must be `postgres_url`.
-## ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
 ## @descriptionEnd
 ##
 db:
-  # postgres_url: secret -> postgres_url
   ## @param db.useCertificate If enabled, the certificate defined in db.certificate is used to verify TLS connections to the Postgres database
   ##
   useCertificate: false
@@ -128,6 +124,13 @@ db:
   ## ref: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION
   ##
   PGSSLMODE: require
+  connectionString:
+    ## @param db.connectionString.secretName Required. A secret containing the full connection string to the Postgres database (e.g. in format of `protocol://username:password@host:port/database`) stored within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+    ##
+    secretName: server-vars
+    ## @param db.connectionString.secretKey Required. The key within the Kubernetes Secret holding the connection string.
+    ##
+    secretKey: postgres_url
   ## @extra db.networkPolicy If networkPolicy is enabled for any service, this provides the NetworkPolicy with the necessary details to allow egress connections to the Postgres database
   ##
   networkPolicy:
@@ -196,6 +199,13 @@ s3:
   ## @param s3.access_key The key of the access key used to authenticate with the s3 compatible storage
   ##
   access_key: ''
+  secret_key:
+    ## @param s3.secret_key.secretName Required. A Kubernetes secret containing the s3 secret_key.  This is expected to be the name of an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+    ##
+    secretName: server-vars
+    ## @param s3.secret_key.secretKey Required. The key within the Kubernetes Secret, the value of which is the s3 secret.
+    ##
+    secretKey: s3_secret_key
   ## @param s3.create_bucket If enabled, will create a bucket with the given bucket name at this endpoint
   ## If enabled, the access_key must be granted the appropriate bucket creation privileges
   ##
@@ -254,12 +264,16 @@ s3:
 ## @section Redis Store
 ## @descriptionStart
 ## Defines parameters related to connecting to the Redis Store.
-## A secret containing the redis url (containing domain, username, and password) must stored within the Kubernetes cluster as an opaque Kubernetes Secret.
-## The name of the Kubernetes Secret resource must match the `secretName` parameter, and the key within this Kubernetes Secret resource must be `redis_url`.
-## ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
 ## @descriptionEnd
 ##
 redis:
+  connectionString:
+    ## @param redis.connectionString.secretName Required. A secret containing the full connection string to the Redis store (e.g. in format of `protocol://username:password@host:port/database`) stored within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+    ##
+    secretName: server-vars
+    ## @param redis.connectionString.secretKey Required. The key within the Kubernetes Secret holding the Redis connection string.
+    ##
+    secretKey: redis_url
   ## @extra redis.networkPolicy If networkPolicy is enabled for Speckle server, this provides the NetworkPolicy with the necessary details to allow egress connections to the Redis store
   ##
   networkPolicy:
@@ -310,15 +324,19 @@ redis:
 ## @section Server
 ## @descriptionStart
 ## Defines parameters related to the backend server component of Speckle.
-## A secret containing the an unique value (this can be generated randomly) must stored within the Kubernetes cluster as an opaque Kubernetes Secret.
-## The name of the Kubernetes Secret resource must match the `secretName` parameter, and the key within this Secret resource must be `session_secret`.
-## ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
 ## @descriptionEnd
 ##
 server:
   ## @param server.replicas The number of instances of the Server pod to be deployed within the cluster.
   ##
   replicas: 1
+  sessionSecret:
+    ## @param server.sessionSecret.secretName The name of the Kubernetes Secret containing the Session secret.  This is a unique value (can be generated randomly). This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+    ##
+    secretName: server-vars
+    ## @param server.sessionSecret.secretKey The key within the Kubernetes Secret holding the Session secret as its value.
+    ##
+    secretKey: session_secret
   ## @extra server.auth Speckle provides a number of different mechanisms for authenticating users.  Each available option must be configured here.
   ##
   auth:
@@ -328,32 +346,35 @@ server:
       ##
       enabled: true
     google:
-      ## @param server.auth.google.enabled If enabled, users can authenticate via Google with their Google account credentials.
-      ## If enabling Google, the `server.auth.google.client_id` parameter is required.
-      ## A secret containing the client secret must stored within the Kubernetes cluster as an opaque Kubernetes Secret.
-      ## The name of the Kubernetes Secret resource must match the `secretName` parameter, and the key within this Kubernetes Secret must be `google_client_secret`.
-      ## ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+      ## @param server.auth.google.enabled If enabled, users can authenticate via Google with their Google account credentials. If enabling Google, the `server.auth.google.client_id` parameter is required, and a secret must be provided via the Kubernetes secret referenced in `server.auth.google.clientSecret`.
       ##
       enabled: false
       ## @param server.auth.google.client_id This is the ID for Speckle that you have registered with Google.
       ##
       client_id: ''
+      clientSecret:
+        ## @param server.auth.google.clientSecret.secretName The name of the Kubernetes Secret containing the Google client secret. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+        ##
+        secretName: server-vars
+        ## @param server.auth.google.clientSecret.secretKey The key within the Kubernetes Secret holding the Google client secret as its value.
+        ##
+        secretKey: google_client_secret
     github:
-      ## @param server.auth.github.enabled If enabled, users can authenticate via Github with their Github account credentials.
-      ## If enabling Github authentication, the `server.auth.github.client_id` parameter is required.
-      ## A secret containing the client secret must stored within the Kubernetes cluster as an opaque Kubernetes Secret.
-      ## The name of the Kubernetes Secret resource must match the `secretName` parameter, and the key within this Kubernetes Secret must be `github_client_secret`.
-      ## ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+      ## @param server.auth.github.enabled If enabled, users can authenticate via Github with their Github account credentials. If enabling Github authentication, the `server.auth.github.client_id` parameter is required.
       ##
       enabled: false
       ## @param server.auth.github.client_id This is the ID for Speckle that you have registered with Github
       ##
       client_id: ''
+      clientSecret:
+        ## @param server.auth.github.clientSecret.secretName The name of the Kubernetes Secret containing the GitHub client secret. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+        ##
+        secretName: server-vars
+        ## @param server.auth.github.clientSecret.secretKey The key within the Kubernetes Secret holding the GitHub client secret as its value.
+        ##
+        secretKey: github_client_secret
     azure_ad:
       ## @param server.auth.azure_ad.enabled If enabled, users can authenticate via Azure Active Directory.
-      ## If enabling Azure Active Directory authentication, a secret containing the client secret must stored within the Kubernetes cluster as an opaque Kubernetes Secret.
-      ## The name of the Kubernetes Secret resource must match the `secretName` parameter, and the key within this Kubernetes Secret must be `azure_ad_client_secret`.
-      ## ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
       ##
       enabled: false
       ## @param server.auth.azure_ad.org_name This is the Organisation Name that you have registered with Azure
@@ -368,6 +389,13 @@ server:
       ## @param server.auth.azure_ad.client_id This is the ID for Speckle that you have registered with Azure
       ##
       client_id: ''
+      clientSecret:
+        ## @param server.auth.azure_ad.clientSecret.secretName The name of the Kubernetes Secret containing the Azure AD client secret. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+        ##
+        secretName: server-vars
+        ## @param server.auth.azure_ad.clientSecret.secretKey The key within the Kubernetes Secret holding the Azure AD client secret as its value.
+        ##
+        secretKey: azure_ad_client_secret
       ## @param server.auth.azure_ad.additional_domains List of `matchName` or `matchPattern` maps for domains that should be allow-listed for egress in Network Policy. https://docs.microsoft.com/en-us/azure/azure-portal/azure-portal-safelist-urls?tabs=public-cloud are enabled by default.
       ##
       additional_domains: []
@@ -393,6 +421,13 @@ server:
     ## Note that the `email_password` is expected to be provided in the Kubernetes Secret with the name provided in the `secretName` parameter.
     ##
     username: ''
+    password:
+      ## @param server.email.password.secretName The name of the Kubernetes Secret containing the email password. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+      ##
+      secretName: server-vars
+      ## @param server.email.password.secretKey The key within the Kubernetes Secret holding the email password as its value.
+      ##
+      secretKey: email_password
     ## @extra server.email.networkPolicy If networkPolicy is enabled for Speckle server, this provides the Network Policy with the necessary details to allow egress connections to the email server
     ##
     networkPolicy:
@@ -476,6 +511,13 @@ server:
       ## @param server.monitoring.apollo.graph_id The ID for Speckle that you registered in Apollo Graphql Studio.
       ##
       graph_id: ''
+      key:
+        ## @param server.monitoring.apollo.key.secretName The name of the Kubernetes Secret containing the Apollo monitoring key. This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+        ##
+        secretName: server-vars
+        ## @param server.monitoring.apollo.key.secretKey The key within the Kubernetes Secret holding the Apollo monitoring key as its value.
+        ##
+        secretKey: apollo_key
 
   ## @param server.sentry_dns (Optional) The Data Source Name that was provided by Sentry.io
   ## Sentry.io allows events within Speckle to be monitored


### PR DESCRIPTION
## Description & motivation

Currently secrets have to be referenced from a single kubernetes Secret resource (default name 'server-vars').  This can be restrictive as all secrets have to be generated together, or the Secret patched (which can break declarative tooling). 
Additionally, when a Service Account permits a pod access to the single Secret the pod then has access to other secrets it may not need.  This does not align with the least privileges principle.

This PR allows each secret to be loaded from a separate kubernetes Secret.  This allows the Kubernetes Secrets to be generated separately, perhaps at different times in the deployment lifecycle or by different tooling. It allows Kubernetes Secrets to be granted to Pods individually, maintaining a least privileges principle.

If values for individual references to secrets are not provided, it defaults to the previous single kubernetes Secret.  This single kubernetes secret should now be considered deprecated in favour of individual references.

The default values of the individual secrets are the same as before, allowing for backwards compatibility.

## Changes:

- helm chart now allows each individual secret to be referenced from a different kubernetes Secret, and a custom key within.

## To-do before merge:

Also merge https://github.com/specklesystems/helm/pull/12 with revised documentation.

## Screenshots:

Showing multiple secrets existing:
<img width="857" alt="Screenshot 2022-09-10 at 18 40 35" src="https://user-images.githubusercontent.com/68657/189495944-0969d6ad-c11f-4b16-abd8-3e7d87efc559.png">

ServiceAccount provides access to relevant Secrets:
<img width="860" alt="Screenshot 2022-09-10 at 18 49 27" src="https://user-images.githubusercontent.com/68657/189495945-fe2f97d6-25dc-4ed0-823c-daf41807ec7e.png">

Secrets are mounted correctly to the pods:
<img width="1068" alt="Screenshot 2022-09-10 at 18 41 47" src="https://user-images.githubusercontent.com/68657/189495946-88b8717d-4a28-4d61-a879-d8aba064754f.png">


## Validation of changes:

Load each change from a different secret and a different key.  See above screenshots.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

https://github.com/specklesystems/speckle-server/issues/923