### PR TITLE
fix(helm chart): fileimport should be deployed if s3 configmap is used

### DIFF
--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -1,4 +1,4 @@
-{{- if .Values.s3.endpoint }}
+{{- if ( or .Values.s3.endpoint .Values.s3.configMap.enabled ) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/utils/helm/speckle-server/templates/fileimport_service/service.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/service.yml
@@ -1,4 +1,4 @@
-{{- if .Values.s3.endpoint -}}
+{{- if ( or .Values.s3.endpoint .Values.s3.configMap.enabled ) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/utils/helm/speckle-server/templates/fileimport_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/serviceaccount.yml
@@ -1,4 +1,4 @@
-{{- if .Values.fileimport_service.serviceAccount.create -}}
+{{- if (and ( or .Values.s3.endpoint .Values.s3.configMap.enabled ) .Values.fileimport_service.serviceAccount.create) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
## Description & motivation

Fixes bug where fileimport-service was not deployed if an s3 configmap was used, instead of defining s3 endpoint etc. in helm chart values

## Changes:

 - helm chart for fileimport service; allows it to be deployed if an s3.endpoint is defined in a ConfigMap instead of in the values.yaml

## To-do before merge:


## Screenshots:


## Validation of changes:

Validated against release which used s3 configmap to define the endpoint.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References
