### PR TITLE
Enable Frontend 2 readiness probe

### DIFF
--- a/utils/helm/speckle-server/templates/frontend/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend/deployment.yml
@@ -41,6 +41,13 @@ spec:
             exec:
               command: ["sleep", "5"]
 
+        readinessProbe:
+          httpGet:
+            path: /
+            port: www
+          initialDelaySeconds: 5
+          periodSeconds: 5
+
         env: 
           - name: FILE_SIZE_LIMIT_MB
             value: {{ .Values.file_size_limit_mb | quote }}

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -28,27 +28,6 @@ spec:
             containerPort: {{ include "server.port" $ }}
             protocol: TCP
 
-        livenessProbe:
-          # account for long-running migrations
-          initialDelaySeconds: 600
-          periodSeconds: 60
-          timeoutSeconds: 10
-          exec:
-            command:
-              - node
-              - -e
-              - "require('node:http').request({headers: {'Content-Type': 'application/json'}, port:3000, hostname:'127.0.0.1', path:'/graphql?query={serverInfo{version}}', method: 'GET' }, (res) => { body = ''; res.on('data', (chunk) => {body += chunk;}); res.on('end', () => {process.exit(res.statusCode != 200 || body.toLowerCase().includes('error'));}); }).end();"
-
-        readinessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 10
-          exec:
-            command:
-              - node
-              - -e
-              - "require('node:http').request({headers: {'Content-Type': 'application/json'}, port:3000, hostname:'127.0.0.1', path:'/graphql?query={serverInfo{version}}', method: 'GET' }, (res) => { body = ''; res.on('data', (chunk) => {body += chunk;}); res.on('end', () => {process.exit(res.statusCode != 200 || body.toLowerCase().includes('error'));}); }).end();"
-
         resources:
           requests:
             cpu: {{ .Values.server.requests.cpu }}
@@ -80,6 +59,27 @@ spec:
           preStop:
             exec:
               command: ["sleep", "5"]
+
+        livenessProbe:
+          # account for long-running migrations
+          initialDelaySeconds: 600
+          periodSeconds: 60
+          timeoutSeconds: 10
+          exec:
+            command:
+              - node
+              - -e
+              - "require('node:http').request({headers: {'Content-Type': 'application/json'}, port:3000, hostname:'127.0.0.1', path:'/graphql?query={serverInfo{version}}', method: 'GET' }, (res) => { body = ''; res.on('data', (chunk) => {body += chunk;}); res.on('end', () => {process.exit(res.statusCode != 200 || body.toLowerCase().includes('error'));}); }).end();"
+
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
+          exec:
+            command:
+              - node
+              - -e
+              - "require('node:http').request({headers: {'Content-Type': 'application/json'}, port:3000, hostname:'127.0.0.1', path:'/graphql?query={serverInfo{version}}', method: 'GET' }, (res) => { body = ''; res.on('data', (chunk) => {body += chunk;}); res.on('end', () => {process.exit(res.statusCode != 200 || body.toLowerCase().includes('error'));}); }).end();"
 
         env:
           - name: CANONICAL_URL


### PR DESCRIPTION
## Description & motivation

Re-enables readiness probes that are present on `main` branch.

## Changes:

- readiness probe for frontend service
- readiness probe for server service
- liveness probe for server service

## To-do before merge:

## Screenshots:

## Validation of changes:


## Checklist:


- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References
