### PR TITLE
Fix: Switch scripts CDN from unpkg to jsdelivr in explorer.html template

### DIFF
--- a/packages/server/assets/apiexplorer/templates/explorer.html
+++ b/packages/server/assets/apiexplorer/templates/explorer.html
@@ -3,7 +3,10 @@
   <html>
     <head>
       <title>Speckle GraphQL API</title>
-      <link href="https://unpkg.com/graphiql/graphiql.min.css" rel="stylesheet" />
+      <link
+        href="https://cdn.jsdelivr.net/npm/graphiql/graphiql.min.css"
+        rel="stylesheet"
+      />
     </head>
 
     <body style="margin: 0">
@@ -44,13 +47,16 @@
       <div id="graphiql" style="height: 88vh"></div>
       <script
         crossorigin
-        src="https://unpkg.com/react/umd/react.production.min.js"
+        src="https://cdn.jsdelivr.net/npm/react/umd/react.production.min.js"
       ></script>
       <script
         crossorigin
-        src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"
+        src="https://cdn.jsdelivr.net/npm/react-dom/umd/react-dom.production.min.js"
       ></script>
-      <script crossorigin src="https://unpkg.com/graphiql/graphiql.min.js"></script>
+      <script
+        crossorigin
+        src="https://cdn.jsdelivr.net/npm/graphiql/graphiql.min.js"
+      ></script>
       <script>
         const graphQLFetcher = (graphQLParams) =>
           fetch('/graphql', {


### PR DESCRIPTION
## Description & motivation

Have noticed some intermittent reliability issues related to loading dependencies from unpkg (we're failing to load react, react-dom, graphiql this afternoon, we're encountering 520 errors) 

This seems to an issue that many others have been facing too: https://github.com/mjackson/unpkg/issues/356, https://github.com/mjackson/unpkg/issues/358, https://github.com/mjackson/unpkg/issues/360, https://github.com/mjackson/unpkg/issues/361

## Changes:

- Switch to using another CDN, for example a multi-cdn like [jsdelivr](https://www.jsdelivr.com/package/npm/graphiql)

## Screenshots:
520 errors with speckle.xyz

![image](https://user-images.githubusercontent.com/69314485/229886869-c401a2b3-be14-4105-be34-122802f7b459.png)

520 errors with Arup servers
![image](https://user-images.githubusercontent.com/69314485/229886727-707dd269-f522-4511-8167-163452ad2d02.png)


## Validation of changes:

Have deployed this updated explorer.html in our dev environment and manually tested/checked that dependencies are loaded

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.
