### PR TITLE
refactor: moving away from 'user' query

### DIFF
--- a/packages/frontend/src/config/apolloConfig.ts
+++ b/packages/frontend/src/config/apolloConfig.ts
@@ -50,6 +50,15 @@ function createCache(): InMemoryCache {
       {
         Query: {
           fields: {
+            otherUser: {
+              read(original, { args, toReference }) {
+                if (args?.id) {
+                  return toReference({ __typename: 'LimitedUser', id: args.id })
+                }
+
+                return original
+              }
+            },
             user: {
               read(original, { args, toReference }) {
                 if (args?.id) {
@@ -71,6 +80,16 @@ function createCache(): InMemoryCache {
             streams: {
               keyArgs: ['query'],
               merge: buildAbstractCollectionMergeFunction('StreamCollection', {
+                checkIdentity: true
+              })
+            }
+          }
+        },
+        LimitedUser: {
+          fields: {
+            commits: {
+              keyArgs: false,
+              merge: buildAbstractCollectionMergeFunction('CommitCollection', {
                 checkIdentity: true
               })
             }

--- a/packages/frontend/src/graphql/generated/graphql.ts
+++ b/packages/frontend/src/graphql/generated/graphql.ts
@@ -411,10 +411,37 @@ export type LimitedUser = {
   __typename?: 'LimitedUser';
   avatar?: Maybe<Scalars['String']>;
   bio?: Maybe<Scalars['String']>;
+  /** Get public stream commits authored by the user */
+  commits?: Maybe<CommitCollection>;
   company?: Maybe<Scalars['String']>;
   id: Scalars['String'];
   name?: Maybe<Scalars['String']>;
+  role?: Maybe<Scalars['String']>;
+  /** Returns all discoverable streams that the user is a collaborator on */
+  streams: StreamCollection;
+  /** Total amount of favorites attached to streams owned by the user */
+  totalOwnedStreamsFavorites: Scalars['Int'];
   verified?: Maybe<Scalars['Boolean']>;
+};
+
+
+/**
+ * Limited user type, for showing public info about a user
+ * to another user
+ */
+export type LimitedUserCommitsArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  limit?: Scalars['Int'];
+};
+
+
+/**
+ * Limited user type, for showing public info about a user
+ * to another user
+ */
+export type LimitedUserStreamsArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  limit?: Scalars['Int'];
 };
 
 export type Mutation = {
@@ -865,6 +892,8 @@ export type Query = {
   __typename?: 'Query';
   /** Stare into the void. */
   _?: Maybe<Scalars['String']>;
+  /** Gets the profile of the authenticated user or null if not authenticated */
+  activeUser?: Maybe<User>;
   /** All the streams of the server. Available to admins only. */
   adminStreams?: Maybe<StreamCollection>;
   /**
@@ -887,6 +916,8 @@ export type Query = {
   commitObjectViewerState: CommitObjectViewerState;
   /** All of the discoverable streams of the server */
   discoverableStreams?: Maybe<StreamCollection>;
+  /** Get the (limited) profile information of another server user */
+  otherUser?: Maybe<LimitedUser>;
   serverInfo: ServerInfo;
   serverStats: ServerStats;
   /**
@@ -908,7 +939,10 @@ export type Query = {
    * Pass in the `query` parameter to search by name, description or ID.
    */
   streams?: Maybe<StreamCollection>;
-  /** Gets the profile of a user. If no id argument is provided, will return the current authenticated user's profile (as extracted from the authorization header). */
+  /**
+   * Gets the profile of a user. If no id argument is provided, will return the current authenticated user's profile (as extracted from the authorization header).
+   * @deprecated To be removed in the near future! Use 'activeUser' to get info about the active user or 'otherUser' to get info about another user.
+   */
   user?: Maybe<User>;
   /** Validate password strength */
   userPwdStrength: PasswordStrengthCheckResults;
@@ -960,6 +994,11 @@ export type QueryDiscoverableStreamsArgs = {
   cursor?: InputMaybe<Scalars['String']>;
   limit?: Scalars['Int'];
   sort?: InputMaybe<DiscoverableStreamsSortingInput>;
+};
+
+
+export type QueryOtherUserArgs = {
+  id: Scalars['String'];
 };
 
 
@@ -1487,7 +1526,7 @@ export type User = {
    * All the streams that a active user has favorited.
    * Note: You can't use this to retrieve another user's favorite streams.
    */
-  favoriteStreams?: Maybe<StreamCollection>;
+  favoriteStreams: StreamCollection;
   /** Whether the user has a pending/active email verification token */
   hasPendingVerification?: Maybe<Scalars['Boolean']>;
   id: Scalars['String'];
@@ -1499,7 +1538,7 @@ export type User = {
    * Returns all streams that the user is a collaborator on. If requested for a user, who isn't the
    * authenticated user, then this will only return discoverable streams.
    */
-  streams?: Maybe<StreamCollection>;
+  streams: StreamCollection;
   timeline?: Maybe<ActivityCollection>;
   /** Total amount of favorites attached to streams owned by the user */
   totalOwnedStreamsFavorites: Scalars['Int'];
@@ -1924,24 +1963,24 @@ export type DeleteStreamMutationVariables = Exact<{
 
 export type DeleteStreamMutation = { __typename?: 'Mutation', streamDelete: boolean };
 
-export type CommonUserFieldsFragment = { __typename?: 'User', id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null, profiles?: Record<string, unknown> | null, role?: string | null, streams?: { __typename?: 'StreamCollection', totalCount: number } | null, commits?: { __typename?: 'CommitCollection', totalCount: number, items?: Array<{ __typename?: 'Commit', id: string, createdAt?: string | null }> | null } | null };
+export type CommonUserFieldsFragment = { __typename?: 'User', id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null, profiles?: Record<string, unknown> | null, role?: string | null, streams: { __typename?: 'StreamCollection', totalCount: number }, commits?: { __typename?: 'CommitCollection', totalCount: number, items?: Array<{ __typename?: 'Commit', id: string, createdAt?: string | null }> | null } | null };
 
 export type UserFavoriteStreamsQueryVariables = Exact<{
   cursor?: InputMaybe<Scalars['String']>;
 }>;
 
 
-export type UserFavoriteStreamsQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null, profiles?: Record<string, unknown> | null, role?: string | null, favoriteStreams?: { __typename?: 'StreamCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Stream', id: string, name: string, description?: string | null, role?: string | null, isPublic: boolean, createdAt: string, updatedAt: string, commentCount: number, favoritedDate?: string | null, favoritesCount: number, collaborators: Array<{ __typename?: 'StreamCollaborator', id: string, name: string, company?: string | null, avatar?: string | null, role: string }>, commits?: { __typename?: 'CommitCollection', totalCount: number } | null, branches?: { __typename?: 'BranchCollection', totalCount: number } | null }> | null } | null, streams?: { __typename?: 'StreamCollection', totalCount: number } | null, commits?: { __typename?: 'CommitCollection', totalCount: number, items?: Array<{ __typename?: 'Commit', id: string, createdAt?: string | null }> | null } | null } | null };
+export type UserFavoriteStreamsQuery = { __typename?: 'Query', activeUser?: { __typename?: 'User', id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null, profiles?: Record<string, unknown> | null, role?: string | null, favoriteStreams: { __typename?: 'StreamCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Stream', id: string, name: string, description?: string | null, role?: string | null, isPublic: boolean, createdAt: string, updatedAt: string, commentCount: number, favoritedDate?: string | null, favoritesCount: number, collaborators: Array<{ __typename?: 'StreamCollaborator', id: string, name: string, company?: string | null, avatar?: string | null, role: string }>, commits?: { __typename?: 'CommitCollection', totalCount: number } | null, branches?: { __typename?: 'BranchCollection', totalCount: number } | null }> | null }, streams: { __typename?: 'StreamCollection', totalCount: number }, commits?: { __typename?: 'CommitCollection', totalCount: number, items?: Array<{ __typename?: 'Commit', id: string, createdAt?: string | null }> | null } | null } | null };
 
 export type MainUserDataQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MainUserDataQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null, profiles?: Record<string, unknown> | null, role?: string | null, streams?: { __typename?: 'StreamCollection', totalCount: number } | null, commits?: { __typename?: 'CommitCollection', totalCount: number, items?: Array<{ __typename?: 'Commit', id: string, createdAt?: string | null }> | null } | null } | null };
+export type MainUserDataQuery = { __typename?: 'Query', activeUser?: { __typename?: 'User', id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null, profiles?: Record<string, unknown> | null, role?: string | null, streams: { __typename?: 'StreamCollection', totalCount: number }, commits?: { __typename?: 'CommitCollection', totalCount: number, items?: Array<{ __typename?: 'Commit', id: string, createdAt?: string | null }> | null } | null } | null };
 
-export type ExtraUserDataQueryVariables = Exact<{ [key: string]: never; }>;
+export type ProfileSelfQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ExtraUserDataQuery = { __typename?: 'Query', user?: { __typename?: 'User', totalOwnedStreamsFavorites: number, notificationPreferences: Record<string, unknown>, id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null, profiles?: Record<string, unknown> | null, role?: string | null, streams?: { __typename?: 'StreamCollection', totalCount: number } | null, commits?: { __typename?: 'CommitCollection', totalCount: number, items?: Array<{ __typename?: 'Commit', id: string, createdAt?: string | null }> | null } | null } | null };
+export type ProfileSelfQuery = { __typename?: 'Query', activeUser?: { __typename?: 'User', totalOwnedStreamsFavorites: number, notificationPreferences: Record<string, unknown>, id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null, profiles?: Record<string, unknown> | null, role?: string | null, streams: { __typename?: 'StreamCollection', totalCount: number }, commits?: { __typename?: 'CommitCollection', totalCount: number, items?: Array<{ __typename?: 'Commit', id: string, createdAt?: string | null }> | null } | null } | null };
 
 export type UserSearchQueryVariables = Exact<{
   query: Scalars['String'];
@@ -1956,7 +1995,7 @@ export type UserSearchQuery = { __typename?: 'Query', userSearch?: { __typename?
 export type IsLoggedInQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type IsLoggedInQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string } | null };
+export type IsLoggedInQuery = { __typename?: 'Query', activeUser?: { __typename?: 'User', id: string } | null };
 
 export type AdminUsersListQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']>;
@@ -1972,7 +2011,7 @@ export type UserTimelineQueryVariables = Exact<{
 }>;
 
 
-export type UserTimelineQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, timeline?: { __typename?: 'ActivityCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Activity', id: string, actionType: string, info: Record<string, unknown>, userId: string, streamId?: string | null, resourceId: string, resourceType: string, time: string, message: string } | null> | null } | null } | null };
+export type UserTimelineQuery = { __typename?: 'Query', activeUser?: { __typename?: 'User', id: string, timeline?: { __typename?: 'ActivityCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Activity', id: string, actionType: string, info: Record<string, unknown>, userId: string, streamId?: string | null, resourceId: string, resourceType: string, time: string, message: string } | null> | null } | null } | null };
 
 export type ValidatePasswordStrengthQueryVariables = Exact<{
   pwd: Scalars['String'];
@@ -1984,7 +2023,7 @@ export type ValidatePasswordStrengthQuery = { __typename?: 'Query', userPwdStren
 export type EmailVerificationBannerStateQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type EmailVerificationBannerStateQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null } | null };
+export type EmailVerificationBannerStateQuery = { __typename?: 'Query', activeUser?: { __typename?: 'User', id: string, email?: string | null, verified?: boolean | null, hasPendingVerification?: boolean | null } | null };
 
 export type RequestVerificationMutationVariables = Exact<{ [key: string]: never; }>;
 
@@ -2003,14 +2042,14 @@ export type UserByIdQueryVariables = Exact<{
 }>;
 
 
-export type UserByIdQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, profiles?: Record<string, unknown> | null, role?: string | null } | null };
+export type UserByIdQuery = { __typename?: 'Query', otherUser?: { __typename?: 'LimitedUser', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null } | null };
 
 export type UserProfileQueryVariables = Exact<{
   id: Scalars['String'];
 }>;
 
 
-export type UserProfileQuery = { __typename?: 'Query', user?: { __typename?: 'User', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null } | null };
+export type UserProfileQuery = { __typename?: 'Query', otherUser?: { __typename?: 'LimitedUser', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null } | null };
 
 export type WebhookQueryVariables = Exact<{
   streamId: Scalars['String'];
@@ -2609,7 +2648,7 @@ export const DeleteStream = gql`
     `;
 export const UserFavoriteStreams = gql`
     query UserFavoriteStreams($cursor: String) {
-  user {
+  activeUser {
     ...CommonUserFields
     favoriteStreams(cursor: $cursor, limit: 10) {
       totalCount
@@ -2624,14 +2663,14 @@ export const UserFavoriteStreams = gql`
 ${CommonStreamFields}`;
 export const MainUserData = gql`
     query MainUserData {
-  user {
+  activeUser {
     ...CommonUserFields
   }
 }
     ${CommonUserFields}`;
-export const ExtraUserData = gql`
-    query ExtraUserData {
-  user {
+export const ProfileSelf = gql`
+    query ProfileSelf {
+  activeUser {
     ...CommonUserFields
     totalOwnedStreamsFavorites
     notificationPreferences
@@ -2650,7 +2689,7 @@ export const UserSearch = gql`
     ${LimitedUserFields}`;
 export const IsLoggedIn = gql`
     query IsLoggedIn {
-  user {
+  activeUser {
     id
   }
 }
@@ -2689,7 +2728,7 @@ export const AdminUsersList = gql`
     `;
 export const UserTimeline = gql`
     query UserTimeline($cursor: DateTime) {
-  user {
+  activeUser {
     id
     timeline(cursor: $cursor) {
       totalCount
@@ -2714,7 +2753,7 @@ export const ValidatePasswordStrength = gql`
     `;
 export const EmailVerificationBannerState = gql`
     query EmailVerificationBannerState {
-  user {
+  activeUser {
     id
     email
     verified
@@ -2734,22 +2773,19 @@ export const UpdateUserNotificationPreferences = gql`
     `;
 export const UserById = gql`
     query UserById($id: String!) {
-  user(id: $id) {
+  otherUser(id: $id) {
     id
-    email
     name
     bio
     company
     avatar
     verified
-    profiles
-    role
   }
 }
     `;
 export const UserProfile = gql`
     query UserProfile($id: String!) {
-  user(id: $id) {
+  otherUser(id: $id) {
     id
     name
     bio
@@ -2859,18 +2895,18 @@ export const StreamSettingsDocument = {"kind":"Document","definitions":[{"kind":
 export const SearchStreamsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"SearchStreams"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"query"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"streams"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"query"},"value":{"kind":"Variable","name":{"kind":"Name","value":"query"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}}]}}]}}]}}]} as unknown as DocumentNode<SearchStreamsQuery, SearchStreamsQueryVariables>;
 export const UpdateStreamSettingsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateStreamSettings"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"StreamUpdateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"streamUpdate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"stream"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}]}]}}]} as unknown as DocumentNode<UpdateStreamSettingsMutation, UpdateStreamSettingsMutationVariables>;
 export const DeleteStreamDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteStream"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"streamDelete"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteStreamMutation, DeleteStreamMutationVariables>;
-export const UserFavoriteStreamsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserFavoriteStreams"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonUserFields"}},{"kind":"Field","name":{"kind":"Name","value":"favoriteStreams"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"cursor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}}},{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"IntValue","value":"10"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonStreamFields"}}]}}]}}]}}]}},...CommonUserFieldsFragmentDoc.definitions,...CommonStreamFieldsFragmentDoc.definitions]} as unknown as DocumentNode<UserFavoriteStreamsQuery, UserFavoriteStreamsQueryVariables>;
-export const MainUserDataDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MainUserData"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonUserFields"}}]}}]}},...CommonUserFieldsFragmentDoc.definitions]} as unknown as DocumentNode<MainUserDataQuery, MainUserDataQueryVariables>;
-export const ExtraUserDataDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ExtraUserData"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonUserFields"}},{"kind":"Field","name":{"kind":"Name","value":"totalOwnedStreamsFavorites"}},{"kind":"Field","name":{"kind":"Name","value":"notificationPreferences"}}]}}]}},...CommonUserFieldsFragmentDoc.definitions]} as unknown as DocumentNode<ExtraUserDataQuery, ExtraUserDataQueryVariables>;
+export const UserFavoriteStreamsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserFavoriteStreams"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"activeUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonUserFields"}},{"kind":"Field","name":{"kind":"Name","value":"favoriteStreams"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"cursor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}}},{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"IntValue","value":"10"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonStreamFields"}}]}}]}}]}}]}},...CommonUserFieldsFragmentDoc.definitions,...CommonStreamFieldsFragmentDoc.definitions]} as unknown as DocumentNode<UserFavoriteStreamsQuery, UserFavoriteStreamsQueryVariables>;
+export const MainUserDataDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MainUserData"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"activeUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonUserFields"}}]}}]}},...CommonUserFieldsFragmentDoc.definitions]} as unknown as DocumentNode<MainUserDataQuery, MainUserDataQueryVariables>;
+export const ProfileSelfDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ProfileSelf"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"activeUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"CommonUserFields"}},{"kind":"Field","name":{"kind":"Name","value":"totalOwnedStreamsFavorites"}},{"kind":"Field","name":{"kind":"Name","value":"notificationPreferences"}}]}}]}},...CommonUserFieldsFragmentDoc.definitions]} as unknown as DocumentNode<ProfileSelfQuery, ProfileSelfQueryVariables>;
 export const UserSearchDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserSearch"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"query"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"limit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"archived"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userSearch"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"query"},"value":{"kind":"Variable","name":{"kind":"Name","value":"query"}}},{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"limit"}}},{"kind":"Argument","name":{"kind":"Name","value":"cursor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}}},{"kind":"Argument","name":{"kind":"Name","value":"archived"},"value":{"kind":"Variable","name":{"kind":"Name","value":"archived"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"LimitedUserFields"}}]}}]}}]}},...LimitedUserFieldsFragmentDoc.definitions]} as unknown as DocumentNode<UserSearchQuery, UserSearchQueryVariables>;
-export const IsLoggedInDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"IsLoggedIn"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<IsLoggedInQuery, IsLoggedInQueryVariables>;
+export const IsLoggedInDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"IsLoggedIn"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"activeUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<IsLoggedInQuery, IsLoggedInQueryVariables>;
 export const AdminUsersListDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"AdminUsersList"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"limit"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"offset"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"query"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"adminUsers"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"limit"}}},{"kind":"Argument","name":{"kind":"Name","value":"offset"},"value":{"kind":"Variable","name":{"kind":"Name","value":"offset"}}},{"kind":"Argument","name":{"kind":"Name","value":"query"},"value":{"kind":"Variable","name":{"kind":"Name","value":"query"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"registeredUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"bio"}},{"kind":"Field","name":{"kind":"Name","value":"company"}},{"kind":"Field","name":{"kind":"Name","value":"avatar"}},{"kind":"Field","name":{"kind":"Name","value":"verified"}},{"kind":"Field","name":{"kind":"Name","value":"profiles"}},{"kind":"Field","name":{"kind":"Name","value":"role"}},{"kind":"Field","name":{"kind":"Name","value":"authorizedApps"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"invitedUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"invitedBy"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]}}]}}]} as unknown as DocumentNode<AdminUsersListQuery, AdminUsersListQueryVariables>;
-export const UserTimelineDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserTimeline"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"timeline"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"cursor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ActivityMainFields"}}]}}]}}]}}]}},...ActivityMainFieldsFragmentDoc.definitions]} as unknown as DocumentNode<UserTimelineQuery, UserTimelineQueryVariables>;
+export const UserTimelineDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserTimeline"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"activeUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"timeline"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"cursor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ActivityMainFields"}}]}}]}}]}}]}},...ActivityMainFieldsFragmentDoc.definitions]} as unknown as DocumentNode<UserTimelineQuery, UserTimelineQueryVariables>;
 export const ValidatePasswordStrengthDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ValidatePasswordStrength"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"pwd"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userPwdStrength"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"pwd"},"value":{"kind":"Variable","name":{"kind":"Name","value":"pwd"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"score"}},{"kind":"Field","name":{"kind":"Name","value":"feedback"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"warning"}},{"kind":"Field","name":{"kind":"Name","value":"suggestions"}}]}}]}}]}}]} as unknown as DocumentNode<ValidatePasswordStrengthQuery, ValidatePasswordStrengthQueryVariables>;
-export const EmailVerificationBannerStateDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"EmailVerificationBannerState"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"verified"}},{"kind":"Field","name":{"kind":"Name","value":"hasPendingVerification"}}]}}]}}]} as unknown as DocumentNode<EmailVerificationBannerStateQuery, EmailVerificationBannerStateQueryVariables>;
+export const EmailVerificationBannerStateDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"EmailVerificationBannerState"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"activeUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"verified"}},{"kind":"Field","name":{"kind":"Name","value":"hasPendingVerification"}}]}}]}}]} as unknown as DocumentNode<EmailVerificationBannerStateQuery, EmailVerificationBannerStateQueryVariables>;
 export const RequestVerificationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RequestVerification"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"requestVerification"}}]}}]} as unknown as DocumentNode<RequestVerificationMutation, RequestVerificationMutationVariables>;
 export const UpdateUserNotificationPreferencesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateUserNotificationPreferences"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"preferences"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"JSONObject"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userNotificationPreferencesUpdate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"preferences"},"value":{"kind":"Variable","name":{"kind":"Name","value":"preferences"}}}]}]}}]} as unknown as DocumentNode<UpdateUserNotificationPreferencesMutation, UpdateUserNotificationPreferencesMutationVariables>;
-export const UserByIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserById"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"bio"}},{"kind":"Field","name":{"kind":"Name","value":"company"}},{"kind":"Field","name":{"kind":"Name","value":"avatar"}},{"kind":"Field","name":{"kind":"Name","value":"verified"}},{"kind":"Field","name":{"kind":"Name","value":"profiles"}},{"kind":"Field","name":{"kind":"Name","value":"role"}}]}}]}}]} as unknown as DocumentNode<UserByIdQuery, UserByIdQueryVariables>;
-export const UserProfileDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserProfile"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"bio"}},{"kind":"Field","name":{"kind":"Name","value":"company"}},{"kind":"Field","name":{"kind":"Name","value":"avatar"}},{"kind":"Field","name":{"kind":"Name","value":"verified"}}]}}]}}]} as unknown as DocumentNode<UserProfileQuery, UserProfileQueryVariables>;
+export const UserByIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserById"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"otherUser"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"bio"}},{"kind":"Field","name":{"kind":"Name","value":"company"}},{"kind":"Field","name":{"kind":"Name","value":"avatar"}},{"kind":"Field","name":{"kind":"Name","value":"verified"}}]}}]}}]} as unknown as DocumentNode<UserByIdQuery, UserByIdQueryVariables>;
+export const UserProfileDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UserProfile"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"otherUser"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"bio"}},{"kind":"Field","name":{"kind":"Name","value":"company"}},{"kind":"Field","name":{"kind":"Name","value":"avatar"}},{"kind":"Field","name":{"kind":"Name","value":"verified"}}]}}]}}]} as unknown as DocumentNode<UserProfileQuery, UserProfileQueryVariables>;
 export const WebhookDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"webhook"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"streamId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"webhookId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"stream"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"streamId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"role"}},{"kind":"Field","name":{"kind":"Name","value":"webhooks"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"webhookId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"streamId"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"triggers"}},{"kind":"Field","name":{"kind":"Name","value":"enabled"}},{"kind":"Field","name":{"kind":"Name","value":"history"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"IntValue","value":"1"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"statusInfo"}}]}}]}}]}}]}}]}}]}}]} as unknown as DocumentNode<WebhookQuery, WebhookQueryVariables>;
 export const WebhooksDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"webhooks"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"streamId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"stream"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"streamId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"role"}},{"kind":"Field","name":{"kind":"Name","value":"webhooks"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"streamId"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"triggers"}},{"kind":"Field","name":{"kind":"Name","value":"enabled"}},{"kind":"Field","name":{"kind":"Name","value":"history"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"IntValue","value":"50"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"statusInfo"}},{"kind":"Field","name":{"kind":"Name","value":"lastUpdate"}}]}}]}}]}}]}}]}}]}}]} as unknown as DocumentNode<WebhooksQuery, WebhooksQueryVariables>;

--- a/packages/frontend/src/graphql/user.js
+++ b/packages/frontend/src/graphql/user.js
@@ -33,7 +33,7 @@ export const commonUserFieldsFragment = gql`
  */
 export const userFavoriteStreamsQuery = gql`
   query UserFavoriteStreams($cursor: String) {
-    user {
+    activeUser {
       ...CommonUserFields
       favoriteStreams(cursor: $cursor, limit: 10) {
         totalCount
@@ -54,7 +54,7 @@ export const userFavoriteStreamsQuery = gql`
  */
 export const mainUserDataQuery = gql`
   query MainUserData {
-    user {
+    activeUser {
       ...CommonUserFields
     }
   }
@@ -66,8 +66,8 @@ export const mainUserDataQuery = gql`
  * Main metadata + extra info shown on profile page
  */
 export const profileSelfQuery = gql`
-  query ExtraUserData {
-    user {
+  query ProfileSelf {
+    activeUser {
       ...CommonUserFields
       totalOwnedStreamsFavorites
       notificationPreferences
@@ -98,7 +98,7 @@ export const userSearchQuery = gql`
  */
 export const isLoggedInQuery = gql`
   query IsLoggedIn {
-    user {
+    activeUser {
       id
     }
   }
@@ -142,7 +142,7 @@ export const adminUsersListQuery = gql`
 
 export const userTimelineQuery = gql`
   query UserTimeline($cursor: DateTime) {
-    user {
+    activeUser {
       id
       timeline(cursor: $cursor) {
         totalCount
@@ -171,7 +171,7 @@ export const validatePasswordStrengthQuery = gql`
 
 export const emailVerificationBannerStateQuery = gql`
   query EmailVerificationBannerState {
-    user {
+    activeUser {
       id
       email
       verified

--- a/packages/frontend/src/graphql/userById.gql
+++ b/packages/frontend/src/graphql/userById.gql
@@ -1,13 +1,10 @@
 query UserById($id: String!) {
-  user(id: $id) {
+  otherUser(id: $id) {
     id
-    email
     name
     bio
     company
     avatar
     verified
-    profiles
-    role
   }
 }

--- a/packages/frontend/src/graphql/userProfile.gql
+++ b/packages/frontend/src/graphql/userProfile.gql
@@ -1,5 +1,5 @@
 query UserProfile($id: String!) {
-  user(id: $id) {
+  otherUser(id: $id) {
     id
     name
     bio

--- a/packages/frontend/src/main/app.js
+++ b/packages/frontend/src/main/app.js
@@ -27,9 +27,11 @@ Vue.use(VueFilterDateFormat)
 
 import PerfectScrollbar from 'vue2-perfect-scrollbar'
 import 'vue2-perfect-scrollbar/dist/vue2-perfect-scrollbar.css'
+
 // adds various helper methods
 import '@/plugins/helpers'
 import { AppLocalStorage } from '@/utils/localStorage'
+import { InvalidAuthTokenError } from '@/main/lib/auth/errors'
 
 Vue.use(PerfectScrollbar)
 
@@ -48,37 +50,8 @@ Vue.filter('capitalize', (value) => {
   return value.charAt(0).toUpperCase() + value.slice(1)
 })
 
-const AuthToken = AppLocalStorage.get(LocalStorageKeys.AuthToken)
-const RefreshToken = AppLocalStorage.get(LocalStorageKeys.RefreshToken)
-
 const apolloProvider = createProvider()
 installVueApollo(apolloProvider)
-
-// TODO: Sort out error handling here, if something goes wrong it just goes into an infinite loop
-if (AuthToken) {
-  prefetchUserAndSetID(apolloProvider.defaultClient)
-    .then(() => {
-      postAuthInit()
-    })
-    .catch(() => {
-      if (RefreshToken) {
-        // TODO: try to rotate token & prefetch user, etc.
-      }
-
-      window.location = `${window.location.origin}/authn/login`
-    })
-} else {
-  checkAccessCodeAndGetTokens()
-    .then(() => {
-      return prefetchUserAndSetID(apolloProvider.defaultClient)
-    })
-    .then(() => {
-      postAuthInit()
-    })
-    .catch(() => {
-      postAuthInit()
-    })
-}
 
 function postAuthInit() {
   // Init mixpanel
@@ -96,5 +69,32 @@ function postAuthInit() {
     render: (h) => h(App)
   }).$mount('#app')
 }
+
+async function init() {
+  const authToken = AppLocalStorage.get(LocalStorageKeys.AuthToken)
+
+  // no auth token - check if we can resolve it from access code
+  if (!authToken) {
+    await checkAccessCodeAndGetTokens()
+  }
+
+  // try to retrieve user info with auth token
+  try {
+    await prefetchUserAndSetID(apolloProvider.defaultClient)
+  } catch (e) {
+    if (e instanceof InvalidAuthTokenError) {
+      // data retrieval failed and user was logged out - go to login page
+      window.location = `${window.location.origin}/authn/login`
+      return
+    }
+
+    // Log and continue
+    console.error(e)
+  }
+
+  // Init app
+  postAuthInit()
+}
+init()
 
 export { apolloProvider }

--- a/packages/frontend/src/main/components/activity/ListItemActivity.vue
+++ b/packages/frontend/src/main/components/activity/ListItemActivity.vue
@@ -305,24 +305,25 @@ export default {
     you: {
       query: gql`
         query {
-          user {
+          activeUser {
             id
             name
           }
         }
       `,
-      update: (data) => data.user
+      update: (data) => data.activeUser
     },
     user: {
       query: gql`
-        query ($id: String) {
-          user(id: $id) {
+        query ($id: String!) {
+          otherUser(id: $id) {
             name
             avatar
             id
           }
         }
       `,
+      update: (data) => data.otherUser,
       variables() {
         return {
           id: this.lastActivity.userId

--- a/packages/frontend/src/main/components/activity/UserPill.vue
+++ b/packages/frontend/src/main/components/activity/UserPill.vue
@@ -34,15 +34,15 @@ export default {
   apollo: {
     targetUser: {
       query: gql`
-        query targetUser($id: String) {
-          user(id: $id) {
+        query targetUser($id: String!) {
+          otherUser(id: $id) {
             name
             avatar
             id
           }
         }
       `,
-      update: (data) => data.user,
+      update: (data) => data.otherUser,
       variables() {
         return {
           id: this.userId

--- a/packages/frontend/src/main/components/auth/UserAvatarAuthoriseApp.vue
+++ b/packages/frontend/src/main/components/auth/UserAvatarAuthoriseApp.vue
@@ -45,6 +45,9 @@ export default {
         return {
           id: this.id
         }
+      },
+      update(data) {
+        return data.otherUser
       }
     }
   },

--- a/packages/frontend/src/main/components/comments/CommentThreadViewer.vue
+++ b/packages/frontend/src/main/components/comments/CommentThreadViewer.vue
@@ -208,10 +208,10 @@
       </v-card>
     </v-dialog>
   </div>
-  <!-- 
+  <!--
     Note: portaling out the mobile view of comment threads because of
     stacking chaos caused by transforms, etc. in positioning from the default
-    view. 
+    view.
   -->
   <div v-else-if="comment.expanded">
     <portal to="mobile-comment-thread">
@@ -253,9 +253,9 @@
               <v-icon>mdi-close</v-icon>
             </v-btn>
           </v-toolbar>
-          <!-- 
+          <!--
             I know, this is bad copy paste. Sigh. Currently, one can only wish for a better world
-            with less technical debt. 
+            with less technical debt.
           -->
           <div
             style="width: 100%"
@@ -465,12 +465,13 @@ export default {
     user: {
       query: gql`
         query {
-          user {
+          activeUser {
             name
             id
           }
         }
       `,
+      update: (data) => data.activeUser,
       skip() {
         return !this.$loggedIn()
       }

--- a/packages/frontend/src/main/components/common/NoDataPlaceholder.vue
+++ b/packages/frontend/src/main/components/common/NoDataPlaceholder.vue
@@ -151,7 +151,7 @@ export default {
     user: {
       query: gql`
         query {
-          user {
+          activeUser {
             id
             authorizedApps {
               id
@@ -159,7 +159,8 @@ export default {
             }
           }
         }
-      `
+      `,
+      update: (data) => data.activeUser
     }
   },
   data() {

--- a/packages/frontend/src/main/components/common/UserAvatar.vue
+++ b/packages/frontend/src/main/components/common/UserAvatar.vue
@@ -118,7 +118,7 @@ export default defineComponent({
       () => ({ id: props.id }),
       () => ({ enabled: isLoggedIn.value })
     )
-    const userById = computed(() => userByIdResult.value?.user)
+    const userById = computed(() => userByIdResult.value?.otherUser)
 
     return { isLoggedIn, userById }
   },

--- a/packages/frontend/src/main/components/common/utility/PrioritizedPortal.vue
+++ b/packages/frontend/src/main/components/common/utility/PrioritizedPortal.vue
@@ -32,6 +32,8 @@ export default defineComponent({
     /**
      * Priority helps figure out which portal entrypoint should take precedence if multiple portals
      * attempt to use the same portal-target. A higher number = higher priority.
+     *
+     * Note: This value isn't reactive and can't be changed during runtime
      */
     priority: {
       type: Number,

--- a/packages/frontend/src/main/components/feed/FeedTimeline.vue
+++ b/packages/frontend/src/main/components/feed/FeedTimeline.vue
@@ -107,14 +107,17 @@ export default {
       { fetchPolicy: 'cache-and-network' }
     )
     const timeline = computed(() => {
-      return timelineResult.value?.user?.timeline || null
+      return timelineResult.value?.activeUser?.timeline || null
     })
     const groupedTimeline = computed(() => {
       const data = timelineResult.value
       if (!data) return []
 
       const skippableActionTypes = SKIPPABLE_ACTION_TYPES
-      const groupedTimeline = data.user.timeline.items.reduce(function (prev, curr) {
+      const groupedTimeline = data.activeUser.timeline.items.reduce(function (
+        prev,
+        curr
+      ) {
         if (skippableActionTypes.includes(curr.actionType)) {
           return prev
         }
@@ -159,7 +162,8 @@ export default {
           prev.push([curr])
         }
         return prev
-      }, [])
+      },
+      [])
 
       return groupedTimeline
     })
@@ -167,7 +171,7 @@ export default {
     // Quick user info
     const { result: quickUserResult, loading: quickUserLoading } = useQuery(gql`
       query {
-        quickUser: user {
+        quickUser: activeUser {
           id
           name
         }
@@ -224,7 +228,7 @@ export default {
         }
       })
 
-      const newItems = result.data?.user?.timeline?.items || []
+      const newItems = result.data?.activeUser?.timeline?.items || []
       if (!newItems.length) {
         $state.complete()
       } else {

--- a/packages/frontend/src/main/components/stream/commit/CommitMultiSelectToolbar.vue
+++ b/packages/frontend/src/main/components/stream/commit/CommitMultiSelectToolbar.vue
@@ -68,9 +68,9 @@ export default defineComponent({
       showDialog.value = true
       dialogType.value = BatchActionType.Delete
     }
-    const onFinish = () => {
+    const onFinish = (payload: unknown) => {
       clear()
-      emit('finish')
+      emit('finish', payload)
     }
 
     return { clear, count, showDialog, initMove, initDelete, onFinish, dialogType }

--- a/packages/frontend/src/main/components/stream/favorites/StreamFavoriteBtn.vue
+++ b/packages/frontend/src/main/components/stream/favorites/StreamFavoriteBtn.vue
@@ -83,7 +83,7 @@ export default {
           // Doesn't exist, no need to update anything
           if (!data) return
 
-          const streams = data?.user?.favoriteStreams?.items || []
+          const streams = data?.activeUser?.favoriteStreams?.items || []
           let newStreams, newTotalCount
 
           if (isNowFavorited) {
@@ -96,27 +96,29 @@ export default {
 
             newStreams = streams.slice()
             newStreams.unshift(stream)
-            newTotalCount = data.user.favoriteStreams.totalCount + 1
+            newTotalCount = data.activeUser.favoriteStreams.totalCount + 1
           } else {
             // Drop from favorite streams query
             if (streams.length < 1) return
 
             newStreams = streams.filter((s) => s.id !== id)
-            newTotalCount = data.user.favoriteStreams.totalCount - 1
+            newTotalCount = data.activeUser.favoriteStreams.totalCount - 1
           }
 
           cache.writeQuery({
             query: userFavoriteStreamsQuery,
             data: {
-              user: {
-                ...data.user,
+              activeUser: {
+                ...data.activeUser,
                 favoriteStreams: {
-                  ...data.user.favoriteStreams,
+                  ...data.activeUser.favoriteStreams,
                   items: newStreams,
-                  totalCount: Math.min(newTotalCount - 1, 0)
+                  totalCount: Math.max(newTotalCount, 0)
                 }
               }
-            }
+            },
+            // So that we don't trigger the merge() function
+            overwrite: true
           })
         }
       })

--- a/packages/frontend/src/main/components/user/EmailVerificationBanner.vue
+++ b/packages/frontend/src/main/components/user/EmailVerificationBanner.vue
@@ -57,7 +57,7 @@ export default defineComponent({
   setup() {
     const { result } = useQuery(EmailVerificationBannerStateDocument)
 
-    const user = computed(() => result.value?.user || null)
+    const user = computed(() => result.value?.activeUser || null)
     const shouldShowBanner = computed(() => {
       if (!user.value) return false
       if (user.value.verified) return false

--- a/packages/frontend/src/main/components/user/UserAccessTokens.vue
+++ b/packages/frontend/src/main/components/user/UserAccessTokens.vue
@@ -49,7 +49,7 @@ export default {
     tokens: {
       query: gql`
         query {
-          user {
+          activeUser {
             id
             apiTokens {
               id
@@ -62,7 +62,7 @@ export default {
           }
         }
       `,
-      update: (data) => data.user.apiTokens
+      update: (data) => data.activeUser.apiTokens
     }
   },
   methods: {

--- a/packages/frontend/src/main/components/user/UserApps.vue
+++ b/packages/frontend/src/main/components/user/UserApps.vue
@@ -43,7 +43,7 @@ export default {
     apps: {
       query: gql`
         query {
-          user {
+          activeUser {
             id
             createdApps {
               id
@@ -55,7 +55,7 @@ export default {
           }
         }
       `,
-      update: (data) => data.user.createdApps
+      update: (data) => data.activeUser.createdApps
     }
   },
   methods: {

--- a/packages/frontend/src/main/components/user/UserAuthorisedApps.vue
+++ b/packages/frontend/src/main/components/user/UserAuthorisedApps.vue
@@ -83,7 +83,7 @@ export default {
     authorizedApps: {
       query: gql`
         query {
-          user {
+          activeUser {
             id
             authorizedApps {
               id
@@ -96,7 +96,7 @@ export default {
         }
       `,
       update: (data) =>
-        data.user.authorizedApps.filter((app) => app.id !== 'spklwebapp')
+        data.activeUser.authorizedApps.filter((app) => app.id !== 'spklwebapp')
     }
   },
   computed: {

--- a/packages/frontend/src/main/components/user/UserInfoCard.vue
+++ b/packages/frontend/src/main/components/user/UserInfoCard.vue
@@ -160,7 +160,6 @@ export default {
 
       this.avatarDialog = false
     },
-    //using vue dialogs just like .net modals
     async editUser() {
       this.$refs.userDialog.open(this.user).then((dialog) => {
         if (!dialog.result) return

--- a/packages/frontend/src/main/components/viewer/CommentAddOverlay.vue
+++ b/packages/frontend/src/main/components/viewer/CommentAddOverlay.vue
@@ -1,5 +1,5 @@
 <template>
-  <!-- 
+  <!--
     HIC SVNT DRACONES
   -->
   <div
@@ -267,12 +267,13 @@ export default {
     user: {
       query: gql`
         query {
-          user {
+          activeUser {
             name
             id
           }
         }
       `,
+      update: (data) => data.activeUser,
       skip() {
         return !this.$loggedIn()
       }

--- a/packages/frontend/src/main/components/viewer/ViewerBubbles.vue
+++ b/packages/frontend/src/main/components/viewer/ViewerBubbles.vue
@@ -117,12 +117,13 @@ export default {
     user: {
       query: gql`
         query {
-          user {
+          activeUser {
             id
             name
           }
         }
       `,
+      update: (data) => data.activeUser,
       skip() {
         return !this.isLoggedIn
       }

--- a/packages/frontend/src/main/dialogs/ShareStreamDialog.vue
+++ b/packages/frontend/src/main/dialogs/ShareStreamDialog.vue
@@ -394,7 +394,8 @@ export default {
               data: {
                 ...cachedStream,
                 isPublic: isSuccessFul ? newIsPublic : !newIsPublic
-              }
+              },
+              overwrite: true
             })
           }
         })

--- a/packages/frontend/src/main/dialogs/commit/CommitsBatchActionsDialog.vue
+++ b/packages/frontend/src/main/dialogs/commit/CommitsBatchActionsDialog.vue
@@ -152,7 +152,7 @@ export default defineComponent({
 
         // finished
         close()
-        emit('finish')
+        emit('finish', { type: props.type, variables })
       } else {
         const msg = getFirstErrorMessage(errors)
         triggerNotification({

--- a/packages/frontend/src/main/lib/auth/errors/index.ts
+++ b/packages/frontend/src/main/lib/auth/errors/index.ts
@@ -1,0 +1,5 @@
+import { BaseError } from '@/helpers/errorHelper'
+
+export class InvalidAuthTokenError extends BaseError {
+  static defaultMessage = 'Invalid auth token stored locally'
+}

--- a/packages/frontend/src/main/lib/common/apollo/helpers/apolloOperationHelper.ts
+++ b/packages/frontend/src/main/lib/common/apollo/helpers/apolloOperationHelper.ts
@@ -74,10 +74,17 @@ export function updateCacheByFilter<TData, TVariables = unknown>(
      * Default: true
      */
     ignoreCacheErrors: boolean
+
+    /**
+     * Whether to overwrite the old cache results, instead of triggering a merge function
+     * to merge the old and new results.
+     * Default: true
+     */
+    overwrite: boolean
   }> = {}
 ): boolean {
   const { fragment, query } = filter
-  const { ignoreCacheErrors = true } = options
+  const { ignoreCacheErrors = true, overwrite = true } = options
 
   if (!fragment && !query) {
     throw new Error(
@@ -97,10 +104,10 @@ export function updateCacheByFilter<TData, TVariables = unknown>(
 
   const writeData = (data: TData): boolean => {
     if (fragment) {
-      cache.writeFragment({ ...fragment, data })
+      cache.writeFragment({ ...fragment, data, overwrite })
       return true
     } else if (query) {
-      cache.writeQuery({ ...query, data })
+      cache.writeQuery({ ...query, data, overwrite })
       return true
     } else {
       return false

--- a/packages/frontend/src/main/lib/common/text-editor/mentionSuggestion.js
+++ b/packages/frontend/src/main/lib/common/text-editor/mentionSuggestion.js
@@ -14,7 +14,7 @@ export const suggestion = {
       return undefined
     }
 
-    // Execute users() query
+    // Execute users search query
     const client = apolloProvider.defaultClient
     const { data } = await client.query({
       query: userSearchQuery,

--- a/packages/frontend/src/main/lib/core/composables/core.ts
+++ b/packages/frontend/src/main/lib/core/composables/core.ts
@@ -29,7 +29,7 @@ export function useMixpanel(): OverridedMixpanel {
  */
 export function useIsLoggedIn() {
   const { result } = useQuery(IsLoggedInDocument)
-  const userId = computed(() => result.value?.user?.id)
+  const userId = computed(() => result.value?.activeUser?.id)
   const isLoggedIn = computed(() => !!userId.value)
   return { isLoggedIn, userId }
 }

--- a/packages/frontend/src/main/lib/core/composables/notifications.ts
+++ b/packages/frontend/src/main/lib/core/composables/notifications.ts
@@ -5,7 +5,7 @@ import {
   NotificationEventPayload,
   ToastNotificationType
 } from '@/main/lib/core/helpers/eventHubHelper'
-import Vue, { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import Vue, { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
 const globalToastState = Vue.observable({
   isInitialized: false,
@@ -44,11 +44,16 @@ export function setupGlobalToast() {
   })
 
   const handleEvent = (e: NotificationEventPayload) => {
-    snack.value = true
-    text.value = e.text
-    actionName.value = e.action ? e.action.name : null
-    to.value = e.action ? e.action.to : null
-    type.value = e.type || 'primary'
+    // first set snack.value to false so that the previous notification gets removed
+    // then wait for next tick so that we're sure vuetify has reset the timeout
+    snack.value = false
+    nextTick().then(() => {
+      snack.value = true
+      text.value = e.text
+      actionName.value = e.action ? e.action.name : null
+      to.value = e.action ? e.action.to : null
+      type.value = e.type || 'primary'
+    })
   }
 
   onMounted(() => {

--- a/packages/frontend/src/main/lib/core/mixins/isLoggedInMixin.ts
+++ b/packages/frontend/src/main/lib/core/mixins/isLoggedInMixin.ts
@@ -15,7 +15,7 @@ export const IsLoggedInMixin = Vue.extend({
   apollo: {
     isLoggedIn: {
       query: IsLoggedInDocument,
-      update: (data: IsLoggedInQuery) => !!data.user?.id
+      update: (data: IsLoggedInQuery) => !!data.activeUser?.id
     }
   }
 })

--- a/packages/frontend/src/main/lib/stream/composables/commitMultiActions.ts
+++ b/packages/frontend/src/main/lib/stream/composables/commitMultiActions.ts
@@ -1,10 +1,8 @@
 import { SetupProps } from '@/helpers/typeHelpers'
+import { BatchActionType } from '@/main/lib/stream/services/commitMultiActions'
 import { ref, computed, SetupContext } from 'vue'
 
-export enum BatchActionType {
-  Move = 'move',
-  Delete = 'delete'
-}
+export { BatchActionType }
 
 /**
  * Composable for setting up commit multi-select & actions like delete, move etc.

--- a/packages/frontend/src/main/lib/stream/mixins/streamInviteMixin.ts
+++ b/packages/frontend/src/main/lib/stream/mixins/streamInviteMixin.ts
@@ -106,7 +106,8 @@ export const UsersStreamInviteMixin = vueWithMixins(IsLoggedInMixin).extend({
                 ...singleStreamInviteCacheFilter,
                 data: {
                   streamInvite: null
-                }
+                },
+                overwrite: true
               })
             }
 
@@ -135,7 +136,8 @@ export const UsersStreamInviteMixin = vueWithMixins(IsLoggedInMixin).extend({
                   data: {
                     ...allUsersStreamInvitesQueryData,
                     streamInvites: newInvites
-                  }
+                  },
+                  overwrite: true
                 })
               }
             }

--- a/packages/frontend/src/main/lib/stream/services/commitMultiActions.ts
+++ b/packages/frontend/src/main/lib/stream/services/commitMultiActions.ts
@@ -1,0 +1,32 @@
+import { ApolloCache } from '@apollo/client/cache'
+
+export enum BatchActionType {
+  Move = 'move',
+  Delete = 'delete'
+}
+
+export function deleteCommitsFromCachedCommitsQuery(
+  cache: ApolloCache<unknown>,
+  parentObjectCacheId: string,
+  commitIds: string[]
+) {
+  cache.modify({
+    id: parentObjectCacheId,
+    fields: {
+      commits(oldCommits: { totalCount: number; items: Array<{ __ref: string }> }) {
+        const newTotalCount = Math.max(oldCommits.totalCount - commitIds.length, 0)
+
+        // old items don't hold the ID prop, but a __ref prop like this 'Commit:XXXXX'
+        const newItems = oldCommits.items.filter(
+          (c) => !commitIds.includes(c.__ref.split(':')[1])
+        )
+
+        return {
+          ...oldCommits,
+          totalCount: newTotalCount,
+          items: newItems
+        }
+      }
+    }
+  })
+}

--- a/packages/frontend/src/main/navigation/MainNav.vue
+++ b/packages/frontend/src/main/navigation/MainNav.vue
@@ -150,7 +150,8 @@ export default {
       query: mainUserDataQuery,
       skip() {
         return !this.$loggedIn()
-      }
+      },
+      update: (data) => data.activeUser
     }
   },
   data() {

--- a/packages/frontend/src/main/pages/TheFavoriteStreams.vue
+++ b/packages/frontend/src/main/pages/TheFavoriteStreams.vue
@@ -65,13 +65,13 @@ export default defineComponent({
     const { result, fetchMore: userFetchMore } = useQuery(UserFavoriteStreamsDocument, {
       cursor: null as Nullable<string>
     })
-    const user = computed(() => result.value?.user)
+    const user = computed(() => result.value?.activeUser)
 
     return { canRenderToolbarPortal, user, userFetchMore }
   },
   computed: {
     streams(): NonNullable<
-      Get<UserFavoriteStreamsQuery, 'user.favoriteStreams.items'>
+      Get<UserFavoriteStreamsQuery, 'activeUser.favoriteStreams.items'>
     > {
       return this.user?.favoriteStreams?.items || []
     },
@@ -100,7 +100,7 @@ export default defineComponent({
         }
       })
 
-      const newItems = result?.data?.user?.favoriteStreams?.items || []
+      const newItems = result?.data?.activeUser?.favoriteStreams?.items || []
       if (!newItems.length) {
         $state.complete()
       } else {

--- a/packages/frontend/src/main/pages/TheStreams.vue
+++ b/packages/frontend/src/main/pages/TheStreams.vue
@@ -106,7 +106,8 @@ export default {
   mixins: [buildPortalStateMixin([STANDARD_PORTAL_KEYS.Toolbar], 'streams', 0)],
   apollo: {
     user: {
-      query: mainUserDataQuery
+      query: mainUserDataQuery,
+      update: (data) => data.activeUser
     }
   },
   setup() {

--- a/packages/frontend/src/main/pages/admin/Admin.vue
+++ b/packages/frontend/src/main/pages/admin/Admin.vue
@@ -42,12 +42,13 @@ export default {
     user: {
       query: gql`
         query {
-          user {
+          activeUser {
             role
             id
           }
         }
       `,
+      update: (data) => data.activeUser,
       prefetch: true
     }
   },

--- a/packages/frontend/src/main/pages/admin/Invites.vue
+++ b/packages/frontend/src/main/pages/admin/Invites.vue
@@ -140,12 +140,13 @@ export default {
     user: {
       query: gql`
         query {
-          user {
+          activeUser {
             id
             name
           }
         }
       `,
+      update: (data) => data.activeUser,
       prefetch: true
     },
     serverInfo: {

--- a/packages/frontend/src/main/pages/stream/TheCollaborators.vue
+++ b/packages/frontend/src/main/pages/stream/TheCollaborators.vue
@@ -321,6 +321,7 @@ export default vueWithMixins(IsLoggedInMixin).extend({
               (c) => c.inviteId !== inviteId
             )
             const newData = {
+              ...cachedData,
               stream: {
                 ...cachedData.stream,
                 pendingCollaborators: newPendingCollaborators
@@ -330,7 +331,8 @@ export default vueWithMixins(IsLoggedInMixin).extend({
             store.writeQuery({
               query: StreamWithCollaboratorsDocument,
               variables: { id: streamId },
-              data: newData
+              data: newData,
+              overwrite: true
             })
           }
         })

--- a/packages/frontend/src/main/pages/stream/TheStream.vue
+++ b/packages/frontend/src/main/pages/stream/TheStream.vue
@@ -138,7 +138,7 @@ export default defineComponent({
   data() {
     return {
       error: null as Nullable<ApolloError>,
-      user: null as Nullable<Get<MainUserDataQuery, 'user'>>,
+      user: null as Nullable<Get<MainUserDataQuery, 'activeUser'>>,
       streamInvite: null as Nullable<StreamInviteType>,
       shareStream: false,
       branchMenuOpen: false,
@@ -207,7 +207,8 @@ export default defineComponent({
       }
     },
     user: {
-      query: MainUserDataDocument
+      query: MainUserDataDocument,
+      update: (data) => data.activeUser
     },
     $subscribe: {
       branchCreated: {
@@ -298,7 +299,8 @@ export default defineComponent({
             cache.writeQuery({
               query: GetStreamAccessRequestDocument,
               variables: { streamId: this.streamId },
-              data: { streamAccessRequest: { ...newReq } }
+              data: { streamAccessRequest: { ...newReq } },
+              overwrite: true
             })
           }
         })

--- a/packages/frontend/src/main/pages/user/TheProfileSelf.vue
+++ b/packages/frontend/src/main/pages/user/TheProfileSelf.vue
@@ -67,7 +67,8 @@ export default {
   ],
   apollo: {
     user: {
-      query: profileSelfQuery
+      query: profileSelfQuery,
+      update: (data) => data.activeUser
     }
   },
   methods: {

--- a/packages/frontend/src/main/pages/user/TheProfileUser.vue
+++ b/packages/frontend/src/main/pages/user/TheProfileUser.vue
@@ -1,8 +1,8 @@
 <template>
   <v-container fluid class="pa-0">
-    <portal v-if="canRenderToolbarPortal && user" to="toolbar">
+    <prioritized-portal v-if="user" to="toolbar" identity="user-profile" :priority="1">
       Profile Page of {{ user.name }}
-    </portal>
+    </prioritized-portal>
     <v-row v-if="$apollo.loading">
       <v-col cols="12">
         <v-skeleton-loader type="card, article"></v-skeleton-loader>
@@ -42,34 +42,28 @@
 <script>
 import ListItemStream from '@/main/components/user/ListItemStream'
 import { gql } from '@apollo/client/core'
-import {
-  STANDARD_PORTAL_KEYS,
-  buildPortalStateMixin
-} from '@/main/utils/portalStateManager'
 import { AppLocalStorage } from '@/utils/localStorage'
+import PrioritizedPortal from '@/main/components/common/utility/PrioritizedPortal.vue'
 
 export default {
   name: 'TheProfileUser',
   components: {
     UserInfoCard: () => import('@/main/components/user/UserInfoCard'),
     SectionCard: () => import('@/main/components/common/SectionCard'),
-    ListItemStream
+    ListItemStream,
+    PrioritizedPortal
   },
-  mixins: [buildPortalStateMixin([STANDARD_PORTAL_KEYS.Toolbar], 'user-profile', 1)],
   apollo: {
     user: {
       query: gql`
         query User($id: String!) {
-          user(id: $id) {
+          otherUser(id: $id) {
             id
-            email
             name
             bio
             company
             avatar
             verified
-            profiles
-            role
             totalOwnedStreamsFavorites
             streams {
               totalCount
@@ -86,6 +80,7 @@ export default {
           }
         }
       `,
+      update: (data) => data.otherUser,
       variables() {
         return {
           id: this.$route.params.userId

--- a/packages/frontend/src/plugins/authHelpers.js
+++ b/packages/frontend/src/plugins/authHelpers.js
@@ -1,8 +1,10 @@
 import { mainUserDataQuery } from '@/graphql/user'
 import { LocalStorageKeys } from '@/helpers/mainConstants'
 import md5 from '@/helpers/md5'
+import { InvalidAuthTokenError } from '@/main/lib/auth/errors'
 import { VALID_EMAIL_REGEX } from '@/main/lib/common/vuetify/validators'
 import { AppLocalStorage } from '@/utils/localStorage'
+import { has } from 'lodash'
 
 const appId = 'spklwebapp'
 const appSecret = 'spklwebapp'
@@ -13,27 +15,24 @@ export function getAuthToken() {
 
 /**
  * Checks for an access token in the url and tries to exchange it for a token/refresh pair.
- * @return {boolean} true if everything is ok, otherwise throws an error.
+ * @return {Promise<boolean>} true if everything is ok, otherwise throws an error.
  */
 export async function checkAccessCodeAndGetTokens() {
   const accessCode = new URLSearchParams(window.location.search).get('access_code')
-  if (accessCode) {
-    const response = await getTokenFromAccessCode(accessCode)
-    // eslint-disable-next-line no-prototype-builtins
-    if (response.hasOwnProperty('token')) {
-      AppLocalStorage.set(LocalStorageKeys.AuthToken, response.token)
-      AppLocalStorage.set(LocalStorageKeys.RefreshToken, response.refreshToken)
-      return true
-    }
-  } else {
-    throw new Error(`No access code present in the url: ${window.location.href}`)
+  if (!accessCode) return false
+
+  const response = await getTokenFromAccessCode(accessCode)
+  if (has(response, 'token')) {
+    AppLocalStorage.set(LocalStorageKeys.AuthToken, response.token)
+    AppLocalStorage.set(LocalStorageKeys.RefreshToken, response.refreshToken)
+    return true
   }
 }
 
 /**
  * Gets the user id and sets it in localStorage
  * @param {import('@apollo/client/core').ApolloClient} apolloClient
- * @return {Object} The full graphql response.
+ * @return {Promise<Object>} The full graphql response.
  */
 export async function prefetchUserAndSetID(apolloClient) {
   const token = AppLocalStorage.get(LocalStorageKeys.AuthToken)
@@ -44,15 +43,16 @@ export async function prefetchUserAndSetID(apolloClient) {
     query: mainUserDataQuery
   })
 
-  if (data.user) {
-    const distinctId = '@' + md5(data.user.email.toLowerCase()).toUpperCase()
+  const user = data.activeUser
+  if (user) {
+    const distinctId = '@' + md5(user.email.toLowerCase()).toUpperCase()
     AppLocalStorage.set('distinct_id', distinctId)
-    AppLocalStorage.set('uuid', data.user.id)
-    AppLocalStorage.set('stcount', data.user.streams.totalCount)
+    AppLocalStorage.set('uuid', user.id)
+    AppLocalStorage.set('stcount', user.streams.totalCount)
     return data
   } else {
     await signOut()
-    throw new Error('Failed to set user')
+    throw new InvalidAuthTokenError()
   }
 }
 

--- a/packages/server/assets/activitystream/typedefs/activity.graphql
+++ b/packages/server/assets/activitystream/typedefs/activity.graphql
@@ -1,5 +1,3 @@
-# TODO: allow queries
-
 extend type User {
   """
   All the recent activity from this user in chronological order
@@ -11,6 +9,35 @@ extend type User {
     cursor: DateTime
     limit: Int! = 25
   ): ActivityCollection @hasRole(role: "server:user") @hasScope(scope: "users:read")
+
+  """
+  The user's timeline in chronological order
+  """
+  timeline(
+    after: DateTime
+    before: DateTime
+    cursor: DateTime
+    limit: Int! = 25
+  ): ActivityCollection
+    @hasRole(role: "server:user")
+    @hasScopes(scopes: ["users:read", "streams:read"])
+}
+
+extend type LimitedUser {
+  """
+  All the recent activity from this user in chronological order
+  """
+  activity(
+    actionType: String
+    after: DateTime
+    before: DateTime
+    cursor: DateTime
+    limit: Int! = 25
+  ): ActivityCollection @hasRole(role: "server:user") @hasScope(scope: "users:read")
+
+  """
+  The user's timeline in chronological order
+  """
   timeline(
     after: DateTime
     before: DateTime

--- a/packages/server/assets/core/typedefs/branchesAndCommits.graphql
+++ b/packages/server/assets/core/typedefs/branchesAndCommits.graphql
@@ -13,6 +13,13 @@ extend type User {
   commits(limit: Int! = 25, cursor: String): CommitCollection
 }
 
+extend type LimitedUser {
+  """
+  Get public stream commits authored by the user
+  """
+  commits(limit: Int! = 25, cursor: String): CommitCollection
+}
+
 type Branch {
   id: String!
   name: String!

--- a/packages/server/assets/core/typedefs/streams.graphql
+++ b/packages/server/assets/core/typedefs/streams.graphql
@@ -76,7 +76,7 @@ extend type User {
   Returns all streams that the user is a collaborator on. If requested for a user, who isn't the
   authenticated user, then this will only return discoverable streams.
   """
-  streams(limit: Int! = 25, cursor: String): StreamCollection
+  streams(limit: Int! = 25, cursor: String): StreamCollection!
     @hasRole(role: "server:user")
     @hasScope(scope: "streams:read")
 
@@ -84,7 +84,21 @@ extend type User {
   All the streams that a active user has favorited.
   Note: You can't use this to retrieve another user's favorite streams.
   """
-  favoriteStreams(limit: Int! = 25, cursor: String): StreamCollection
+  favoriteStreams(limit: Int! = 25, cursor: String): StreamCollection!
+    @hasRole(role: "server:user")
+    @hasScope(scope: "streams:read")
+
+  """
+  Total amount of favorites attached to streams owned by the user
+  """
+  totalOwnedStreamsFavorites: Int!
+}
+
+extend type LimitedUser {
+  """
+  Returns all discoverable streams that the user is a collaborator on
+  """
+  streams(limit: Int! = 25, cursor: String): StreamCollection!
     @hasRole(role: "server:user")
     @hasScope(scope: "streams:read")
 

--- a/packages/server/assets/core/typedefs/user.graphql
+++ b/packages/server/assets/core/typedefs/user.graphql
@@ -1,8 +1,23 @@
 extend type Query {
   """
+  Gets the profile of the authenticated user or null if not authenticated
+  """
+  activeUser: User
+
+  """
+  Get the (limited) profile information of another server user
+  """
+  otherUser(id: String!): LimitedUser
+    @hasRole(role: "server:user")
+    @hasScope(scope: "users:read")
+
+  """
   Gets the profile of a user. If no id argument is provided, will return the current authenticated user's profile (as extracted from the authorization header).
   """
   user(id: String): User
+    @deprecated(
+      reason: "To be removed in the near future! Use 'activeUser' to get info about the active user or 'otherUser' to get info about another user."
+    )
 
   """
   Get all (or search for specific) users, registered or invited, from the server in a paginated view.
@@ -86,6 +101,7 @@ type LimitedUser {
   company: String
   avatar: String
   verified: Boolean
+  role: String
 }
 
 """

--- a/packages/server/codegen.yml
+++ b/packages/server/codegen.yml
@@ -12,6 +12,7 @@ generates:
       mappers:
         Stream: '@/modules/core/helpers/graphTypes#StreamGraphQLReturn'
         StreamAccessRequest: '@/modules/accessrequests/helpers/graphTypes#StreamAccessRequestGraphQLReturn'
+        LimitedUser: '@/modules/core/helpers/graphTypes#LimitedUserGraphQLReturn'
   test/graphql/generated/graphql.ts:
     plugins:
       - 'typescript'

--- a/packages/server/modules/accessrequests/graph/resolvers/index.ts
+++ b/packages/server/modules/accessrequests/graph/resolvers/index.ts
@@ -6,6 +6,8 @@ import {
 } from '@/modules/accessrequests/services/stream'
 import { Resolvers } from '@/modules/core/graph/generated/graphql'
 import { mapStreamRoleToValue } from '@/modules/core/helpers/graphTypes'
+import { Roles } from '@/modules/core/helpers/mainConstants'
+import { validateStreamAccess } from '@/modules/core/services/streams/streamAccessService'
 import { LogicError } from '@/modules/shared/errors'
 
 const resolvers: Resolvers = {
@@ -60,8 +62,13 @@ const resolvers: Resolvers = {
     async stream(parent, _args, ctx) {
       const { streamId } = parent
       const stream = await ctx.loaders.streams.getStream.load(streamId)
+
       if (!stream) {
         throw new LogicError('Unable to find request stream')
+      }
+
+      if (!stream.isPublic) {
+        await validateStreamAccess(ctx.userId, stream.id, Roles.Stream.Reviewer)
       }
 
       return stream

--- a/packages/server/modules/accessrequests/tests/streamAccessRequests.spec.ts
+++ b/packages/server/modules/accessrequests/tests/streamAccessRequests.spec.ts
@@ -4,7 +4,12 @@ import {
 } from '@/modules/accessrequests/repositories'
 import { requestStreamAccess } from '@/modules/accessrequests/services/stream'
 import { ActionTypes } from '@/modules/activitystream/helpers/types'
-import { ServerAccessRequests, StreamActivity } from '@/modules/core/dbSchema'
+import {
+  ServerAccessRequests,
+  StreamActivity,
+  Streams,
+  Users
+} from '@/modules/core/dbSchema'
 import { mapStreamRoleToValue } from '@/modules/core/helpers/graphTypes'
 import { Roles } from '@/modules/core/helpers/mainConstants'
 import { getStreamCollaborators } from '@/modules/core/repositories/streams'
@@ -16,6 +21,7 @@ import { NotificationType } from '@/modules/notifications/helpers/types'
 import { BasicTestUser, createTestUsers } from '@/test/authHelper'
 import {
   createStreamAccessRequest,
+  getFullStreamAccessRequest,
   getPendingStreamAccessRequests,
   getStreamAccessRequest,
   useStreamAccessRequest
@@ -37,6 +43,10 @@ import { noop } from 'lodash'
 const createReqAndGetId = async (userId: string, streamId: string) => {
   const createReqRes = await requestStreamAccess(userId, streamId)
   return createReqRes.id
+}
+
+const cleanup = async () => {
+  await truncateTables([Streams.name, ServerAccessRequests.name, Users.name])
 }
 
 describe('Stream access requests', () => {
@@ -83,6 +93,7 @@ describe('Stream access requests', () => {
   }
 
   before(async () => {
+    await cleanup()
     await createTestUsers([me, otherGuy, anotherGuy])
     await createTestStreams([
       [otherGuysPrivateStream, otherGuy],
@@ -195,17 +206,21 @@ describe('Stream access requests', () => {
   describe('when being read', () => {
     let myRequestId: string
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let myPublicReqId: string
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     let anotherGuysRequestId: string
 
     beforeEach(async () => {
       await truncateTables([ServerAccessRequests.name])
 
-      const [myNewReqId, anotherGuysNewReqId] = await Promise.all([
+      const [myNewReqId, anotherGuysNewReqId, myNewPublicReqId] = await Promise.all([
         createReqAndGetId(me.id, otherGuysPrivateStream.id),
-        createReqAndGetId(anotherGuy.id, otherGuysPrivateStream.id)
+        createReqAndGetId(anotherGuy.id, otherGuysPrivateStream.id),
+        createReqAndGetId(me.id, otherGuysPublicStream.id)
       ])
       myRequestId = myNewReqId
       anotherGuysRequestId = anotherGuysNewReqId
+      myPublicReqId = myNewPublicReqId
     })
 
     it('returns the request correctly', async () => {
@@ -226,6 +241,25 @@ describe('Stream access requests', () => {
       const results = await getReq(otherGuysPrivateStream.id)
       expect(results).to.not.haveGraphQLErrors()
       expect(results.data?.streamAccessRequest).to.eq(null)
+    })
+
+    it('throws error if attempting to read private stream metadata before has access to it', async () => {
+      const results = await getFullStreamAccessRequest(apollo, {
+        streamId: otherGuysPrivateStream.id
+      })
+
+      expect(results).to.haveGraphQLErrors(
+        'User does not have required access to stream'
+      )
+    })
+
+    it('doesnt throw if attempting to read stream metadata on accessible stream', async () => {
+      const results = await getFullStreamAccessRequest(apollo, {
+        streamId: otherGuysPublicStream.id
+      })
+
+      expect(results).to.not.haveGraphQLErrors()
+      expect(results.data?.streamAccessRequest?.stream.id).to.be.ok
     })
   })
 

--- a/packages/server/modules/activitystream/graph/resolvers/activity.js
+++ b/packages/server/modules/activitystream/graph/resolvers/activity.js
@@ -11,46 +11,62 @@ const {
   getTimelineCount
 } = require('../../services/index')
 
-module.exports = {
-  Query: {},
-  User: {
-    async activity(parent, args) {
-      const { items, cursor } = await getUserActivity({
-        userId: parent.id,
-        actionType: args.actionType,
-        after: args.after,
-        before: args.before,
-        cursor: args.cursor,
-        limit: args.limit
-      })
-      const totalCount = await getActivityCountByUserId({
-        userId: parent.id,
-        actionType: args.actionType,
-        after: args.after,
-        before: args.before
-      })
+const userActivityQueryCore = async (parent, args) => {
+  const { items, cursor } = await getUserActivity({
+    userId: parent.id,
+    actionType: args.actionType,
+    after: args.after,
+    before: args.before,
+    cursor: args.cursor,
+    limit: args.limit
+  })
+  const totalCount = await getActivityCountByUserId({
+    userId: parent.id,
+    actionType: args.actionType,
+    after: args.after,
+    before: args.before
+  })
 
-      return { items, cursor, totalCount }
+  return { items, cursor, totalCount }
+}
+
+const userTimelineQueryCore = async (parent, args) => {
+  const { items, cursor } = await getUserTimeline({
+    userId: parent.id,
+    after: args.after,
+    before: args.before,
+    cursor: args.cursor,
+    limit: args.limit
+  })
+  const totalCount = await getTimelineCount({
+    userId: parent.id,
+    after: args.after,
+    before: args.before
+  })
+
+  return { items, cursor, totalCount }
+}
+
+/** @type {import('@/modules/core/graph/generated/graphql').Resolvers} */
+module.exports = {
+  LimitedUser: {
+    async activity(parent, args) {
+      return await userActivityQueryCore(parent, args)
     },
 
     async timeline(parent, args) {
-      const { items, cursor } = await getUserTimeline({
-        userId: parent.id,
-        after: args.after,
-        before: args.before,
-        cursor: args.cursor,
-        limit: args.limit
-      })
-      const totalCount = await getTimelineCount({
-        userId: parent.id,
-        after: args.after,
-        before: args.before
-      })
-
-      return { items, cursor, totalCount }
+      return await userTimelineQueryCore(parent, args)
     }
   },
+  User: {
+    async activity(parent, args) {
+      return await userActivityQueryCore(parent, args)
+    },
 
+    async timeline(parent, args) {
+      return await userTimelineQueryCore(parent, args)
+    }
+  },
   Stream: {
     async activity(parent, args) {
       const { items, cursor } = await getStreamActivity({

--- a/packages/server/modules/activitystream/tests/activity.spec.js
+++ b/packages/server/modules/activitystream/tests/activity.spec.js
@@ -191,10 +191,10 @@ describe('Activity @activity', () => {
 
   it("Should get a user's own activity", async () => {
     const res = await sendRequest(userIz.token, {
-      query: `query {user(id:"${userIz.id}") { name activity { totalCount items {id streamId resourceType resourceId actionType userId message time}}} }`
+      query: `query {activeUser { name activity { totalCount items {id streamId resourceType resourceId actionType userId message time}}} }`
     })
     expect(noErrors(res))
-    const activity = res.body.data.user.activity
+    const activity = res.body.data.activeUser.activity
 
     expect(activity.items.length).to.equal(6)
     expect(activity.totalCount).to.equal(6)
@@ -204,20 +204,20 @@ describe('Activity @activity', () => {
 
   it("Should get another user's activity", async () => {
     const res = await sendRequest(userIz.token, {
-      query: `query {user(id:"${userCr.id}") { name activity { totalCount items {id streamId resourceType resourceId actionType userId message time}}} }`
+      query: `query {otherUser(id:"${userCr.id}") { name activity { totalCount items {id streamId resourceType resourceId actionType userId message time}}} }`
     })
     expect(noErrors(res))
-    expect(res.body.data.user.activity.items.length).to.equal(3)
-    expect(res.body.data.user.activity.totalCount).to.equal(3)
+    expect(res.body.data.otherUser.activity.items.length).to.equal(3)
+    expect(res.body.data.otherUser.activity.totalCount).to.equal(3)
   })
 
   it("Should get a user's timeline", async () => {
     const res = await sendRequest(userIz.token, {
-      query: `query {user(id:"${userCr.id}") { name timeline { totalCount items {id streamId resourceType resourceId actionType userId message time}}} }`
+      query: `query {otherUser(id:"${userCr.id}") { name timeline { totalCount items {id streamId resourceType resourceId actionType userId message time}}} }`
     })
     expect(noErrors(res))
-    expect(res.body.data.user.timeline.items.length).to.equal(7) // sum of all actions in before hook
-    expect(res.body.data.user.timeline.totalCount).to.equal(7)
+    expect(res.body.data.otherUser.timeline.items.length).to.equal(7) // sum of all actions in before hook
+    expect(res.body.data.otherUser.timeline.totalCount).to.equal(7)
   })
 
   it("Should get a stream's activity", async () => {
@@ -258,14 +258,14 @@ describe('Activity @activity', () => {
 
   it("Should *not* get a user's activity without the `users:read` scope", async () => {
     const res = await sendRequest(userX.token, {
-      query: `query {user(id:"${userCr.id}") { name activity {items {id streamId resourceType resourceId actionType userId message time}}} }`
+      query: `query {otherUser(id:"${userCr.id}") { name activity {items {id streamId resourceType resourceId actionType userId message time}}} }`
     })
     expect(res.body.errors.length).to.equal(1)
   })
 
   it("Should *not* get a user's timeline without the `users:read` scope", async () => {
     const res = await sendRequest(userX.token, {
-      query: `query {user(id:"${userCr.id}") { name timeline {items {id streamId resourceType resourceId actionType userId message time}}} }`
+      query: `query {otherUser(id:"${userCr.id}") { name timeline {items {id streamId resourceType resourceId actionType userId message time}}} }`
     })
     expect(res.body.errors.length).to.equal(1)
   })

--- a/packages/server/modules/cli/commands/db/seed/commits.ts
+++ b/packages/server/modules/cli/commands/db/seed/commits.ts
@@ -1,0 +1,68 @@
+import { getStream } from '@/modules/core/repositories/streams'
+import { getUser } from '@/modules/core/repositories/users'
+import { cliDebug } from '@/modules/shared/utils/logger'
+import { BasicTestCommit, createTestCommits } from '@/test/speckle-helpers/commitHelper'
+import dayjs from 'dayjs'
+import { times } from 'lodash'
+import { CommandModule } from 'yargs'
+
+const command: CommandModule<
+  unknown,
+  { streamId: string; count: number; authorId: string }
+> = {
+  command: 'commits <authorId> <streamId> <count>',
+  describe: 'Generate fake commits into the specified stream',
+  builder: {
+    authorId: {
+      describe: 'ID of the user who is going to be the commit author',
+      type: 'string'
+    },
+    streamId: {
+      describe: 'ID of the stream that should receive the commits',
+      type: 'string'
+    },
+    count: {
+      describe: 'Commit count',
+      type: 'number',
+      default: 50
+    }
+  },
+  handler: async (argv) => {
+    const count = argv.count
+    const streamId = argv.streamId
+    const authorId = argv.authorId
+    const date = dayjs().toISOString()
+
+    const user = await getUser(authorId)
+    if (!user?.id) {
+      throw new Error(`User with ID ${authorId} not found`)
+    }
+
+    const stream = await getStream({ streamId, userId: user.id })
+    if (!stream?.id) {
+      throw new Error(`Stream with ID ${streamId} not found`)
+    }
+    if (!stream.isPublic && !stream.role) {
+      throw new Error(
+        `Commit author does not have access to the specified stream ${streamId}`
+      )
+    }
+
+    cliDebug(`Generating ${count} objects & commits for stream ${streamId}...`)
+    await createTestCommits(
+      times(
+        count,
+        (i): BasicTestCommit => ({
+          id: '',
+          objectId: '',
+          streamId,
+          authorId,
+          message: `#${i} - ${date} - Fake commit batch`
+        })
+      )
+    )
+    cliDebug(`...done`)
+  }
+}
+
+export = command

--- a/packages/server/modules/comments/tests/comments.graph.spec.js
+++ b/packages/server/modules/comments/tests/comments.graph.spec.js
@@ -461,7 +461,7 @@ const queryCommitCollectionCommentCount = async ({
   const res = await apollo.executeOperation({
     query: gql`
       query ($id: String!) {
-        user(id: $id) {
+        otherUser(id: $id) {
           commits {
             items {
               commentCount
@@ -473,7 +473,7 @@ const queryCommitCollectionCommentCount = async ({
     variables: { id: resources.testActorId }
   })
   testResult(shouldSucceed, res, (res) => {
-    res.data.user.commits.items
+    res.data.otherUser.commits.items
       .map((i) => i.commentCount)
       .map((commentCount) => {
         expect(commentCount).to.be.greaterThanOrEqual(1)

--- a/packages/server/modules/core/helpers/graphTypes.ts
+++ b/packages/server/modules/core/helpers/graphTypes.ts
@@ -1,10 +1,12 @@
-import { Stream, StreamRole } from '@/modules/core/graph/generated/graphql'
+import { LimitedUser, Stream, StreamRole } from '@/modules/core/graph/generated/graphql'
 import { Roles, StreamRoles } from '@/modules/core/helpers/mainConstants'
 
 /**
  * The types of objects we return in resolvers often don't have the exact type as the object in the schema.
  * Often some fields will be missing, because they are defined as separate resolvers and thus don't need
  * to be defined on the object being returned.
+ *
+ * These are registered in the server's codegen.yml
  */
 
 export type StreamGraphQLReturn = Omit<
@@ -29,16 +31,21 @@ export type StreamGraphQLReturn = Omit<
   | 'webhooks'
 >
 
+export type LimitedUserGraphQLReturn = Omit<
+  LimitedUser,
+  'totalOwnedStreamsFavorites' | 'commits' | 'streams'
+>
+
 /**
  * Map GQL StreamRole enum to the value types we use in the backend
  */
 export function mapStreamRoleToValue(graphqlStreamRole: StreamRole): StreamRoles {
   switch (graphqlStreamRole) {
-    case 'STREAM_REVIEWER':
+    case StreamRole.StreamReviewer:
       return Roles.Stream.Reviewer
-    case 'STREAM_OWNER':
+    case StreamRole.StreamOwner:
       return Roles.Stream.Owner
-    case 'STREAM_CONTRIBUTOR':
+    case StreamRole.StreamContributor:
     default:
       return Roles.Stream.Contributor
   }

--- a/packages/server/modules/core/services/commits.js
+++ b/packages/server/modules/core/services/commits.js
@@ -10,6 +10,38 @@ const BranchCommits = () => knex('branch_commits')
 const { getBranchByNameAndStreamId } = require('./branches')
 const { getObject } = require('./objects')
 
+const getCommitsByUserIdBase = ({ userId, publicOnly }) => {
+  publicOnly = publicOnly !== false
+
+  const query = Commits()
+    .columns([
+      { id: 'commits.id' },
+      'message',
+      'referencedObject',
+      'sourceApplication',
+      'totalChildrenCount',
+      'parents',
+      'commits.createdAt',
+      { branchName: 'branches.name' },
+      { streamId: 'stream_commits.streamId' },
+      { streamName: 'streams.name' },
+      { authorName: 'users.name' },
+      { authorId: 'users.id' },
+      { authorAvatar: 'users.avatar' }
+    ])
+    .select()
+    .join('stream_commits', 'commits.id', 'stream_commits.commitId')
+    .join('streams', 'stream_commits.streamId', 'streams.id')
+    .join('branch_commits', 'commits.id', 'branch_commits.commitId')
+    .join('branches', 'branches.id', 'branch_commits.branchId')
+    .leftJoin('users', 'commits.author', 'users.id')
+    .where('author', userId)
+
+  if (publicOnly) query.andWhere('streams.isPublic', true)
+
+  return query
+}
+
 module.exports = {
   async createCommitByBranchId({
     streamId,
@@ -252,31 +284,7 @@ module.exports = {
     limit = limit || 25
     publicOnly = publicOnly !== false
 
-    const query = Commits()
-      .columns([
-        { id: 'commits.id' },
-        'message',
-        'referencedObject',
-        'sourceApplication',
-        'totalChildrenCount',
-        'parents',
-        'commits.createdAt',
-        { branchName: 'branches.name' },
-        { streamId: 'stream_commits.streamId' },
-        { streamName: 'streams.name' },
-        { authorName: 'users.name' },
-        { authorId: 'users.id' },
-        { authorAvatar: 'users.avatar' }
-      ])
-      .select()
-      .join('stream_commits', 'commits.id', 'stream_commits.commitId')
-      .join('streams', 'stream_commits.streamId', 'streams.id')
-      .join('branch_commits', 'commits.id', 'branch_commits.commitId')
-      .join('branches', 'branches.id', 'branch_commits.branchId')
-      .leftJoin('users', 'commits.author', 'users.id')
-      .where('author', userId)
-
-    if (publicOnly) query.andWhere('streams.isPublic', true)
+    const query = getCommitsByUserIdBase({ userId, publicOnly })
 
     if (cursor) query.andWhere('commits.createdAt', '<', cursor)
 
@@ -289,8 +297,12 @@ module.exports = {
     }
   },
 
-  async getCommitsTotalCountByUserId({ userId }) {
-    const [res] = await Commits().count().where('author', userId)
+  async getCommitsTotalCountByUserId({ userId, publicOnly }) {
+    const query = getCommitsByUserIdBase({ userId, publicOnly })
+    query.clearSelect()
+    query.select(knex.raw('COUNT(*) as count'))
+
+    const [res] = await query
     return parseInt(res.count)
   }
 }

--- a/packages/server/modules/core/tests/commitsGraphql.spec.ts
+++ b/packages/server/modules/core/tests/commitsGraphql.spec.ts
@@ -1,0 +1,209 @@
+import { Commits, Streams, Users } from '@/modules/core/dbSchema'
+import { Roles } from '@/modules/core/helpers/mainConstants'
+import { addOrUpdateStreamCollaborator } from '@/modules/core/services/streams/streamAccessService'
+import { Nullable } from '@/modules/shared/helpers/typeHelper'
+import { BasicTestUser, createTestUsers } from '@/test/authHelper'
+import { readOtherUsersCommits, readOwnCommits } from '@/test/graphql/commits'
+import { truncateTables } from '@/test/hooks'
+import { buildAuthenticatedApolloServer } from '@/test/serverHelper'
+import { createTestCommit } from '@/test/speckle-helpers/commitHelper'
+import { BasicTestStream, createTestStreams } from '@/test/speckle-helpers/streamHelper'
+import { ApolloServer } from 'apollo-server-express'
+import { expect } from 'chai'
+
+describe('Commits (GraphQL)', () => {
+  const readableUserCommitsCount = 15
+  let readablePublicUserCommitsCount = 0
+
+  const me: BasicTestUser = {
+    id: '',
+    email: '',
+    name: 'its a meeeee',
+    bio: 'ayyy',
+    company: 'ayyy inc'
+  }
+
+  const otherGuy: BasicTestUser = {
+    id: '',
+    email: '',
+    name: 'its an other guyyyyy',
+    bio: 'fffoooo',
+    company: 'fooooo inc'
+  }
+
+  const myStream: BasicTestStream = {
+    id: '',
+    name: 'my stream 1',
+    isPublic: true,
+    ownerId: ''
+  }
+
+  const myPrivateStream: BasicTestStream = {
+    id: '',
+    name: 'my private stream 1',
+    isPublic: false,
+    ownerId: ''
+  }
+
+  before(async () => {
+    await truncateTables([Users.name, Commits.name, Streams.name])
+    await createTestUsers([me, otherGuy])
+    await createTestStreams([
+      [myStream, me],
+      [myPrivateStream, me]
+    ])
+
+    await Promise.all([
+      addOrUpdateStreamCollaborator(
+        myStream.id,
+        otherGuy.id,
+        Roles.Stream.Contributor,
+        me.id
+      ),
+      addOrUpdateStreamCollaborator(
+        myPrivateStream.id,
+        otherGuy.id,
+        Roles.Stream.Contributor,
+        me.id
+      )
+    ])
+
+    // creating commits sequentially so that we don't get duplicate cursor issues
+    for (let i = 0; i < readableUserCommitsCount; i++) {
+      const usePrivateStream = i % 2 === 0 ? myStream.id : myPrivateStream.id
+      if (usePrivateStream) {
+        readablePublicUserCommitsCount++
+      }
+
+      // my commit
+      await createTestCommit({
+        id: '',
+        objectId: '',
+        streamId: usePrivateStream ? myStream.id : myPrivateStream.id,
+        authorId: me.id
+      })
+
+      // other guys commit
+      await createTestCommit({
+        id: '',
+        objectId: '',
+        streamId: usePrivateStream ? myStream.id : myPrivateStream.id,
+        authorId: otherGuy.id
+      })
+    }
+  })
+
+  describe('when user authenticated', async () => {
+    let apollo: ApolloServer
+
+    before(async () => {
+      apollo = buildAuthenticatedApolloServer(me.id)
+    })
+
+    describe('and reading user commits', async () => {
+      it('can read own public and private commits', async () => {
+        const readOwnCommitsPage = async (cursor: Nullable<string>, limit = 5) => {
+          const results = await readOwnCommits(apollo, { cursor, limit })
+
+          expect(results).to.not.haveGraphQLErrors()
+          expect(results.data?.activeUser?.commits?.totalCount).to.eq(
+            readableUserCommitsCount
+          )
+          expect(results.data?.activeUser?.commits?.cursor).to.be.ok
+
+          expect(
+            results.data?.activeUser?.commits?.items || []
+          ).to.have.lengthOf.lessThanOrEqual(limit)
+
+          const commits = results.data!.activeUser!.commits!.items!
+          const returnedCommitCount = commits.length
+
+          for (const commit of commits) {
+            expect(commit.id).to.be.ok
+            expect(commit.authorId).to.eq(me.id)
+            expect(commit.authorName).to.eq(me.name)
+            expect(commit.streamId).to.eq(myStream.id)
+            expect(commit.streamName).to.eq(myStream.name)
+          }
+
+          const newCursor = results.data!.activeUser!.commits!.cursor!
+          const totalCount = results.data!.activeUser!.commits!.totalCount!
+
+          return { newCursor, returnedCommitCount, totalCount }
+        }
+
+        const limit = 5
+        const { newCursor, returnedCommitCount, totalCount } = await readOwnCommitsPage(
+          null,
+          limit
+        )
+
+        let readCommitsCount = returnedCommitCount
+        const remainingPages = Math.ceil((totalCount - returnedCommitCount) / limit)
+        for (let p = 0; p < remainingPages; p++) {
+          const { returnedCommitCount } = await readOwnCommitsPage(newCursor, limit)
+          readCommitsCount += returnedCommitCount
+        }
+
+        expect(readCommitsCount).to.eq(totalCount)
+      })
+
+      it('can read other users public commits', async () => {
+        const readOtherUsersCommitsPage = async (
+          userId: string,
+          cursor: Nullable<string>,
+          limit = 5
+        ) => {
+          const results = await readOtherUsersCommits(apollo, { userId, cursor, limit })
+
+          expect(results).to.not.haveGraphQLErrors()
+          expect(results.data?.otherUser?.commits?.totalCount).to.eq(
+            readablePublicUserCommitsCount
+          )
+          expect(results.data?.otherUser?.commits?.cursor).to.be.ok
+
+          expect(
+            results.data?.otherUser?.commits?.items || []
+          ).to.have.lengthOf.lessThanOrEqual(limit)
+
+          const commits = results.data!.otherUser!.commits!.items!
+          const returnedCommitCount = commits.length
+
+          for (const commit of commits) {
+            expect(commit.id).to.be.ok
+            expect(commit.authorId).to.eq(otherGuy.id)
+            expect(commit.authorName).to.eq(otherGuy.name)
+            expect(commit.streamId).to.eq(myStream.id)
+            expect(commit.streamName).to.eq(myStream.name)
+
+            expect(commit.stream.id).to.eq(myStream.id)
+            expect(commit.stream.name).to.eq(myStream.name)
+            expect(commit.stream.isPublic).to.be.true
+          }
+
+          const newCursor = results.data!.otherUser!.commits!.cursor!
+          const totalCount = results.data!.otherUser!.commits!.totalCount!
+
+          return { newCursor, returnedCommitCount, totalCount }
+        }
+
+        const limit = 5
+        const { newCursor, returnedCommitCount, totalCount } =
+          await readOtherUsersCommitsPage(otherGuy.id, null, limit)
+
+        let readCommitsCount = returnedCommitCount
+        const remainingPages = Math.ceil((totalCount - returnedCommitCount) / limit)
+        for (let p = 0; p < remainingPages; p++) {
+          const { returnedCommitCount } = await readOtherUsersCommitsPage(
+            otherGuy.id,
+            newCursor,
+            limit
+          )
+          readCommitsCount += returnedCommitCount
+        }
+
+        expect(readCommitsCount).to.eq(totalCount)
+      })
+    })
+  })
+})

--- a/packages/server/modules/core/tests/commitsGraphql.spec.ts
+++ b/packages/server/modules/core/tests/commitsGraphql.spec.ts
@@ -97,7 +97,7 @@ describe('Commits (GraphQL)', () => {
     let apollo: ApolloServer
 
     before(async () => {
-      apollo = buildAuthenticatedApolloServer(me.id)
+      apollo = await buildAuthenticatedApolloServer(me.id)
     })
 
     describe('and reading user commits', async () => {

--- a/packages/server/modules/core/tests/favoriteStreams.spec.js
+++ b/packages/server/modules/core/tests/favoriteStreams.spec.js
@@ -29,7 +29,7 @@ const favoriteMutationGql = gql`
 
 const favoriteStreamsQueryGql = gql`
   query ($cursor: String, $limit: Int! = 10) {
-    user {
+    activeUser {
       id
       favoriteStreams(cursor: $cursor, limit: $limit) {
         totalCount
@@ -42,6 +42,10 @@ const favoriteStreamsQueryGql = gql`
   }
 `
 
+/**
+ * @deprecated Leaving this behind while we still have the old user() query. This should
+ * be deleted afterwards
+ */
 const anotherUserFavoriteStreamsQueryGql = gql`
   query ($cursor: String, $limit: Int! = 10, $uid: String!) {
     user(id: $uid) {
@@ -57,9 +61,22 @@ const anotherUserFavoriteStreamsQueryGql = gql`
   }
 `
 
-const totalOwnedStreamsFavorites = gql`
+/**
+ * @deprecated Leaving this behind while we still have the old user() query. This should
+ * be deleted afterwards
+ */
+const totalOwnedStreamsFavoritesOld = gql`
   query ($uid: String!) {
     user(id: $uid) {
+      id
+      totalOwnedStreamsFavorites
+    }
+  }
+`
+
+const totalOwnedStreamsFavoritesNew = gql`
+  query ($uid: String!) {
+    otherUser(id: $uid) {
       id
       totalOwnedStreamsFavorites
     }
@@ -253,7 +270,7 @@ describe('Favorite streams', () => {
         })
 
         expect(data).to.be.ok
-        expect(data.user?.favoriteStreams).to.not.be.ok
+        expect(data.otherUser?.favoriteStreams).to.not.be.ok
         expect((errors || []).map((e) => e.message).join()).to.match(
           /cannot view another user's favorite streams/i
         )
@@ -264,9 +281,11 @@ describe('Favorite streams', () => {
         const ids = favoritedStreamIds()
 
         expect(results.errors).to.not.be.ok
-        expect(results.data?.user?.favoriteStreams?.items).to.have.lengthOf(ids.length)
-        expect(results.data.user.favoriteStreams.totalCount).to.equal(ids.length)
-        expect(results.data.user.favoriteStreams.cursor).to.be.a('string')
+        expect(results.data?.activeUser?.favoriteStreams?.items).to.have.lengthOf(
+          ids.length
+        )
+        expect(results.data.activeUser.favoriteStreams.totalCount).to.equal(ids.length)
+        expect(results.data.activeUser.favoriteStreams.cursor).to.be.a('string')
       })
 
       it('are paginated correctly', async () => {
@@ -276,11 +295,11 @@ describe('Favorite streams', () => {
         const getPaginatedAndAssert = async (nextCursor) => {
           const results = await getFavorites(nextCursor, 1)
           expect(results.errors).to.not.be.ok
-          expect(results.data?.user?.favoriteStreams).to.be.ok
+          expect(results.data?.activeUser?.favoriteStreams).to.be.ok
 
           return {
-            cursor: results.data.user.favoriteStreams.cursor,
-            sids: results.data.user.favoriteStreams.items.map((i) => i.id)
+            cursor: results.data.activeUser.favoriteStreams.cursor,
+            sids: results.data.activeUser.favoriteStreams.items.map((i) => i.id)
           }
         }
 
@@ -296,60 +315,40 @@ describe('Favorite streams', () => {
 
         expect(returnedStreamIds).to.deep.equalInAnyOrder(favoritedStreamIds())
       })
-    })
 
-    it('return total favorites count for user', async () => {
-      // "Log in" with other user
-      const apollo = await buildApolloServer({
-        context: () =>
-          addLoadersToCtx({
-            auth: true,
-            userId: otherGuy.id,
-            role: Roles.Server.User,
-            token: 'asd',
-            scopes: AllScopes
-          })
-      })
-
-      const favoriteStream = async (sid, favorited) =>
-        await apollo.executeOperation({
-          query: favoriteMutationGql,
-          variables: { sid, favorited }
-        })
-
-      // Create favoritable streams
-      const favoriteStreams = [
-        {
-          name: 'OtherStream1',
-          isPublic: true,
-          ownerId: otherGuy.id
-        },
-        {
-          name: 'OtherStream2',
-          isPublic: true,
-          ownerId: otherGuy.id
-        }
+      const oldNewQueryDataset = [
+        { display: 'old', isNew: false },
+        { display: 'new', isNew: true }
       ]
 
-      await Promise.all(
-        favoriteStreams.map((s) =>
-          createStream(s).then((res) => {
-            s.id = res
+      oldNewQueryDataset.forEach(({ display, isNew }) => {
+        it(`return total favorites count for user (${display} query)`, async () => {
+          // "Log in" with other user
+          const apollo = await buildApolloServer({
+            context: () =>
+              addLoadersToCtx({
+                auth: true,
+                userId: otherGuy.id,
+                role: Roles.Server.User,
+                token: 'asd',
+                scopes: AllScopes
+              })
           })
-        )
-      )
 
-      // Favorite all of them
-      await Promise.all(favoriteStreams.map((s) => favoriteStream(s.id, true)))
+          const { data, errors } = await apollo.executeOperation({
+            query: isNew
+              ? totalOwnedStreamsFavoritesNew
+              : totalOwnedStreamsFavoritesOld,
+            variables: { uid: me.id }
+          })
 
-      const { data, errors } = await apollo.executeOperation({
-        query: totalOwnedStreamsFavorites,
-        variables: { uid: otherGuy.id }
+          expect(errors).to.not.be.ok
+
+          const user = isNew ? data?.otherUser : data?.user
+          expect(user?.id).to.equal(me.id)
+          expect(user?.totalOwnedStreamsFavorites).to.equal(favoritableStreams.length)
+        })
       })
-
-      expect(errors).to.not.be.ok
-      expect(data?.user?.id).to.equal(otherGuy.id)
-      expect(data?.user?.totalOwnedStreamsFavorites).to.equal(3)
     })
   })
 
@@ -379,7 +378,7 @@ describe('Favorite streams', () => {
         query: favoriteStreamsQueryGql
       })
 
-      expect(result.data.user).to.be.null
+      expect(result.data.activeUser).to.be.null
       expect(result.errors).to.not.be.ok
     })
   })

--- a/packages/server/modules/core/tests/graph.spec.js
+++ b/packages/server/modules/core/tests/graph.spec.js
@@ -302,32 +302,32 @@ describe('GraphQL API Core @core-api', () => {
     describe('User role change', () => {
       it('User role is changed', async () => {
         let queriedUserB = await sendRequest(userA.token, {
-          query: ` { user(id:"${userB.id}") { id name email role } }`
+          query: ` { otherUser(id:"${userB.id}") { id name role } }`
         })
-        expect(queriedUserB.body.data.user.role).to.equal('server:user')
+        expect(queriedUserB.body.data.otherUser.role).to.equal('server:user')
         let query = `mutation { userRoleChange(userRoleInput: {id: "${userB.id}", role: "server:admin"})}`
         await sendRequest(userA.token, { query })
         queriedUserB = await sendRequest(userA.token, {
-          query: ` { user(id:"${userB.id}") { id name email role } }`
+          query: ` { otherUser(id:"${userB.id}") { id name role } }`
         })
-        expect(queriedUserB.body.data.user.role).to.equal('server:admin')
+        expect(queriedUserB.body.data.otherUser.role).to.equal('server:admin')
         expect(queriedUserB.body.data)
         query = `mutation { userRoleChange(userRoleInput: {id: "${userB.id}", role: "server:user"})}`
         await sendRequest(userA.token, { query })
         queriedUserB = await sendRequest(userA.token, {
-          query: ` { user(id:"${userB.id}") { id name email role } }`
+          query: ` { otherUser(id:"${userB.id}") { id name role } }`
         })
-        expect(queriedUserB.body.data.user.role).to.equal('server:user')
+        expect(queriedUserB.body.data.otherUser.role).to.equal('server:user')
       })
 
       it('Only admins can change user role', async () => {
         const query = `mutation { userRoleChange(userRoleInput: {id: "${userB.id}", role: "server:admin"})}`
         const res = await sendRequest(userB.token, { query })
         const queriedUserB = await sendRequest(userA.token, {
-          query: ` { user(id:"${userB.id}") { id name email role } }`
+          query: ` { otherUser(id:"${userB.id}") { id name role } }`
         })
         expect(res.body.errors).to.exist
-        expect(queriedUserB.body.data.user.role).to.equal('server:user')
+        expect(queriedUserB.body.data.otherUser.role).to.equal('server:user')
       })
     })
 
@@ -1135,6 +1135,10 @@ describe('GraphQL API Core @core-api', () => {
     })
 
     describe('Different Users` Profile', () => {
+      /**
+       * TODO: These user() queries should be swapped to otherUser() afterwards
+       */
+
       it('Should retrieve a different profile profile', async () => {
         const res = await sendRequest(userA.token, {
           query: ` { user(id:"${userB.id}") { id name email } }`

--- a/packages/server/modules/core/tests/streams.spec.ts
+++ b/packages/server/modules/core/tests/streams.spec.ts
@@ -26,7 +26,12 @@ import {
   buildAuthenticatedApolloServer,
   buildUnauthenticatedApolloServer
 } from '@/test/serverHelper'
-import { getUserStreams, leaveStream } from '@/test/graphql/streams'
+import {
+  getLimitedUserStreams,
+  getUserStreams,
+  leaveStream
+} from '@/test/graphql/streams'
+import { StreamInvalidAccessError } from '@/modules/core/errors/stream'
 import { BasicTestUser, createTestUsers } from '@/test/authHelper'
 import {
   BasicTestStream,
@@ -34,12 +39,17 @@ import {
   createTestStreams
 } from '@/test/speckle-helpers/streamHelper'
 import { StreamWithOptionalRole } from '@/modules/core/repositories/streams'
-import { times } from 'lodash'
+import { has, times } from 'lodash'
 import { Streams } from '@/modules/core/dbSchema'
 import { ApolloServer } from 'apollo-server-express'
 import { Nullable } from '@/modules/shared/helpers/typeHelper'
 import { sleep } from '@/test/helpers'
 import dayjs, { Dayjs } from 'dayjs'
+import {
+  GetLimitedUserStreamsQuery,
+  GetUserStreamsQuery
+} from '@/test/graphql/generated/graphql'
+import { Get } from 'type-fest'
 
 describe('Streams @core-streams', () => {
   const userOne: BasicTestUser = {
@@ -71,6 +81,11 @@ describe('Streams @core-streams', () => {
     ownerId: '',
     id: ''
   }
+
+  const userLimitedUserDataSet = [
+    { display: 'User', limitedUser: false },
+    { display: 'LimitedUser', limitedUser: true }
+  ]
 
   before(async () => {
     await beforeEachContext()
@@ -383,6 +398,10 @@ describe('Streams @core-streams', () => {
       { display: 'without pagination', pagination: false }
     ]
 
+    const isLimitedUserStreams = (
+      data: GetLimitedUserStreamsQuery | GetUserStreamsQuery
+    ): data is GetLimitedUserStreamsQuery => has(data, 'otherUser')
+
     /**
      * Base test for testing paginated & unpaginated User.streams query in various circumstances
      */
@@ -390,23 +409,37 @@ describe('Streams @core-streams', () => {
       apollo: ApolloServer,
       pagination: boolean,
       userId: string,
-      isOtherUser: boolean
+      isOtherUser: boolean,
+      options: Partial<{ limitedUserQuery: boolean }> = {}
     ) => {
+      const { limitedUserQuery } = options
       const expectedTotalCount = isOtherUser
         ? SHARED_STREAM_COUNT + DISCOVERABLE_STREAM_COUNT // only shared streams + discoverable ones
         : TOTAL_OWN_STREAM_COUNT // all owned & shared streams
 
       const requestPage = async (cursor?: Nullable<string>) => {
-        const results = await getUserStreams(apollo, {
+        const vars = {
           userId,
           limit: pagination ? PAGE_LIMIT : 100,
           cursor
-        })
+        }
+        const results = limitedUserQuery
+          ? await getLimitedUserStreams(apollo, vars)
+          : await getUserStreams(apollo, vars)
 
         expect(results).to.not.haveGraphQLErrors()
-        if (!results.data?.user?.streams) throw new Error('Unexpected issue')
-        expect(results.data.user.streams.totalCount).to.eq(expectedTotalCount)
-        return results.data.user.streams
+        if (!results.data) throw new Error('Unexpected issue')
+
+        let streams: Get<GetUserStreamsQuery, 'user.streams'>
+        if (isLimitedUserStreams(results.data)) {
+          streams = results.data.otherUser?.streams
+        } else {
+          streams = results.data.user?.streams
+        }
+
+        if (!streams) throw new Error('Unexpected issue')
+        expect(streams.totalCount).to.eq(expectedTotalCount)
+        return streams
       }
 
       let cursor: Nullable<string> = null
@@ -475,8 +508,16 @@ describe('Streams @core-streams', () => {
           await testPaginatedUserStreams(apollo, pagination, activeUserId, false)
         })
 
-        it(`User.streams() ${display} for a different user only returns that users discoverable streams`, async () => {
-          await testPaginatedUserStreams(apollo, pagination, userTwo.id, true)
+        userLimitedUserDataSet.forEach(({ limitedUser }) => {
+          const prefix = limitedUser
+            ? 'LimitedUser.streams()'
+            : 'User.streams() for a different user'
+
+          it(`${prefix} ${display} returns that users discoverable streams`, async () => {
+            await testPaginatedUserStreams(apollo, pagination, userTwo.id, true, {
+              limitedUserQuery: limitedUser
+            })
+          })
         })
       })
     })
@@ -488,9 +529,14 @@ describe('Streams @core-streams', () => {
         apollo = await buildUnauthenticatedApolloServer()
       })
 
-      it('User.streams is inaccessible', async () => {
-        const results = await getUserStreams(apollo, { userId: userOne.id })
-        expect(results).to.haveGraphQLErrors('you must provide an auth token')
+      userLimitedUserDataSet.forEach(({ display, limitedUser }) => {
+        it(`${display}.streams is inaccessible`, async () => {
+          const results = limitedUser
+            ? await getLimitedUserStreams(apollo, { userId: userOne.id })
+            : await getUserStreams(apollo, { userId: userOne.id })
+          expect(results).to.haveGraphQLErrors()
+          expect(results.data?.otherUser || results.data?.user).to.be.not.ok
+        })
       })
     })
   })

--- a/packages/server/modules/core/tests/streams.spec.ts
+++ b/packages/server/modules/core/tests/streams.spec.ts
@@ -31,7 +31,6 @@ import {
   getUserStreams,
   leaveStream
 } from '@/test/graphql/streams'
-import { StreamInvalidAccessError } from '@/modules/core/errors/stream'
 import { BasicTestUser, createTestUsers } from '@/test/authHelper'
 import {
   BasicTestStream,

--- a/packages/server/modules/core/tests/usersGraphql.spec.ts
+++ b/packages/server/modules/core/tests/usersGraphql.spec.ts
@@ -1,0 +1,83 @@
+import { Users } from '@/modules/core/dbSchema'
+import { BasicTestUser, createTestUsers } from '@/test/authHelper'
+import { getActiveUser, getOtherUser } from '@/test/graphql/users'
+import { truncateTables } from '@/test/hooks'
+import {
+  buildAuthenticatedApolloServer,
+  buildUnauthenticatedApolloServer
+} from '@/test/serverHelper'
+import { ApolloServer } from 'apollo-server-express'
+import { expect } from 'chai'
+
+describe('Users (GraphQL)', () => {
+  const me: BasicTestUser = {
+    id: '',
+    email: '',
+    name: 'its a meeeee',
+    bio: 'ayyy',
+    company: 'ayyy inc'
+  }
+
+  const otherGuy: BasicTestUser = {
+    id: '',
+    email: '',
+    name: 'its an other guyyyyy',
+    bio: 'fffoooo',
+    company: 'fooooo inc'
+  }
+
+  before(async () => {
+    await truncateTables([Users.name])
+    await createTestUsers([me, otherGuy])
+  })
+
+  describe('when unauthenticated', () => {
+    let apollo: ApolloServer
+
+    before(async () => {
+      apollo = buildUnauthenticatedApolloServer()
+    })
+
+    it('activeUser returns null', async () => {
+      const results = await getActiveUser(apollo)
+
+      expect(results).to.not.haveGraphQLErrors()
+      expect(results.data?.activeUser).to.be.null
+    })
+
+    it('otherUser throws an authorization error', async () => {
+      const results = await getOtherUser(apollo, { id: otherGuy.id })
+
+      expect(results.data?.otherUser).to.be.null
+      expect(results).to.haveGraphQLErrors('you do not have the required privileges')
+    })
+  })
+
+  describe('when authenticated', () => {
+    let apollo: ApolloServer
+
+    before(async () => {
+      apollo = buildAuthenticatedApolloServer(me.id)
+    })
+
+    it('activeUser returns authenticated user info', async () => {
+      const results = await getActiveUser(apollo)
+
+      expect(results).to.not.haveGraphQLErrors()
+      expect(results.data?.activeUser?.id).to.eq(me.id)
+      expect(results.data?.activeUser?.name).to.be.ok
+      expect(results.data?.activeUser?.bio).to.be.ok
+      expect(results.data?.activeUser?.company).to.be.ok
+    })
+
+    it('otherUser returns limited user info', async () => {
+      const results = await getOtherUser(apollo, { id: otherGuy.id })
+
+      expect(results).to.not.haveGraphQLErrors()
+      expect(results.data?.otherUser?.id).to.eq(otherGuy.id)
+      expect(results.data?.otherUser?.name).to.be.ok
+      expect(results.data?.otherUser?.bio).to.be.ok
+      expect(results.data?.otherUser?.company).to.be.ok
+    })
+  })
+})

--- a/packages/server/modules/core/tests/usersGraphql.spec.ts
+++ b/packages/server/modules/core/tests/usersGraphql.spec.ts
@@ -35,7 +35,7 @@ describe('Users (GraphQL)', () => {
     let apollo: ApolloServer
 
     before(async () => {
-      apollo = buildUnauthenticatedApolloServer()
+      apollo = await buildUnauthenticatedApolloServer()
     })
 
     it('activeUser returns null', async () => {
@@ -57,7 +57,7 @@ describe('Users (GraphQL)', () => {
     let apollo: ApolloServer
 
     before(async () => {
-      apollo = buildAuthenticatedApolloServer(me.id)
+      apollo = await buildAuthenticatedApolloServer(me.id)
     })
 
     it('activeUser returns authenticated user info', async () => {

--- a/packages/server/modules/shared/index.js
+++ b/packages/server/modules/shared/index.js
@@ -163,10 +163,9 @@ async function authorizeResolver(userId, resourceId, requiredRole) {
     )
   }
 
-  const userAclEntry = await knex(role.aclTableName)
-    .select('*')
-    .where({ resourceId, userId })
-    .first()
+  const userAclEntry = userId
+    ? await knex(role.aclTableName).select('*').where({ resourceId, userId }).first()
+    : null
 
   if (!userAclEntry)
     throw new ForbiddenError('You do not have access to this resource.')

--- a/packages/server/test/graphql/accessRequests.ts
+++ b/packages/server/test/graphql/accessRequests.ts
@@ -1,6 +1,8 @@
 import {
   CreateStreamAccessRequestMutation,
   CreateStreamAccessRequestMutationVariables,
+  GetFullStreamAccessRequestQuery,
+  GetFullStreamAccessRequestQueryVariables,
   GetPendingStreamAccessRequestsQuery,
   GetPendingStreamAccessRequestsQueryVariables,
   GetStreamAccessRequestQuery,
@@ -38,6 +40,20 @@ const getStreamAccessRequestQuery = gql`
   query GetStreamAccessRequest($streamId: String!) {
     streamAccessRequest(streamId: $streamId) {
       ...BasicStreamAccessRequestFields
+    }
+  }
+
+  ${basicStreamAccessRequestFragment}
+`
+
+const getFullStreamAccessRequestQuery = gql`
+  query GetFullStreamAccessRequest($streamId: String!) {
+    streamAccessRequest(streamId: $streamId) {
+      ...BasicStreamAccessRequestFields
+      stream {
+        id
+        name
+      }
     }
   }
 
@@ -90,6 +106,15 @@ export const getStreamAccessRequest = (
     getStreamAccessRequestQuery,
     variables
   )
+
+export const getFullStreamAccessRequest = (
+  apollo: ApolloServer,
+  variables: GetFullStreamAccessRequestQueryVariables
+) =>
+  executeOperation<
+    GetFullStreamAccessRequestQuery,
+    GetFullStreamAccessRequestQueryVariables
+  >(apollo, getFullStreamAccessRequestQuery, variables)
 
 export const getPendingStreamAccessRequests = (
   apollo: ApolloServer,

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -390,12 +390,68 @@ export type FileUpload = {
  */
 export type LimitedUser = {
   __typename?: 'LimitedUser';
+  /** All the recent activity from this user in chronological order */
+  activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']>;
   bio?: Maybe<Scalars['String']>;
+  /** Get public stream commits authored by the user */
+  commits?: Maybe<CommitCollection>;
   company?: Maybe<Scalars['String']>;
   id: Scalars['String'];
   name?: Maybe<Scalars['String']>;
+  role?: Maybe<Scalars['String']>;
+  /** Returns all discoverable streams that the user is a collaborator on */
+  streams: StreamCollection;
+  /** The user's timeline in chronological order */
+  timeline?: Maybe<ActivityCollection>;
+  /** Total amount of favorites attached to streams owned by the user */
+  totalOwnedStreamsFavorites: Scalars['Int'];
   verified?: Maybe<Scalars['Boolean']>;
+};
+
+
+/**
+ * Limited user type, for showing public info about a user
+ * to another user
+ */
+export type LimitedUserActivityArgs = {
+  actionType?: InputMaybe<Scalars['String']>;
+  after?: InputMaybe<Scalars['DateTime']>;
+  before?: InputMaybe<Scalars['DateTime']>;
+  cursor?: InputMaybe<Scalars['DateTime']>;
+  limit?: Scalars['Int'];
+};
+
+
+/**
+ * Limited user type, for showing public info about a user
+ * to another user
+ */
+export type LimitedUserCommitsArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  limit?: Scalars['Int'];
+};
+
+
+/**
+ * Limited user type, for showing public info about a user
+ * to another user
+ */
+export type LimitedUserStreamsArgs = {
+  cursor?: InputMaybe<Scalars['String']>;
+  limit?: Scalars['Int'];
+};
+
+
+/**
+ * Limited user type, for showing public info about a user
+ * to another user
+ */
+export type LimitedUserTimelineArgs = {
+  after?: InputMaybe<Scalars['DateTime']>;
+  before?: InputMaybe<Scalars['DateTime']>;
+  cursor?: InputMaybe<Scalars['DateTime']>;
+  limit?: Scalars['Int'];
 };
 
 export type Mutation = {
@@ -845,6 +901,8 @@ export type Query = {
   __typename?: 'Query';
   /** Stare into the void. */
   _?: Maybe<Scalars['String']>;
+  /** Gets the profile of the authenticated user or null if not authenticated */
+  activeUser?: Maybe<User>;
   /** All the streams of the server. Available to admins only. */
   adminStreams?: Maybe<StreamCollection>;
   /**
@@ -865,6 +923,8 @@ export type Query = {
   comments?: Maybe<CommentCollection>;
   /** All of the discoverable streams of the server */
   discoverableStreams?: Maybe<StreamCollection>;
+  /** Get the (limited) profile information of another server user */
+  otherUser?: Maybe<LimitedUser>;
   serverInfo: ServerInfo;
   serverStats: ServerStats;
   /**
@@ -886,7 +946,10 @@ export type Query = {
    * Pass in the `query` parameter to search by name, description or ID.
    */
   streams?: Maybe<StreamCollection>;
-  /** Gets the profile of a user. If no id argument is provided, will return the current authenticated user's profile (as extracted from the authorization header). */
+  /**
+   * Gets the profile of a user. If no id argument is provided, will return the current authenticated user's profile (as extracted from the authorization header).
+   * @deprecated To be removed in the near future! Use 'activeUser' to get info about the active user or 'otherUser' to get info about another user.
+   */
   user?: Maybe<User>;
   /** Validate password strength */
   userPwdStrength: PasswordStrengthCheckResults;
@@ -938,6 +1001,11 @@ export type QueryDiscoverableStreamsArgs = {
   cursor?: InputMaybe<Scalars['String']>;
   limit?: Scalars['Int'];
   sort?: InputMaybe<DiscoverableStreamsSortingInput>;
+};
+
+
+export type QueryOtherUserArgs = {
+  id: Scalars['String'];
 };
 
 
@@ -1458,7 +1526,7 @@ export type User = {
    * All the streams that a active user has favorited.
    * Note: You can't use this to retrieve another user's favorite streams.
    */
-  favoriteStreams?: Maybe<StreamCollection>;
+  favoriteStreams: StreamCollection;
   /** Whether the user has a pending/active email verification token */
   hasPendingVerification?: Maybe<Scalars['Boolean']>;
   id: Scalars['String'];
@@ -1470,7 +1538,8 @@ export type User = {
    * Returns all streams that the user is a collaborator on. If requested for a user, who isn't the
    * authenticated user, then this will only return discoverable streams.
    */
-  streams?: Maybe<StreamCollection>;
+  streams: StreamCollection;
+  /** The user's timeline in chronological order */
   timeline?: Maybe<ActivityCollection>;
   /** Total amount of favorites attached to streams owned by the user */
   totalOwnedStreamsFavorites: Scalars['Int'];
@@ -1633,6 +1702,13 @@ export type GetStreamAccessRequestQueryVariables = Exact<{
 
 export type GetStreamAccessRequestQuery = { __typename?: 'Query', streamAccessRequest?: { __typename?: 'StreamAccessRequest', id: string, requesterId: string, streamId: string, createdAt: string, requester: { __typename?: 'LimitedUser', id: string, name?: string | null } } | null };
 
+export type GetFullStreamAccessRequestQueryVariables = Exact<{
+  streamId: Scalars['String'];
+}>;
+
+
+export type GetFullStreamAccessRequestQuery = { __typename?: 'Query', streamAccessRequest?: { __typename?: 'StreamAccessRequest', id: string, requesterId: string, streamId: string, createdAt: string, stream: { __typename?: 'Stream', id: string, name: string }, requester: { __typename?: 'LimitedUser', id: string, name?: string | null } } | null };
+
 export type GetPendingStreamAccessRequestsQueryVariables = Exact<{
   streamId: Scalars['String'];
 }>;
@@ -1681,6 +1757,25 @@ export type GetCommentsQueryVariables = Exact<{
 
 export type GetCommentsQuery = { __typename?: 'Query', comments?: { __typename?: 'CommentCollection', totalCount: number, cursor?: string | null, items: Array<{ __typename?: 'Comment', id: string, text: { __typename?: 'SmartTextEditorValue', doc?: Record<string, unknown> | null, attachments?: Array<{ __typename?: 'BlobMetadata', id: string, fileName: string, streamId: string }> | null }, replies?: { __typename?: 'CommentCollection', items: Array<{ __typename?: 'Comment', id: string, text: { __typename?: 'SmartTextEditorValue', doc?: Record<string, unknown> | null, attachments?: Array<{ __typename?: 'BlobMetadata', id: string, fileName: string, streamId: string }> | null } }> } | null }> } | null };
 
+export type BaseCommitFieldsFragment = { __typename?: 'Commit', id: string, authorName?: string | null, authorId?: string | null, authorAvatar?: string | null, streamId?: string | null, streamName?: string | null, sourceApplication?: string | null, message?: string | null, referencedObject: string, createdAt?: string | null, commentCount: number };
+
+export type ReadOwnCommitsQueryVariables = Exact<{
+  cursor?: InputMaybe<Scalars['String']>;
+  limit?: Scalars['Int'];
+}>;
+
+
+export type ReadOwnCommitsQuery = { __typename?: 'Query', activeUser?: { __typename?: 'User', commits?: { __typename?: 'CommitCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Commit', id: string, authorName?: string | null, authorId?: string | null, authorAvatar?: string | null, streamId?: string | null, streamName?: string | null, sourceApplication?: string | null, message?: string | null, referencedObject: string, createdAt?: string | null, commentCount: number }> | null } | null } | null };
+
+export type ReadOtherUsersCommitsQueryVariables = Exact<{
+  userId: Scalars['String'];
+  cursor?: InputMaybe<Scalars['String']>;
+  limit?: Scalars['Int'];
+}>;
+
+
+export type ReadOtherUsersCommitsQuery = { __typename?: 'Query', otherUser?: { __typename?: 'LimitedUser', commits?: { __typename?: 'CommitCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Commit', id: string, authorName?: string | null, authorId?: string | null, authorAvatar?: string | null, streamId?: string | null, streamName?: string | null, sourceApplication?: string | null, message?: string | null, referencedObject: string, createdAt?: string | null, commentCount: number, stream: { __typename?: 'Stream', id: string, name: string, isPublic: boolean } }> | null } | null } | null };
+
 export type ReadStreamBranchCommitsQueryVariables = Exact<{
   streamId: Scalars['String'];
   branchName: Scalars['String'];
@@ -1689,7 +1784,7 @@ export type ReadStreamBranchCommitsQueryVariables = Exact<{
 }>;
 
 
-export type ReadStreamBranchCommitsQuery = { __typename?: 'Query', stream?: { __typename?: 'Stream', id: string, name: string, role?: string | null, branch?: { __typename?: 'Branch', id: string, name: string, description?: string | null, commits?: { __typename?: 'CommitCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Commit', id: string, authorName?: string | null, authorId?: string | null, authorAvatar?: string | null, sourceApplication?: string | null, message?: string | null, referencedObject: string, createdAt?: string | null, commentCount: number }> | null } | null } | null } | null };
+export type ReadStreamBranchCommitsQuery = { __typename?: 'Query', stream?: { __typename?: 'Stream', id: string, name: string, role?: string | null, branch?: { __typename?: 'Branch', id: string, name: string, description?: string | null, commits?: { __typename?: 'CommitCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Commit', id: string, authorName?: string | null, authorId?: string | null, authorAvatar?: string | null, streamId?: string | null, streamName?: string | null, sourceApplication?: string | null, message?: string | null, referencedObject: string, createdAt?: string | null, commentCount: number }> | null } | null } | null } | null };
 
 export type MoveCommitsMutationVariables = Exact<{
   input: CommitsMoveInput;
@@ -1832,7 +1927,32 @@ export type GetUserStreamsQueryVariables = Exact<{
 }>;
 
 
-export type GetUserStreamsQuery = { __typename?: 'Query', user?: { __typename?: 'User', streams?: { __typename?: 'StreamCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Stream', id: string, name: string, description?: string | null, isPublic: boolean, isDiscoverable: boolean, allowPublicComments: boolean, role?: string | null, createdAt: string, updatedAt: string }> | null } | null } | null };
+export type GetUserStreamsQuery = { __typename?: 'Query', user?: { __typename?: 'User', streams: { __typename?: 'StreamCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Stream', id: string, name: string, description?: string | null, isPublic: boolean, isDiscoverable: boolean, allowPublicComments: boolean, role?: string | null, createdAt: string, updatedAt: string }> | null } } | null };
+
+export type GetLimitedUserStreamsQueryVariables = Exact<{
+  userId: Scalars['String'];
+  limit?: Scalars['Int'];
+  cursor?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type GetLimitedUserStreamsQuery = { __typename?: 'Query', otherUser?: { __typename?: 'LimitedUser', streams: { __typename?: 'StreamCollection', totalCount: number, cursor?: string | null, items?: Array<{ __typename?: 'Stream', id: string, name: string, description?: string | null, isPublic: boolean, isDiscoverable: boolean, allowPublicComments: boolean, role?: string | null, createdAt: string, updatedAt: string }> | null } } | null };
+
+export type BaseUserFieldsFragment = { __typename?: 'User', id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, role?: string | null };
+
+export type BaseLimitedUserFieldsFragment = { __typename?: 'LimitedUser', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null };
+
+export type GetActiveUserQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetActiveUserQuery = { __typename?: 'Query', activeUser?: { __typename?: 'User', id: string, email?: string | null, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null, role?: string | null } | null };
+
+export type GetOtherUserQueryVariables = Exact<{
+  id: Scalars['String'];
+}>;
+
+
+export type GetOtherUserQuery = { __typename?: 'Query', otherUser?: { __typename?: 'LimitedUser', id: string, name?: string | null, bio?: string | null, company?: string | null, avatar?: string | null, verified?: boolean | null } | null };
 
 export type GetAdminUsersQueryVariables = Exact<{
   limit?: Scalars['Int'];

--- a/packages/server/test/graphql/streams.ts
+++ b/packages/server/test/graphql/streams.ts
@@ -10,7 +10,9 @@ import {
   ReadDiscoverableStreamsQueryVariables,
   ReadDiscoverableStreamsQuery,
   GetUserStreamsQueryVariables,
-  GetUserStreamsQuery
+  GetUserStreamsQuery,
+  GetLimitedUserStreamsQuery,
+  GetLimitedUserStreamsQueryVariables
 } from '@/test/graphql/generated/graphql'
 import { executeOperation } from '@/test/graphqlHelper'
 import { ApolloServer, gql } from 'apollo-server-express'
@@ -76,9 +78,29 @@ const readDiscoverableStreamsQuery = gql`
   ${basicStreamFieldsFragment}
 `
 
+/**
+ * @deprecated Leaving this behind while we still have the old user() query. This should
+ * be deleted afterwards
+ */
 const getUserStreamsQuery = gql`
   query GetUserStreams($userId: String, $limit: Int! = 25, $cursor: String) {
     user(id: $userId) {
+      streams(limit: $limit, cursor: $cursor) {
+        totalCount
+        cursor
+        items {
+          ...BasicStreamFields
+        }
+      }
+    }
+  }
+
+  ${basicStreamFieldsFragment}
+`
+
+const getLimitedUserStreamsQuery = gql`
+  query GetLimitedUserStreams($userId: String!, $limit: Int! = 25, $cursor: String) {
+    otherUser(id: $userId) {
       streams(limit: $limit, cursor: $cursor) {
         totalCount
         cursor
@@ -146,5 +168,15 @@ export const getUserStreams = (
   executeOperation<GetUserStreamsQuery, GetUserStreamsQueryVariables>(
     apollo,
     getUserStreamsQuery,
+    variables
+  )
+
+export const getLimitedUserStreams = (
+  apollo: ApolloServer,
+  variables: GetLimitedUserStreamsQueryVariables
+) =>
+  executeOperation<GetLimitedUserStreamsQuery, GetLimitedUserStreamsQueryVariables>(
+    apollo,
+    getLimitedUserStreamsQuery,
     variables
   )

--- a/packages/server/test/graphql/users.ts
+++ b/packages/server/test/graphql/users.ts
@@ -1,13 +1,61 @@
 import { ApolloServer, gql } from 'apollo-server-express'
 import {
+  GetActiveUserQuery,
+  GetActiveUserQueryVariables,
   GetAdminUsersQuery,
   GetAdminUsersQueryVariables,
+  GetOtherUserQuery,
+  GetOtherUserQueryVariables,
   GetPendingEmailVerificationStatusQuery,
   GetPendingEmailVerificationStatusQueryVariables,
   RequestVerificationMutation,
   RequestVerificationMutationVariables
 } from '@/test/graphql/generated/graphql'
 import { executeOperation } from '@/test/graphqlHelper'
+
+const baseUserFieldsFragment = gql`
+  fragment BaseUserFields on User {
+    id
+    email
+    name
+    bio
+    company
+    avatar
+    verified
+    role
+  }
+`
+
+const baseLimitedUserFieldsFragment = gql`
+  fragment BaseLimitedUserFields on LimitedUser {
+    id
+    name
+    bio
+    company
+    avatar
+    verified
+  }
+`
+
+const getActiveUserQuery = gql`
+  query GetActiveUser {
+    activeUser {
+      ...BaseUserFields
+    }
+  }
+
+  ${baseUserFieldsFragment}
+`
+
+const getOtherUserQuery = gql`
+  query GetOtherUser($id: String!) {
+    otherUser(id: $id) {
+      ...BaseLimitedUserFields
+    }
+  }
+
+  ${baseLimitedUserFieldsFragment}
+`
 
 const adminUsersQuery = gql`
   query GetAdminUsers($limit: Int! = 25, $offset: Int! = 0, $query: String = null) {
@@ -33,6 +81,10 @@ const adminUsersQuery = gql`
   }
 `
 
+/**
+ * @deprecated Leaving this behind while we still have the old user() query. This should
+ * be deleted afterwards
+ */
 const getPendingEmailVerificationStatusQuery = gql`
   query GetPendingEmailVerificationStatus($id: String) {
     user(id: $id) {
@@ -46,6 +98,22 @@ const requestVerificationMutation = gql`
     requestVerification
   }
 `
+
+export const getActiveUser = (apollo: ApolloServer) =>
+  executeOperation<GetActiveUserQuery, GetActiveUserQueryVariables>(
+    apollo,
+    getActiveUserQuery
+  )
+
+export const getOtherUser = (
+  apollo: ApolloServer,
+  variables: GetOtherUserQueryVariables
+) =>
+  executeOperation<GetOtherUserQuery, GetOtherUserQueryVariables>(
+    apollo,
+    getOtherUserQuery,
+    variables
+  )
 
 export async function getAdminUsersList(
   apollo: ApolloServer,

--- a/packages/server/test/speckle-helpers/commitHelper.ts
+++ b/packages/server/test/speckle-helpers/commitHelper.ts
@@ -59,3 +59,7 @@ export async function createTestCommits(commits: BasicTestCommit[]) {
     )
   )
 }
+
+export async function createTestCommit(commit: BasicTestCommit) {
+  await createTestCommits([commit])
+}


### PR DESCRIPTION
- Deprecated the `user` query and introduced `activeUser: User` and `otherUser(id: String!): LimitedUser`. The impetus for this is security of user related operations. Previously we've mixed together 2 very separate concerns - operations regarding the active user and operations regarding other users - and the mixing together occurred by using the same User type (and thus the same API) for both. Because of this dealing with User queries was complicated (the same query would work differently depending on the target user) and it was easy to accidentally add a query that you only meant for the active user, but that ends up also being usable for other users.
- Updated `server` tests to not rely on `user`, where it wasn't `user` itself being tested. Since the `user` query is still available, just deprecated, it doesn't make sense to remove it from tests completely.

Extra unrelated bugfixes I found while re-testing the site:
- Refactored client-side authentication, previously if there ever was any kind of error during the authentication phase the page just entered an infinite reload loop
- Fixed some Apollo cache updates not working properly due to a missing `overwrite` flag. This caused cache update calls to just go through the merge function normally and merging the new results with the old ones, not actually re-writing the cache.
- Fixed multiple toast notifications in a row using the same timeout. This resulted in the 2nd notification timing out a lot earlier than it was supposed to.
- Fixed "Your Commits" page total commit number. Previously it showed the total commit count including commits to 'global', while the page itself only showed commits not made to 'global'. This resulted in a mismatch between the total and all of the items actually shown on the page.
- Fixed batch commit actions not updating commit queries properly, when there were multiple pages of commits
- Fixed Favorite Streams page total streams count not updating properly once a stream was unfavorited from that page

Extra features:
- CLI command for generating any amount of test commits into a stream

@gjedlicska @didimitrie this should go in once we release the new server release, so that we can keep testing it on latest for a while. the bugfixes are nice to have as well tho, so maybe we can do a patch release sometime fairly soon after the next one