### PR TITLE
fix(frontend): viewer activity broadcast request volume greatly reduced

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -78,7 +78,7 @@
     "@types/node": "^17.0.43",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
-    "@vitejs/plugin-vue2": "^1.1.2",
+    "@vitejs/plugin-vue2": "^2.0.0",
     "@vue/eslint-config-typescript": "^11.0.1",
     "babel-plugin-lodash": "^3.3.4",
     "eslint": "^8.11.0",

--- a/packages/frontend/src/config/apolloConfig.ts
+++ b/packages/frontend/src/config/apolloConfig.ts
@@ -21,6 +21,7 @@ import {
 } from '@/main/lib/core/helpers/apolloSetupHelper'
 import { merge } from 'lodash'
 import { statePolicies as commitObjectViewerStatePolicies } from '@/main/lib/viewer/commit-object-viewer/stateManagerCore'
+import { Optional } from '@speckle/shared'
 
 // Name of the localStorage item
 const AUTH_TOKEN = LocalStorageKeys.AuthToken
@@ -30,6 +31,8 @@ const httpEndpoint = `${window.location.origin}/graphql`
 const wsEndpoint = `${window.location.origin.replace('http', 'ws')}/graphql`
 // app version
 const appVersion = import.meta.env.SPECKLE_SERVER_VERSION || 'unknown'
+
+let instance: Optional<ApolloProvider> = undefined
 
 function hasAuthToken() {
   return !!AppLocalStorage.get(AUTH_TOKEN)
@@ -232,7 +235,7 @@ function createApolloClient() {
 }
 
 /**
- * Create a Vue Apollo provider instance
+ * Create and set a global Vue Apollo provider instance
  */
 export function createProvider(): ApolloProvider {
   // Create apollo client
@@ -243,8 +246,17 @@ export function createProvider(): ApolloProvider {
   const apolloProvider = createApolloProvider({
     defaultClient: apolloClient
   })
+  instance = apolloProvider
 
   return apolloProvider
+}
+
+export function getApolloProvider(): ApolloProvider {
+  if (!instance) {
+    throw new Error('Attempting to use unitialized global Apollo Provider')
+  }
+
+  return instance
 }
 
 export function installVueApollo(apolloProvider: ApolloProvider): void {

--- a/packages/frontend/src/main/app.js
+++ b/packages/frontend/src/main/app.js
@@ -1,3 +1,8 @@
+/**
+ * Don't export anything out of this file and import it in other files, this borks Vite HMR for some reason
+ * (runs app.js twice in the browser)!
+ */
+
 import '@/bootstrapper'
 import Vue from 'vue'
 
@@ -96,5 +101,3 @@ async function init() {
   postAuthInit()
 }
 init()
-
-export { apolloProvider }

--- a/packages/frontend/src/main/lib/common/text-editor/mentionSuggestion.js
+++ b/packages/frontend/src/main/lib/common/text-editor/mentionSuggestion.js
@@ -2,7 +2,7 @@ import { VueRenderer } from '@tiptap/vue-2'
 import SmartTextEditorMentionList from '@/main/components/common/text-editor/SmartTextEditorMentionList.vue'
 import Popper from 'popper.js'
 import vuetify from '@/plugins/vuetify'
-import { apolloProvider } from '@/main/app'
+import { getApolloProvider } from '@/config/apolloConfig'
 import { userSearchQuery } from '@/graphql/user'
 
 /**
@@ -15,7 +15,7 @@ export const suggestion = {
     }
 
     // Execute users search query
-    const client = apolloProvider.defaultClient
+    const client = getApolloProvider().defaultClient
     const { data } = await client.query({
       query: userSearchQuery,
       variables: {

--- a/packages/server/modules/comments/graph/resolvers/comments.js
+++ b/packages/server/modules/comments/graph/resolvers/comments.js
@@ -156,7 +156,8 @@ module.exports = {
       await pubsub.publish('VIEWER_ACTIVITY', {
         userViewerActivity: args.data,
         streamId: args.streamId,
-        resourceId: args.resourceId
+        resourceId: args.resourceId,
+        authorId: context.userId
       })
       return true
     },
@@ -342,6 +343,11 @@ module.exports = {
 
           if (!stream.allowPublicComments && !stream.role)
             throw new ApolloForbiddenError('You are not authorized.')
+
+          // dont report users activity to himself
+          if (context.userId && context.userId === payload.authorId) {
+            return false
+          }
 
           return (
             payload.streamId === variables.streamId &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -4865,7 +4865,7 @@ __metadata:
     "@types/node": ^17.0.43
     "@typescript-eslint/eslint-plugin": ^5.39.0
     "@typescript-eslint/parser": ^5.39.0
-    "@vitejs/plugin-vue2": ^1.1.2
+    "@vitejs/plugin-vue2": ^2.0.0
     "@vue/apollo-composable": ^4.0.0-alpha.19
     "@vue/apollo-option": ^4.0.0-alpha.20
     "@vue/eslint-config-typescript": ^11.0.1
@@ -6549,13 +6549,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-vue2@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@vitejs/plugin-vue2@npm:1.1.2"
+"@vitejs/plugin-vue2@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@vitejs/plugin-vue2@npm:2.0.0"
   peerDependencies:
-    vite: ">=2.5.10"
+    vite: ^3.0.0
     vue: ^2.7.0-0
-  checksum: a0b4ca94489f7dbb5d8f44f9fed8c6ad094456ec014096157054ed2b2432f56462400882a1639ca695bad2010d341b5b1a43f8b9f54c7a5eb8a399c1174c52ba
+  checksum: c249a601c506b0c2b5f81fdf06257098b55751d8db335ee0211c2976cd6424abc5e472b67688418f42149916d69f059458306ffb0087bace90f9557f39515d32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #902 

@didimitrie I converted the existing logic to this:
- Instead of 1) marking users without any recent updates as stale/hidden and 2) sending out an update about own position being done together in the same function - sendUpdateAndPrune() - I've split both of those algorithms apart.
- "Marking users without any recent updates as stale/hidden" still gets executed every 2 seconds, but doesn't trigger any web requests
- "Sending out an update about own position" (sendUpdateAndPrune()) is now done every 60s not every 2s. This cyclical update call could be disabled entirely, but this way we at least validate every 60s that the user is in fact still there. If we ever need to reduce request volume even more, I'd vote for removing it and relying on the beforeDestroy() and window unload events for sending out a "disconnected" message.
- Fixed user receiving subscription messages about his own activities

Additional fixes:
- Fixed the bug I mentioned this morning where HMR inside the viewer breaks the page and causes app.js to be loaded twice