### PR TITLE
chore: securing apollo server cache against DDoS attacks

### DIFF
--- a/packages/server/app.ts
+++ b/packages/server/app.ts
@@ -158,6 +158,7 @@ export async function buildApolloServer(
     introspection: true,
     cache: 'bounded',
     persistedQueries: false,
+    csrfPrevention: true,
     formatError: buildErrorFormatter(debug),
     debug,
     ...optionOverrides

--- a/packages/server/app.ts
+++ b/packages/server/app.ts
@@ -156,6 +156,8 @@ export async function buildApolloServer(
         : [])
     ],
     introspection: true,
+    cache: 'bounded',
+    persistedQueries: false,
     formatError: buildErrorFormatter(debug),
     debug,
     ...optionOverrides


### PR DESCRIPTION
more info https://www.apollographql.com/docs/apollo-server/performance/cache-backends/#ensuring-a-bounded-cache

we don't use any of the server-side apollo caching functionality, so I don't anticipate any problems