### PR TITLE
Removing redundancy from filtering

### DIFF
--- a/packages/viewer-sandbox/src/main.ts
+++ b/packages/viewer-sandbox/src/main.ts
@@ -89,7 +89,7 @@ await sandbox.loadUrl(
   // 'http://localhost:3000/streams/6960695d7b/commits/da0a2343fa'
   // 'http://100.66.180.109:3000/streams/6960695d7b/commits/417526751d'
   // IFC building (good for a tree based structure)
-  'https://latest.speckle.dev/streams/92b620fb17/commits/2ebd336223'
+  // 'https://latest.speckle.dev/streams/92b620fb17/commits/2ebd336223'
   // IFC story, a subtree of the above
   // 'https://latest.speckle.dev/streams/92b620fb17/objects/8247bbc53865b0e0cb5ee4e252e66216'
   // Small scale lines
@@ -109,4 +109,6 @@ await sandbox.loadUrl(
   // 'https://latest.speckle.dev/streams/46e3e0e1ec/commits/a6392c19d6?c=%5B6.85874,2.9754,0.79022,0,0,0,0,1%5D'
   // Groups of groups
   // 'https://speckle.xyz/streams/1ce562e99a/commits/6fa28a5a0f'
+  // Freezers
+  'https://speckle.xyz/streams/f0532359ac/commits/98678e2a3d?c=%5B2455.15367,2689.87156,4366.68444,205.422,-149.41199,148.749,0,1%5D'
 )

--- a/packages/viewer/src/modules/tree/RenderTree.ts
+++ b/packages/viewer/src/modules/tree/RenderTree.ts
@@ -118,6 +118,16 @@ export class RenderTree {
       .map((val: TreeNode) => val.model.renderView)
   }
 
+  public getRenderViewNodesForNode(node: TreeNode, parent?: TreeNode): TreeNode[] {
+    if (node.model.atomic && node.model.renderView) {
+      return [node]
+    }
+
+    return (parent ? parent : node.parent).all((_node: TreeNode): boolean => {
+      return _node.model.renderView !== null && _node.model.renderView.hasGeometry
+    })
+  }
+
   public getAtomicParent(node: TreeNode) {
     if (node.model.atomic) {
       return node.model.renderView


### PR DESCRIPTION

<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation
When dealing with streams holding a large number of objects, filtering gets very slow. The main reason for this is the large redundancy we currently have in working with the stream's data tree. This pull request aims at reducing some of that redundancy.
#1094 Signals such a case where the data tree is dense and filtering is very slow
<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:
- Removed a lot of redundant walks inside the `populateGenericState `function of the `FilteringManager`. There is still some redundancy left, but I think that fixing that will require a more general solution.
- **Speedup X6** for the particular case reported in #1094
<!---

- Item 1
- Item 2

-->

## To-do before merge:
<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
