### PR TITLE
fix(fe2): invalid totalCount cache updates for project.versions, project.models and model.versions

### DIFF
--- a/packages/frontend-2/lib/common/composables/singleton.ts
+++ b/packages/frontend-2/lib/common/composables/singleton.ts
@@ -1,0 +1,57 @@
+import { nanoid } from 'nanoid'
+import { useScopedState } from '~~/lib/common/composables/scopedState'
+import { MaybeRef } from '@vueuse/core'
+
+const useComponentLockState = () =>
+  useScopedState('componentLockState', () =>
+    ref(new Array<{ key: string; instanceId: string }>())
+  )
+
+/**
+ * A lock that is scoped to a component. If multiple instances of the same lock composable are invoked,
+ * only the first one will have the lock.
+ *
+ * The lock is released when the component that owns the composable invocation is unmounted
+ */
+export const useLock = (key: MaybeRef<string>) => {
+  const instanceId = nanoid()
+  const lockState = useComponentLockState()
+
+  const isActiveInstance = computed(() => {
+    return (
+      lockState.value.find((lock) => lock.key === unref(key))?.instanceId === instanceId
+    )
+  })
+
+  // On unmount, remove this instance from the list of active instances
+  onBeforeUnmount(() => {
+    lockState.value = lockState.value.filter(
+      (lock) => lock.key !== unref(key) || lock.instanceId !== instanceId
+    )
+  })
+
+  watch(
+    lockState,
+    () => {
+      // If there is no active instance, mark this as the active one
+      if (!lockState.value.find((lock) => lock.key === unref(key))) {
+        lockState.value.push({ key: unref(key), instanceId })
+      }
+    },
+    { immediate: true, deep: true, flush: 'sync' }
+  )
+
+  watch(
+    () => unref(key),
+    (newKey, oldKey) => {
+      if (newKey === oldKey) return
+
+      // If the key changes, remove the old key from the list of active instances
+      lockState.value = lockState.value.filter(
+        (lock) => lock.key !== oldKey || lock.instanceId !== instanceId
+      )
+    }
+  )
+
+  return { hasLock: isActiveInstance }
+}

--- a/packages/frontend-2/lib/common/helpers/debugging.ts
+++ b/packages/frontend-2/lib/common/helpers/debugging.ts
@@ -31,3 +31,17 @@ export function wrapRefWithTracking<R extends Ref<unknown>>(
     // hiding the real type so that you don't have to re-type everything that relies on the ref being a ref
   }) as unknown as R
 }
+
+/**
+ * Use this to render a stack trace with clickable links to the source code in the browser console
+ */
+export class StackTrace extends Error {
+  constructor() {
+    super('')
+    this.name = 'Stack trace:'
+  }
+}
+
+export function getCurrentTrace() {
+  return (new Error('Trace:').stack || '').substring(7)
+}

--- a/packages/frontend-2/lib/core/helpers/observability.ts
+++ b/packages/frontend-2/lib/core/helpers/observability.ts
@@ -20,7 +20,7 @@ export function buildFakePinoLogger(
     warn: console.warn,
     error: errLogger,
     fatal: errLogger,
-    trace: console.debug,
+    trace: console.trace,
     silent: noop
   } as unknown as ReturnType<typeof Observability.getLogger>
 

--- a/packages/frontend-2/lib/projects/composables/modelManagement.ts
+++ b/packages/frontend-2/lib/projects/composables/modelManagement.ts
@@ -37,6 +37,7 @@ import {
 import { modelRoute, useNavigateToProject } from '~~/lib/common/helpers/route'
 import { FileUploadConvertedStatus } from '~~/lib/core/api/fileImport'
 import { useLock } from '~~/lib/common/composables/singleton'
+import { isUndefined } from 'lodash-es'
 
 const isValidModelName: GenericValidateFunction<string> = (name) => {
   name = name.trim()
@@ -268,19 +269,21 @@ export function useProjectModelUpdateTracking(
           if (variables.filter?.contributors?.length) return
           if (!variables.filter?.onlyWithVersions) return
 
+          const limit = variables.limit
           const newModelRef = ref('Model', model.id)
           const newItems = (value?.items || []).slice()
 
-          let isAdded = false
-          if (!newItems.find((i) => i.__ref === newModelRef.__ref)) {
+          if (
+            !newItems.find((i) => i.__ref === newModelRef.__ref) &&
+            (isUndefined(limit) || newItems.length < limit)
+          ) {
             newItems.unshift(newModelRef)
-            isAdded = true
           }
 
           return {
             ...(value || {}),
             items: newItems,
-            totalCount: (value.totalCount || 0) + (isAdded ? 1 : 0)
+            totalCount: (value.totalCount || 0) + 1
           }
         }
       )

--- a/packages/frontend-2/lib/projects/composables/modelManagement.ts
+++ b/packages/frontend-2/lib/projects/composables/modelManagement.ts
@@ -262,8 +262,7 @@ export function useProjectModelUpdateTracking(
       modifyObjectFields<ProjectModelsArgs, Project['models']>(
         apollo.cache,
         getCacheId('Project', unref(projectId)),
-        (fieldName, variables, value, { ref }) => {
-          if (fieldName !== 'models') return
+        (_fieldName, variables, value, { ref }) => {
           if (variables.filter?.search) return
           if (variables.filter?.sourceApps?.length) return
           if (variables.filter?.contributors?.length) return
@@ -285,7 +284,8 @@ export function useProjectModelUpdateTracking(
             items: newItems,
             totalCount: (value.totalCount || 0) + 1
           }
-        }
+        },
+        { fieldNameWhitelist: ['models'] }
       )
 
       // + Evict modelsTree, if it doesnt have this model
@@ -350,12 +350,12 @@ export function useProjectPendingModelUpdateTracking(
       >(
         apollo.cache,
         getCacheId('Project', unref(projectId)),
-        (fieldName, _variables, value, { ref }) => {
-          if (fieldName !== 'pendingImportedModels') return
+        (_fieldName, _variables, value, { ref }) => {
           const currentModels = (value || []).slice()
           currentModels.push(ref('FileUpload', event.id))
           return currentModels
-        }
+        },
+        { fieldNameWhitelist: ['pendingImportedModels'] }
       )
     } else if (event.type === ProjectPendingModelsUpdatedMessageType.Updated) {
       // If converted emit toast notification & remove from pending models
@@ -372,15 +372,15 @@ export function useProjectPendingModelUpdateTracking(
         >(
           apollo.cache,
           getCacheId('Project', unref(projectId)),
-          (fieldName, _variables, value, { ref }) => {
-            if (fieldName !== 'pendingImportedModels') return
+          (_fieldName, _variables, value, { ref }) => {
             if (!value?.length) return
 
             const currentModels = (value || []).filter(
               (i) => i.__ref !== ref('FileUpload', event.id).__ref
             )
             return currentModels
-          }
+          },
+          { fieldNameWhitelist: ['pendingImportedModels'] }
         )
       } else if (failure) {
         triggerNotification({


### PR DESCRIPTION
+ Improved various singletons to use locks so that they can be used multiple times per page without bugs arising (easier code maintenance)
+ Improved troubleshooting DX for local apollo cache updates