### PR TITLE
Upgrade postgres in DO 1click template to 14.5

### DIFF
--- a/utils/1click_image_scripts/template-docker-compose.yml
+++ b/utils/1click_image_scripts/template-docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # Speckle Server dependencies
   #######
   postgres:
-    image: 'postgres:13.1-alpine'
+    image: 'postgres:14.5-alpine'
     restart: always
     environment:
       POSTGRES_DB: speckle


### PR DESCRIPTION
## Description & motivation

Addresses the deployment context of https://github.com/specklesystems/speckle-server/issues/1088 by upgrading DigitalOcean 1click template to postgres 14.5.

## Changes:

- [x] DigitalOcean 1click template uses postgres 14.5

## To-do before merge:
- [x] merge and test https://github.com/specklesystems/speckle-server/pull/1089


## Screenshots:



## Validation of changes:


## Checklist:



- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References
