### PR TITLE
fix(frontend): fix commit share btn looking off in light theme

### DIFF
--- a/packages/frontend/src/main/components/stream/commit/CommitShareBtn.vue
+++ b/packages/frontend/src/main/components/stream/commit/CommitShareBtn.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-btn class="primary" icon small @click="onShareClicked">
+  <v-btn class="primary white--text" icon small @click="onShareClicked">
     <v-icon small>mdi-share-variant</v-icon>
   </v-btn>
 </template>


### PR DESCRIPTION
Fixed commit share buttons having black text on light theme. This is what it looks like after the fix:

<img width="429" alt="image" src="https://user-images.githubusercontent.com/938316/198244839-0097e7d5-03c1-4e70-b850-de2112fcbdaf.png">
<img width="429" alt="image" src="https://user-images.githubusercontent.com/938316/198244866-066c77fb-5629-46d0-9dc7-46ce69fd538c.png">
