### PR TITLE
chore: moving writableAsyncComputed to ui-components

### DIFF
--- a/packages/frontend-2/nuxt.config.ts
+++ b/packages/frontend-2/nuxt.config.ts
@@ -131,6 +131,10 @@ export default defineNuxtConfig({
     }
   },
 
+  nitro: {
+    compressPublicAssets: true
+  },
+
   build: {
     transpile: [
       /^@apollo\/client/,

--- a/packages/ui-components/src/composables/common/async.ts
+++ b/packages/ui-components/src/composables/common/async.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { MaybeAsync } from '@speckle/shared'
+import { AsyncComputedOptions, computedAsync } from '@vueuse/core'
+import { ComputedRef, computed } from 'vue'
+
+export interface AsyncWritableComputedOptions<T> {
+  get: (...args: any[]) => MaybeAsync<T>
+  set: (value: T) => MaybeAsync<void>
+  initialState: T
+  readOptions?: AsyncComputedOptions
+  asyncRead?: boolean
+  debugging?: Partial<{
+    log: {
+      name: string
+      writesOnly?: boolean
+      readsOnly?: boolean
+      logger?: (msg: string, ...args: any[]) => void
+    }
+  }>
+}
+
+export type AsyncWritableComputedRef<T> = ComputedRef<T> & {
+  update: AsyncWritableComputedOptions<T>['set']
+}
+
+/**
+ * Allows async read/write from/to computed. Use `res.value` to read and `res.update` to write. If you only need
+ * the computed to be read-only then use vueuse's `computedAsync`. If you only need async writes you can
+ * disable async reads through the `asyncRead` param.
+ * @param params
+ */
+export function writableAsyncComputed<T>(
+  params: AsyncWritableComputedOptions<T>
+): AsyncWritableComputedRef<T> {
+  const { get, initialState, readOptions, set, asyncRead = true, debugging } = params
+  const logSettings = debugging?.log
+  const getTrace = () => (new Error('Trace:').stack || '').substring(7)
+  const logger = params.debugging?.log?.logger || console.debug
+
+  const finalGet: typeof get =
+    logSettings && !logSettings.writesOnly
+      ? () => {
+          const res = get()
+          logger(`debugging: '${logSettings.name}' read`, res, getTrace())
+          return res
+        }
+      : get
+
+  const finalSet: typeof set =
+    logSettings && !logSettings.readsOnly
+      ? (newVal) => {
+          logger(`debugging: '${logSettings.name}' written to`, newVal, getTrace())
+          return set(newVal)
+        }
+      : set
+
+  const readValue = asyncRead
+    ? computedAsync(finalGet, initialState, readOptions)
+    : computed(finalGet)
+
+  const getter = computed(() => readValue.value) as AsyncWritableComputedRef<T>
+  getter.update = finalSet
+
+  return getter
+}

--- a/packages/ui-components/src/lib.ts
+++ b/packages/ui-components/src/lib.ts
@@ -47,6 +47,11 @@ import InfiniteLoading from '~~/src/components/InfiniteLoading.vue'
 import { InfiniteLoaderState } from '~~/src/helpers/global/components'
 import LayoutPanel from '~~/src/components/layout/Panel.vue'
 import CommonAlert from '~~/src/components/common/Alert.vue'
+import {
+  writableAsyncComputed,
+  AsyncWritableComputedOptions,
+  AsyncWritableComputedRef
+} from '~~/src/composables/common/async'
 
 export {
   GlobalToastRenderer,
@@ -85,7 +90,8 @@ export {
   LayoutTabs,
   InfiniteLoading,
   LayoutPanel,
-  CommonAlert
+  CommonAlert,
+  writableAsyncComputed
 }
 export type {
   ToastNotification,
@@ -94,5 +100,7 @@ export type {
   HorizontalOrVertical,
   LayoutMenuItem,
   LayoutTabItem,
-  InfiniteLoaderState
+  InfiniteLoaderState,
+  AsyncWritableComputedOptions,
+  AsyncWritableComputedRef
 }


### PR DESCRIPTION
moving stuff from fe2 to ui-components so we can use it in automate