### PR TITLE
fix(fe2): spotlight & zoom extents fixes

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/serialization.ts
+++ b/packages/frontend-2/lib/viewer/composables/serialization.ts
@@ -275,7 +275,7 @@ export function useApplySerializedState() {
         instruction.versionA.versionId,
         instruction.versionB.versionId
       )
-    } else if (!activeDiffEnabled) {
+    } else if (!activeDiffEnabled || mode === StateApplyMode.Spotlight) {
       await endDiff()
     }
 


### PR DESCRIPTION
Bugfixes:
- Diff Mode for Follower not ending when source stops the diff

Features:
- No longer triggering "zoom extents" on object load, if a thread is open