### PR TITLE
fix(logs): previews not found is a warning, not an error

### DIFF
--- a/packages/server/modules/previews/index.js
+++ b/packages/server/modules/previews/index.js
@@ -65,8 +65,8 @@ exports.init = (app) => {
 
     const previewImgId = previewInfo.preview[angle]
     if (!previewImgId) {
-      logger.error(
-        `Error: Preview angle '${angle}' not found for object ${streamId}:${objectId}`
+      logger.warn(
+        `Preview angle '${angle}' not found for object ${streamId}:${objectId}`
       )
       return {
         type: 'file',
@@ -76,7 +76,7 @@ exports.init = (app) => {
     }
     const previewImg = await getPreviewImage({ previewId: previewImgId })
     if (!previewImg) {
-      logger.error(`Error: Preview image not found: ${previewImgId}`)
+      logger.warn(`Preview image not found: ${previewImgId}`)
       return {
         type: 'file',
         file: previewErrorImage


### PR DESCRIPTION



## Description & motivation

We were logging failures to find a preview as error severity. This PR makes them warn severity. This is because there are many legitimate reasons as to why a preview cannot be found, for example the preview service may not yet have generated the preview as this takes some time.

## Changes:

## To-do before merge:

## Screenshots:

## Validation of changes:

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
