### PR TITLE
fix(preview-service prometheus): additional buckets in prometheus histogram

### DIFF
--- a/packages/preview-service/bg_service/prometheusMetrics.js
+++ b/packages/preview-service/bg_service/prometheusMetrics.js
@@ -100,7 +100,7 @@ module.exports = {
   metricDuration: new prometheusClient.Histogram({
     name: 'speckle_server_operation_duration',
     help: 'Summary of the operation durations in seconds',
-    buckets: [0.5, 1, 5, 10, 30, 60, 300, 600],
+    buckets: [0.5, 1, 5, 10, 30, 60, 300, 600, 1200, 1800],
     labelNames: ['op']
   }),
 


### PR DESCRIPTION
## Description & motivation

Currently all previews operation durations were falling into the 600s-to-infinity bucket of the prometheus histogram, rendering it effectively a counter and useless as a histogram. This PR adds additional larger buckets at 1200 and 1800 ranges to provide better granularity at longer durations.

## Changes:

- additional histogram buckets.

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

Previously the histogram looks like this:
<img width="1000" alt="Screenshot 2022-11-04 at 16 43 02" src="https://user-images.githubusercontent.com/68657/200030696-603f667f-94c7-4162-a15f-401f57b5b4dd.png">

## Validation of changes:



## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

