### PR TITLE
fix(tailwind-theme): Move default to be last option on exports.

### DIFF
--- a/packages/tailwind-theme/package.json
+++ b/packages/tailwind-theme/package.json
@@ -17,12 +17,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/index.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       },
       "require": {
-        "default": "./dist-cjs/index.js",
-        "types": "./dist-cjs/index.d.ts"
+        "types": "./dist-cjs/index.d.ts",
+        "default": "./dist-cjs/index.js"
       }
     },
     "./tailwind-configure": {


### PR DESCRIPTION
Fixes #1586 

Just ensuring `default` is the last option in each object seems to do the trick.

@fabis94 may want to double check this as I've only verified this is the case on my machine (Intel Mac) on both VSCode and Webstorm.