### PR TITLE
refactor(server email templates): use the mjml ejs rendering for all emails

### DIFF
--- a/packages/server/assets/emails/templates/components/ctaButton.mjml
+++ b/packages/server/assets/emails/templates/components/ctaButton.mjml
@@ -1,7 +1,7 @@
 <mj-section padding="0">
   <mj-column>
     <mj-button
-      background-color="rgba(59, 130, 246, 1)"
+      mj-class="bgblue"
       border-radius="8px"
       color="white"
       href="<%- params.cta.url -%>"

--- a/packages/server/assets/emails/templates/components/footer.mjml
+++ b/packages/server/assets/emails/templates/components/footer.mjml
@@ -2,7 +2,10 @@
   <mj-column>
     <mj-text font-size="12px" line-height="18px" align="center" color="#999">
       Sent from <%- params.serverInfo.name -%> at
-      <a href="<%- params.serverInfo.canonicalUrl -%>">
+      <a
+        href="<%- params.serverInfo.canonicalUrl -%>"
+        title="<%- params.serverInfo.name -%>"
+      >
         <%- params.serverInfo.canonicalUrl -%>
       </a>
       , deployed and managed by <%- params.serverInfo.company -%>. Your admin contact is

--- a/packages/server/assets/emails/templates/components/head.mjml
+++ b/packages/server/assets/emails/templates/components/head.mjml
@@ -1,5 +1,7 @@
 <mj-head>
-  <mj-attributes></mj-attributes>
+  <mj-attributes>
+    <mj-class name="bgblue" background-color="#3b82f6" />
+  </mj-attributes>
   <mj-style inline="inline">
     h1 { font-size: 2em } h2 { font-size: 1.5em } h3 { font-size: 1.17em } h4 {
     font-size: 1em }

--- a/packages/server/assets/emails/templates/components/headerLogo.mjml
+++ b/packages/server/assets/emails/templates/components/headerLogo.mjml
@@ -3,11 +3,7 @@
     <mj-spacer height="10px" />
   </mj-column>
 </mj-section>
-<mj-section
-  border-radius="8px"
-  background-color="rgba(59, 130, 246, 1)"
-  padding="10px 0 15px 0"
->
+<mj-section border-radius="8px" mj-class="bgblue" padding="10px 0 15px 0">
   <mj-column>
     <mj-image
       width="100px"

--- a/packages/server/assets/emails/templates/speckleBasicEmailTemplate.mjml.ejs
+++ b/packages/server/assets/emails/templates/speckleBasicEmailTemplate.mjml.ejs
@@ -23,6 +23,8 @@
       </mj-column>
     </mj-section>
     <% } %>
+
+    <% if (params.user?.email) { %>
     <mj-section>
       <mj-column>
         <mj-text font-size="12px" color="#999" align="center">
@@ -34,6 +36,7 @@
         </mj-text>
       </mj-column>
     </mj-section>
+    <% } %>
 
     <mj-include path="./components/footer.mjml" />
   </mj-body>

--- a/packages/server/assets/emails/templates/speckleBasicEmailTemplate.txt.ejs
+++ b/packages/server/assets/emails/templates/speckleBasicEmailTemplate.txt.ejs
@@ -1,0 +1,6 @@
+<%_ if (params.text?.bodyStart?.length) print("\n" + params.text.bodyStart + "\n"); _%>
+<%_ if (params.cta) print("\n" + params.cta.title + ': ' + params.cta.url + "\n"); _%>
+<%_ if (params.text?.bodyEnd?.length) print("\n" + params.text.bodyEnd + "\n"); _%>
+
+------------------------------------------------------
+Sent from <%= params.server.name || 'Speckle Server' %> at <%= params.server.canonicalUrl %>, deployed and managed by <%= params.server.company %>. Your admin contact is <%= params.server.adminContact %>.

--- a/packages/server/modules/emails/services/emailRendering.ts
+++ b/packages/server/modules/emails/services/emailRendering.ts
@@ -1,0 +1,112 @@
+import { UserRecord } from '@/modules/core/helpers/types'
+import { packageRoot } from '@/bootstrap'
+import path from 'path'
+import mjml2html from 'mjml'
+import * as ejs from 'ejs'
+
+export type EmailTemplateServerInfo = {
+  name: string
+  canonicalUrl: string
+  company: string
+  adminContact: string
+}
+
+export type EmailCta = {
+  title: string
+  url: string
+}
+
+export type EmailBody = {
+  text: string
+  mjml: string
+}
+
+export type EmailTemplateParams = {
+  mjml: { bodyStart: string; bodyEnd?: string }
+  text: { bodyStart: string; bodyEnd?: string }
+  cta?: {
+    url: string
+    title: string
+    altTitle?: string
+  }
+}
+
+export type EmailInput = {
+  from?: string
+  to: string
+  subject: string
+  text: string
+  html: string
+}
+
+export type EmailContent = {
+  text: string
+  html: string
+}
+
+export const renderEmail = async (
+  templateParams: EmailTemplateParams,
+  serverInfo: EmailTemplateServerInfo,
+  user: UserRecord | null = null
+): Promise<EmailContent> => {
+  const [html, text] = await Promise.all([
+    renderEmailHtml(templateParams, serverInfo, user),
+    renderEmailText(templateParams, serverInfo)
+  ])
+  return {
+    text,
+    html
+  }
+}
+
+const renderEmailHtml = async (
+  templateParams: EmailTemplateParams,
+  serverInfo: EmailTemplateServerInfo,
+  user: UserRecord | null = null
+): Promise<string> => {
+  const mjmlPath = path.resolve(
+    packageRoot,
+    'assets/emails/templates/speckleBasicEmailTemplate.mjml.ejs'
+  )
+  const params = {
+    cta: templateParams.cta,
+    // i know, the parameter names need reshuffling
+    body: { mjml: templateParams.mjml.bodyStart },
+    bodyEnd: { mjml: templateParams.mjml.bodyEnd },
+    user,
+    serverInfo
+  }
+  const fullMjml = await ejs.renderFile(
+    mjmlPath,
+    { params },
+    { cache: false, outputFunctionName: 'print' }
+  )
+  const fullHtml = mjml2html(fullMjml, { filePath: mjmlPath })
+  const renderedHtml = ejs.render(fullHtml.html, { params })
+
+  return renderedHtml
+}
+
+const renderEmailText = async (
+  templateParams: EmailTemplateParams,
+  serverInfo: EmailTemplateServerInfo
+): Promise<string> => {
+  const ejsPath = path.resolve(
+    packageRoot,
+    'assets/emails/templates/speckleBasicEmailTemplate.txt.ejs'
+  )
+  const params = {
+    cta: templateParams.cta,
+    text: {
+      bodyStart: templateParams.text.bodyStart,
+      bodyEnd: templateParams.text.bodyEnd
+    },
+    server: serverInfo
+  }
+  const fullText = await ejs.renderFile(
+    ejsPath,
+    { params },
+    { cache: false, outputFunctionName: 'print' }
+  )
+  return fullText
+}

--- a/packages/server/modules/emails/services/sending.ts
+++ b/packages/server/modules/emails/services/sending.ts
@@ -26,13 +26,14 @@ export async function sendEmail({
   }
   try {
     const emailFrom = process.env.EMAIL_FROM || 'no-reply@speckle.systems'
-    return await transporter.sendMail({
+    await transporter.sendMail({
       from: from || `"Speckle" <${emailFrom}>`,
       to,
       subject,
       text,
       html
     })
+    return true
   } catch (error) {
     logger.error(error)
   }

--- a/packages/server/modules/emails/tests/emailTemplating.spec.ts
+++ b/packages/server/modules/emails/tests/emailTemplating.spec.ts
@@ -1,9 +1,8 @@
 import { getServerInfo } from '@/modules/core/services/generic'
 import {
-  buildBasicTemplateEmail,
-  buildBasicTemplateServerInfo,
-  EmailTemplateServerInfo
-} from '@/modules/emails/services/templateFormatting'
+  EmailTemplateServerInfo,
+  renderEmail
+} from '@/modules/emails/services/emailRendering'
 import { expect } from 'chai'
 import sanitize from 'sanitize-html'
 
@@ -19,21 +18,26 @@ describe('Basic email template', () => {
 
     const server: EmailTemplateServerInfo = {
       name: 'ADADADAD',
-      url: 'http://welcome-to-the-server.com',
+      canonicalUrl: 'http://welcome-to-the-server.com',
       company: 'COOL COMPANY LLC',
-      contact: 'bbbb@aaaaeeee.com'
+      adminContact: 'bbbb@aaaaeeee.com'
     }
 
-    const { text, html } = await buildBasicTemplateEmail({
-      html: { bodyStart, bodyEnd },
-      text: { bodyStart, bodyEnd },
-      cta: {
-        url,
-        title,
-        altTitle
+    const { text, html } = await renderEmail(
+      {
+        mjml: {
+          bodyStart: `<mj-text>${bodyStart}</mj-text>`,
+          bodyEnd: `<mj-text>${bodyEnd}</mj-text>`
+        },
+        text: { bodyStart, bodyEnd },
+        cta: {
+          url,
+          title,
+          altTitle
+        }
       },
       server
-    })
+    )
 
     expect(text).to.be.ok
     expect(sanitize(text, { allowedTags: [] })).to.eq(text) // there should be no HTML
@@ -43,9 +47,9 @@ describe('Basic email template', () => {
     expect(text).to.contain(title)
     expect(text).to.not.contain(altTitle)
     expect(text).to.contain(server.name)
-    expect(text).to.contain(server.url)
+    expect(text).to.contain(server.canonicalUrl)
     expect(text).to.contain(server.company)
-    expect(text).to.contain(server.contact)
+    expect(text).to.contain(server.adminContact)
 
     expect(html).to.be.ok
     expect(html).to.contain(bodyStart)
@@ -54,7 +58,7 @@ describe('Basic email template', () => {
     const matches = [...(html.matchAll(HTML_LINK_MATCHER) || [])]
     expect(matches.length).to.be.greaterThanOrEqual(2)
 
-    const expectedUrlsToCheck = [url, server.url]
+    const expectedUrlsToCheck = [url, server.canonicalUrl]
     let checkedUrls = 0
     for (const match of matches) {
       const [, foundHref, foundAltTitle, foundTitle] = match
@@ -65,10 +69,10 @@ describe('Basic email template', () => {
         expect(foundAltTitle).to.eq(altTitle)
         expect(foundTitle).to.eq(title)
         checkedUrls++
-      } else if (foundHref === server.url) {
+      } else if (foundHref === server.canonicalUrl) {
         // Server info
         expect(foundAltTitle).to.eq(server.name)
-        expect(foundTitle).to.eq(server.url)
+        expect(foundTitle).to.eq(server.canonicalUrl)
         checkedUrls++
       }
     }
@@ -76,27 +80,30 @@ describe('Basic email template', () => {
     expect(checkedUrls).to.be.greaterThanOrEqual(2)
 
     expect(html).to.contain(server.company)
-    expect(html).to.contain(server.contact)
+    expect(html).to.contain(server.adminContact)
   })
 
   it('prefills server info, if not passed in', async () => {
-    const serverInfo = buildBasicTemplateServerInfo(await getServerInfo())
+    const serverInfo = await getServerInfo()
 
-    const { text, html } = await buildBasicTemplateEmail({
-      html: { bodyStart: '', bodyEnd: '' },
-      text: { bodyStart: '', bodyEnd: '' }
-    })
+    const { text, html } = await renderEmail(
+      {
+        mjml: { bodyStart: '', bodyEnd: '' },
+        text: { bodyStart: '', bodyEnd: '' }
+      },
+      serverInfo
+    )
 
     expect(text).to.be.ok
     expect(text).to.contain(serverInfo.name)
-    expect(text).to.contain(serverInfo.url)
+    expect(text).to.contain(serverInfo.canonicalUrl)
     expect(text).to.contain(serverInfo.company)
-    expect(text).to.contain(serverInfo.contact)
+    expect(text).to.contain(serverInfo.adminContact)
 
     expect(html).to.be.ok
     expect(html).to.contain(serverInfo.name)
-    expect(html).to.contain(serverInfo.url)
+    expect(html).to.contain(serverInfo.canonicalUrl)
     expect(html).to.contain(serverInfo.company)
-    expect(html).to.contain(serverInfo.contact)
+    expect(html).to.contain(serverInfo.adminContact)
   })
 })

--- a/packages/server/modules/notifications/services/handlers/newStreamAccessRequest.ts
+++ b/packages/server/modules/notifications/services/handlers/newStreamAccessRequest.ts
@@ -108,7 +108,7 @@ function buildEmailTemplateParams(state: ValidatedMessageState): EmailTemplatePa
 const handler: NotificationHandler<NewStreamAccessRequestMessage> = async (msg) => {
   const state = await validateMessage(msg)
   const htmlTemplateParams = buildEmailTemplateParams(state)
-  const serverInfo = getServerInfo()
+  const serverInfo = await getServerInfo()
   const { html, text } = await renderEmail(
     htmlTemplateParams,
     serverInfo,

--- a/packages/server/modules/notifications/services/handlers/newStreamAccessRequest.ts
+++ b/packages/server/modules/notifications/services/handlers/newStreamAccessRequest.ts
@@ -11,14 +11,15 @@ import { NotificationValidationError } from '@/modules/notifications/errors'
 import { getStream } from '@/modules/core/repositories/streams'
 import { Roles } from '@/modules/core/helpers/mainConstants'
 import {
-  BasicEmailTemplateParams,
-  buildBasicTemplateEmail
-} from '@/modules/emails/services/templateFormatting'
-import {
   buildAbsoluteUrlFromRoute,
   getStreamCollaboratorsRoute
 } from '@/modules/core/helpers/routeHelper'
 import { sendEmail } from '@/modules/emails/services/sending'
+import {
+  EmailTemplateParams,
+  renderEmail
+} from '@/modules/emails/services/emailRendering'
+import { getServerInfo } from '@/modules/core/services/generic'
 
 async function validateMessage(msg: NewStreamAccessRequestMessage) {
   const {
@@ -63,22 +64,26 @@ type ValidatedMessageState = Awaited<ReturnType<typeof validateMessage>>
 
 function buildEmailTemplateHtml(
   state: ValidatedMessageState
-): BasicEmailTemplateParams['html'] {
+): EmailTemplateParams['mjml'] {
   const { requester, stream } = state
 
   return {
-    bodyStart: `Hello,<br/>
+    bodyStart: `<mj-text>
+Hello,<br/>
 <br/>
 <b>${requester.name}</b> requested access to the <b>${stream.name}</b> stream.
 You can add them as a collaborator by clicking the button below.
+</mj-text>
 `,
-    bodyEnd: `You received this email because you are an owner on <b>${stream.name}</b>.`
+    bodyEnd: `<mj-text>
+You received this email because you are an owner on <b>${stream.name}</b>.
+</mj-text>`
   }
 }
 
 function buildEmailTemplateText(
   state: ValidatedMessageState
-): BasicEmailTemplateParams['text'] {
+): EmailTemplateParams['text'] {
   const { requester, stream } = state
 
   return {
@@ -87,13 +92,11 @@ function buildEmailTemplateText(
   }
 }
 
-function buildEmailTemplateParams(
-  state: ValidatedMessageState
-): BasicEmailTemplateParams {
+function buildEmailTemplateParams(state: ValidatedMessageState): EmailTemplateParams {
   const { stream } = state
 
   return {
-    html: buildEmailTemplateHtml(state),
+    mjml: buildEmailTemplateHtml(state),
     text: buildEmailTemplateText(state),
     cta: {
       title: 'Review Request',
@@ -105,7 +108,12 @@ function buildEmailTemplateParams(
 const handler: NotificationHandler<NewStreamAccessRequestMessage> = async (msg) => {
   const state = await validateMessage(msg)
   const htmlTemplateParams = buildEmailTemplateParams(state)
-  const { html, text } = await buildBasicTemplateEmail(htmlTemplateParams)
+  const serverInfo = getServerInfo()
+  const { html, text } = await renderEmail(
+    htmlTemplateParams,
+    serverInfo,
+    state.targetUser
+  )
 
   await sendEmail({
     to: state.targetUser.email,

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -68,7 +68,7 @@
     "volar.completion.preferredTagNameCase": "kebab",
     "volar.vueserver.maxOldSpaceSize": 4000,
     "vscode-graphql.cacheSchemaFileForLookup": true,
-    "cSpell.words": ["Bursty"]
+    "cSpell.words": ["Bursty", "mjml"]
   },
   "extensions": {
     // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.


### PR DESCRIPTION
This has been left half baked for a while. Now all outgoing emails should use the ejs mjml on the fly rendering.

Unforch my local server is refusing to send emails with mailjet, so I'd like to get this out to latest for a proper testing.
Once that is done, I'm gonna create an additional cleanup PR, that removes the traces of the old rendering system.