### PR TITLE
fix: improvements not really related to "guest role" launch

### DIFF
--- a/packages/frontend-2/components/project/model-page/versions/CardActions.vue
+++ b/packages/frontend-2/components/project/model-page/versions/CardActions.vue
@@ -35,6 +35,10 @@ const props = defineProps<{
 
 const copyModelLink = useCopyModelLink()
 
+const disabledMessage = ref(
+  'Version editing is only allowed to project or version owners'
+)
+
 const showActionsMenu = computed({
   get: () => props.open,
   set: (newVal) => emit('update:open', newVal)
@@ -45,24 +49,28 @@ const actionsItems = computed<LayoutMenuItem<VersionActionTypes>[][]>(() => [
     {
       title: 'Delete',
       id: VersionActionTypes.Delete,
-      disabled: !!props.selectionDisabled
+      disabled: !!props.selectionDisabled,
+      disabledTooltip: disabledMessage.value
     },
     {
       title: 'Move to',
       id: VersionActionTypes.MoveTo,
-      disabled: !!props.selectionDisabled
+      disabled: !!props.selectionDisabled,
+      disabledTooltip: disabledMessage.value
     },
     {
       title: 'Edit message',
       id: VersionActionTypes.EditMessage,
-      disabled: !!props.selectionDisabled
+      disabled: !!props.selectionDisabled,
+      disabledTooltip: disabledMessage.value
     }
   ],
   [
     {
       title: 'Select',
       id: VersionActionTypes.Select,
-      disabled: !!props.selectionDisabled
+      disabled: !!props.selectionDisabled,
+      disabledTooltip: disabledMessage.value
     }
   ],
   [{ title: 'Share', id: VersionActionTypes.Share }]

--- a/packages/frontend/src/main/pages/stream/TheStream.vue
+++ b/packages/frontend/src/main/pages/stream/TheStream.vue
@@ -227,16 +227,18 @@ export default defineComponent({
           { data }: { data: { branchCreated: Record<string, unknown> } }
         ): void {
           if (!data.branchCreated) return
+          const branchName = data.branchCreated.name
+          const streamId = data.branchCreated.streamId
           this.$eventHub.$emit('notification', {
             text: `A new branch was created!`,
             action: {
               name: 'View Branch',
-              to: `/streams/${this.streamId}/branches/${data.branchCreated.name}`
+              to: `/streams/${streamId}/branches/${branchName}`
             }
           })
         },
         skip(this: VueThis): boolean {
-          return !this.isLoggedIn
+          return !this.isLoggedIn || !this.streamId
         }
       },
       commitCreated: {
@@ -255,16 +257,19 @@ export default defineComponent({
           { data }: { data: { commitCreated: Record<string, unknown> } }
         ): void {
           if (!data.commitCreated) return
+          const commitId = data.commitCreated.id
+          const streamId = data.commitCreated.streamId
+
           this.$eventHub.$emit('notification', {
             text: `A new commit was created!`,
             action: {
               name: 'View Commit',
-              to: `/streams/${this.streamId}/commits/${data.commitCreated.id}`
+              to: `/streams/${streamId}/commits/${commitId}`
             }
           })
         },
         skip(this: VueThis): boolean {
-          return !this.isLoggedIn
+          return !this.isLoggedIn || !this.streamId
         }
       }
     } as never // for some reason Vue Apollo Options API being used for subscriptions breaks all types in this SFC

--- a/packages/ui-components/src/components/form/select/Base.vue
+++ b/packages/ui-components/src/components/form/select/Base.vue
@@ -173,9 +173,6 @@ import { MaybeAsync, Nullable, Optional } from '@speckle/shared'
 import { RuleExpression, useField } from 'vee-validate'
 import { nanoid } from 'nanoid'
 import CommonLoadingBar from '~~/src/components/common/loading/Bar.vue'
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import { directive as vTippy } from 'vue-tippy'
 
 type ButtonStyle = 'base' | 'simple' | 'tinted'

--- a/packages/ui-components/src/components/layout/Menu.stories.ts
+++ b/packages/ui-components/src/components/layout/Menu.stories.ts
@@ -33,7 +33,9 @@ export default {
   }
 } as Meta
 
-const defaultItems: LayoutMenuItem<'a' | 'b' | 'c'>[][] = [
+const defaultItems = (
+  params?: Partial<{ withTooltip: boolean }>
+): LayoutMenuItem<'a' | 'b' | 'c'>[][] => [
   [
     {
       title: 'First Group Item - #1',
@@ -43,7 +45,8 @@ const defaultItems: LayoutMenuItem<'a' | 'b' | 'c'>[][] = [
     {
       title: 'First Group Item - #2 (Disabled)',
       id: 'b',
-      disabled: true
+      disabled: true,
+      disabledTooltip: params?.withTooltip ? "Here's why it is disabled..." : undefined
     }
   ],
   [
@@ -86,6 +89,14 @@ export const Default: StoryType = {
   }),
   args: {
     open: false,
-    items: defaultItems
+    items: defaultItems()
+  }
+}
+
+export const WithDisabledTooltip: StoryType = {
+  ...Default,
+  args: {
+    ...Default.args,
+    items: defaultItems({ withTooltip: true })
   }
 }

--- a/packages/ui-components/src/components/layout/Menu.vue
+++ b/packages/ui-components/src/components/layout/Menu.vue
@@ -45,8 +45,6 @@
   </Menu>
 </template>
 <script setup lang="ts">
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import { directive as vTippy } from 'vue-tippy'
 import { Menu, MenuButton, MenuItems, MenuItem } from '@headlessui/vue'
 import { Nullable } from '@speckle/shared'

--- a/packages/ui-components/src/components/layout/Menu.vue
+++ b/packages/ui-components/src/components/layout/Menu.vue
@@ -29,12 +29,15 @@
             :key="item.id"
             :disabled="item.disabled"
           >
-            <button
-              :class="buildButtonClassses({ active, disabled })"
-              @click="chooseItem(item, $event)"
-            >
-              <slot name="item" :item="item">{{ item.title }}</slot>
-            </button>
+            <span v-tippy="item.disabled && item.disabledTooltip">
+              <button
+                :class="buildButtonClassses({ active, disabled })"
+                :disabled="disabled"
+                @click="chooseItem(item, $event)"
+              >
+                <slot name="item" :item="item">{{ item.title }}</slot>
+              </button>
+            </span>
           </MenuItem>
         </div>
       </MenuItems>
@@ -42,6 +45,9 @@
   </Menu>
 </template>
 <script setup lang="ts">
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { directive as vTippy } from 'vue-tippy'
 import { Menu, MenuButton, MenuItems, MenuItem } from '@headlessui/vue'
 import { Nullable } from '@speckle/shared'
 import { computed, ref, watch } from 'vue'

--- a/packages/ui-components/src/helpers/layout/components.ts
+++ b/packages/ui-components/src/helpers/layout/components.ts
@@ -12,4 +12,5 @@ export type LayoutMenuItem<I extends string = string> = {
   title: string
   id: I
   disabled?: boolean
+  disabledTooltip?: string
 }

--- a/packages/ui-components/src/vue-tippy.d.ts
+++ b/packages/ui-components/src/vue-tippy.d.ts
@@ -1,0 +1,4 @@
+declare module 'vue-tippy' {
+  import * as coreTippy from 'vue-tippy/dist/vue-tippy.d.ts'
+  export = coreTippy
+}


### PR DESCRIPTION
View Commit button broken: 
* The bug described could've already happened before guest roles, it seems. In either case, I don't see how it could've happened, because to get a broken notification button you have to be on a broken URL already.
* I added extra safeguards tho, so that even if the URL is broken, the notification URL should be valid

FE2 Delete versions:
* I don't think there's any bug here - versions can only be deleted by project owners or authors of those specific versions. But maybe that's not clear enough, so I added tooltips to the disabled select items. 