### PR TITLE
Fix: improves `SelectionEvent` type usage to repair `viewer-sandbox` build

### DIFF
--- a/packages/viewer-sandbox/src/Sandbox.ts
+++ b/packages/viewer-sandbox/src/Sandbox.ts
@@ -16,7 +16,7 @@ export default class Sandbox {
   private viewsFolder!: FolderApi
   private streams: { [url: string]: Array<unknown> } = {}
   private properties: PropertyInfo[]
-  private selectionList: SelectionEvent[] = null
+  private selectionList: SelectionEvent[] = []
 
   public static urlParams = {
     url: 'https://latest.speckle.dev/streams/c43ac05d04/commits/ec724cfbeb'

--- a/packages/viewer-sandbox/src/type-augmentations/speckle-viewer.d.ts
+++ b/packages/viewer-sandbox/src/type-augmentations/speckle-viewer.d.ts
@@ -1,0 +1,9 @@
+import { SelectionEvent } from '@speckle/viewer'
+
+declare module '@speckle/viewer' {
+  interface SelectionEvent {
+    userData: {
+      id: string
+    }
+  }
+}

--- a/packages/viewer/src/IViewer.ts
+++ b/packages/viewer/src/IViewer.ts
@@ -49,7 +49,7 @@ export enum ViewerEvent {
   SectionBoxChanged = 'section-box-changed'
 }
 
-export type SelectionEvent = {
+export interface SelectionEvent {
   multiple: boolean
   hits: Array<{
     guid?: string


### PR DESCRIPTION
## Description & motivation

I'd like to start developing with speckle-server locally, so I followed the instructions available [here](https://speckle.guide/dev/server-local-dev.html#local-development-environment). During the `yarn build` step, I encountered the following errors:

```
➤ YN0000: [@speckle/viewer-sandbox]: src/Sandbox.ts(19,11): error TS2322: Type 'null' is not assignable to type 'SelectionEvent[]'.
➤ YN0000: [@speckle/viewer-sandbox]: src/Sandbox.ts(175,45): error TS2339: Property 'userData' does not exist on type 'SelectionEvent'.
➤ YN0000: [@speckle/viewer-sandbox]: src/Sandbox.ts(192,45): error TS2339: Property 'userData' does not exist on type 'SelectionEvent'.
```

These all relate to usage of the `SelectionEvent` type exported by `@speckle/viewer`. In order to proceed, I needed to make a few small fixes.

Hopeful to have some more meaningful changes in the future, now that I'm finally working with the code. 💙

## Changes:

- Modifies the `selectionList` initialization on line 19 to be `[]`
  - Alternatively, I could have changed the type to `SelectionEvent[] | null`, but this seemed closer to how the type is intended to be used. It's included in the constructor.
- Adds a type augmentation to `viewer-sandbox` for the `SelectionEvent` type. Changes the export in `@speckle/viewer` from a `type` declaration to an `interface` to enable declaration merging.
  - This felt safer than changing the shape of the type in the main package. It looks like `userData` is only ever expected on this object within `viewer-sandbox` anyways.
- The `git cz` command was also insistent that the line endings be changed in `Sandbox.ts`. This makes the diff annoying! I promise I tried to figure out how to avoid this.

## Validation of changes:

After these changes, I was able to `yarn build` successfully. I was also able to successfully complete the local dev instructions and get Speckle running locally. 🎉

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.