### PR TITLE
Fix: add `types` to root viewer `exports`

### DIFF
--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -11,7 +11,10 @@
   "main": "dist/speckleviewer.js",
   "module": "dist/speckleviewer.esm.js",
   "exports": {
-    ".": "./dist/speckleviewer.esm.js",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/speckleviewer.esm.js"
+    },
     "./dist/assets/*": "./dist/assets/*",
     "./assets/*": "./dist/assets/*"
   },


### PR DESCRIPTION
## Description & motivation

TypeScript 5.0 just introduced new `moduleResolution` options. Specifically, `"bundler"` ([link](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#moduleresolution-bundler)) for cases where the build is being managed by a modern bundler. They write a lot about why they decided to ~~make us fight tsconfig~~ do this in that link.

This setting requires packages consumed with `exports` specified to also specify where `types` come from for those exports. It can detect the current value in the top-level `types` property, but it chooses to ignore it and outputs an error like this:

```
@nodepen/nodes:build: src/views/speckle-model-view/SpeckleModelView.tsx(2,58): error TS7016: Could not find a declaration file for module '@speckle/viewer'. 'D:/src/github.com/nodepen/nodes/node_modules/@speckle/viewer/dist/speckleviewer.esm.js' implicitly has an 'any' type.
@nodepen/nodes:build:   There are types at 'D:/src/github.com/nodepen/nodes/node_modules/@speckle/viewer/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@speckle/viewer' library may need to update its package.json or typings.
```

There are a lot of [levers we can pull](https://github.com/pmndrs/zustand/blob/main/package.json), but this is a [minimal fix](https://github.com/mantinedev/mantine-flagpack/pull/3/files).

## Changes:

- Duplicates current `types` value (`"./dist/index.d.ts"`) at `"exports" > "." > "types"` and sets current value as `"default"`.

## Validation of changes:

- When I make these changes locally and link `@speckle/viewer`, I'm able to successfully build my project with `"moduleResolution": "bundler"` set in `tsconfig.json`.
- I'm still able to `yarn` and `yarn build` the `speckle-server` workspace after this change.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [N/A] I have added appropriate tests.
- [N/A] I have updated or added relevant documentation.

