### PR TITLE
gergo/invalid token throw

### DIFF
--- a/packages/server/modules/core/tests/rest.spec.js
+++ b/packages/server/modules/core/tests/rest.spec.js
@@ -79,19 +79,19 @@ describe('Upload/Download Routes @api-rest', () => {
     let res = await request(app)
       .get('/objects/wow_hack/null')
       .set('Authorization', 'this is a hoax')
-    expect(res).to.have.status(401)
+    expect(res).to.have.status(403)
 
     // private stream snooping is forbidden
     res = await request(app)
       .get(`/objects/${privateTestStream.id}/maybeSomethingIsHere`)
       .set('Authorization', 'this is a hoax')
-    expect(res).to.have.status(401)
+    expect(res).to.have.status(403)
 
     // invalid token for public stream works
     res = await request(app)
       .get(`/objects/${testStream.id}/null`)
       .set('Authorization', 'this is a hoax')
-    expect(res).to.have.status(404)
+    expect(res).to.have.status(403)
 
     // invalid streamId
     res = await request(app)
@@ -110,16 +110,17 @@ describe('Upload/Download Routes @api-rest', () => {
       .attach('batch2', Buffer.from(JSON.stringify(objBatches[1]), 'utf8'))
 
     // should allow invalid tokens (treat them the same as no tokens?)
+    // no, we're treating invalid tokens as invalid tokens
     res = await request(app)
       .get(`/objects/${testStream.id}/${objBatches[0][0].id}`)
       .set('Authorization', 'this is a hoax')
-    expect(res).to.have.status(200)
+    expect(res).to.have.status(403)
 
     // should not allow invalid tokens on private streams
     res = await request(app)
       .get(`/objects/${privateTestStream.id}/${objBatches[0][0].id}`)
       .set('Authorization', 'this is a hoax')
-    expect(res).to.have.status(401)
+    expect(res).to.have.status(403)
 
     // should not allow user b to access user a's private stream
     res = await request(app)
@@ -155,13 +156,13 @@ describe('Upload/Download Routes @api-rest', () => {
     let res = await request(app)
       .post('/objects/wow_hack')
       .set('Authorization', 'this is a hoax')
-    expect(res).to.have.status(401)
+    expect(res).to.have.status(403)
 
     // invalid token
     res = await request(app)
       .post(`/objects/${testStream.id}`)
       .set('Authorization', 'this is a hoax')
-    expect(res).to.have.status(401)
+    expect(res).to.have.status(403)
 
     // invalid streamId
     res = await request(app)

--- a/packages/server/test/hooks.js
+++ b/packages/server/test/hooks.js
@@ -62,11 +62,17 @@ const initializeTestServer = async (server, app) => {
     serverAddress,
     wsAddress,
     sendRequest(auth, obj) {
-      return chai
-        .request(serverAddress)
-        .post('/graphql')
-        .set('Authorization', auth)
-        .send(obj)
+      return (
+        chai
+          .request(serverAddress)
+          .post('/graphql')
+          // if you set the header to null, the actual header in the req will be
+          // a string -> 'null'
+          // this is now treated as an invalid token, and gets forbidden
+          // switching to an empty string token
+          .set('Authorization', auth || '')
+          .send(obj)
+      )
     }
   }
 }


### PR DESCRIPTION
This is embarrassingly late, but here it is, fixing #927 