### PR TITLE
chore(server/fileimports): add more logging around file import failures

### DIFF
--- a/packages/server/modules/fileuploads/index.js
+++ b/packages/server/modules/fileuploads/index.js
@@ -57,6 +57,14 @@ exports.init = async (app) => {
                 branchName: req.params.branchName ?? 'main',
                 uploadResults
               })
+            } else {
+              res.log.error(
+                {
+                  statusCode: response.statusCode,
+                  path: `${process.env.CANONICAL_URL}/api/stream/${req.params.streamId}/blob`
+                },
+                'Error while uploading file.'
+              )
             }
             res.status(response.statusCode).send(body)
           }


### PR DESCRIPTION
## Description & motivation

This adds more logging around error cases where a non-201 response is returned by the `/api/file` import endpoint.

## Changes:

## To-do before merge:


## Screenshots:


## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:



- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References
