### PR TITLE
WIP: test of nginxinc/nginx-unprivileged container

### DIFF
--- a/docker-compose-speckle.yml
+++ b/docker-compose-speckle.yml
@@ -7,7 +7,7 @@ services:
     image: speckle/speckle-frontend:local
     restart: always
     ports:
-      - '0.0.0.0:80:80'
+      - '0.0.0.0:80:8080'
     environment:
       FILE_SIZE_LIMIT_MB: 100
 

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -31,7 +31,9 @@ COPY packages/shared ./packages/shared/
 RUN yarn workspaces foreach run build
 
 # production stage
-FROM openresty/openresty:1.21.4.1-4-jammy-amd64 as production-stage
+#FIXME nginx alone won't work because of the directive in packages/frontend/nginx/templates/nginx.conf.template
+#content_by_lua_block does not exist in standard nginx, and we require openresty
+FROM nginxinc/nginx-unprivileged:1.23-alpine-slim as production-stage
 ARG NODE_ENV
 ARG SPECKLE_SERVER_VERSION
 
@@ -41,10 +43,6 @@ ENV FILE_SIZE_LIMIT_MB=100
 COPY --from=build-stage /speckle-server/packages/frontend/dist /usr/share/nginx/html
 RUN rm /etc/nginx/conf.d/default.conf
 
-COPY packages/frontend/nginx/ /etc/nginx/
+COPY packages/frontend/nginx/templates /etc/nginx/templates
 
-# prepare the environment
-ENTRYPOINT ["/etc/nginx/docker-entrypoint.sh"]
-
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+EXPOSE 8080

--- a/utils/helm/speckle-server/templates/frontend/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend/deployment.yml
@@ -25,7 +25,7 @@ spec:
 
         ports:
           - name: www
-            containerPort: 80
+            containerPort: 8080
             protocol: TCP
 
         resources:
@@ -48,6 +48,16 @@ spec:
             port: www
           initialDelaySeconds: 5
           periodSeconds: 5
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 20000
 
         env: 
           - name: FILE_SIZE_LIMIT_MB

--- a/utils/helm/speckle-server/templates/frontend/service.yml
+++ b/utils/helm/speckle-server/templates/frontend/service.yml
@@ -12,5 +12,5 @@ spec:
   ports:
     - protocol: TCP
       name: www
-      port: 80
+      port: 8080
       targetPort: www

--- a/utils/helm/speckle-server/templates/ingress.yml
+++ b/utils/helm/speckle-server/templates/ingress.yml
@@ -30,7 +30,7 @@ spec:
           service:
             name: speckle-frontend
             port:
-              number: 80
+              number: 8080
       - pathType: Exact
         path: "/(graphql|explorer|(auth/.*)|(objects/.*)|(preview/.*)|(api/.*)|(static/.*))"
         backend:


### PR DESCRIPTION


## Description & motivation

This is an experiment to determine if the frontend can be hosted on an unprivileged nginx image, without any openresty.

This experiment failed because of the openresty `content_by_lua_block` directive in `nginx.conf.template`

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
