### PR TITLE
Feat (dui3): Multiple notifications

### DIFF
--- a/packages/dui3/components/common/ModelCard.vue
+++ b/packages/dui3/components/common/ModelCard.vue
@@ -61,10 +61,13 @@
       </div>
     </div>
     <!-- Card Notification -->
-    <CommonModelNotification
-      v-if="props.modelCard.notification"
-      :notification="props.modelCard.notification"
-    />
+    <div v-for="notification in props.modelCard.notifications" :key="notification.id">
+      <CommonModelNotification
+        v-if="notification.visible"
+        :key="notification.id"
+        :notification="notification"
+      />
+    </div>
     <LayoutDialog v-model:open="openRemoveCardDialog">
       <FormButton @click="removeCard">Remove</FormButton>
       <!-- <RemoveCardDialog :model="modelCard" @close="openRemoveCardDialog = false" /> -->
@@ -74,8 +77,8 @@
 <script setup lang="ts">
 import { CommonLoadingProgressBar } from '@speckle/ui-components'
 import { TrashIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline'
-import { IModelCard } from '~~/lib/bindings/definitions/IBasicConnectorBinding'
 import { ProjectModelGroup, useHostAppStore } from '~~/store/hostApp'
+import { IModelCard } from '~~/lib/models/card'
 
 const store = useHostAppStore()
 

--- a/packages/dui3/components/common/ModelReceiver.vue
+++ b/packages/dui3/components/common/ModelReceiver.vue
@@ -29,7 +29,7 @@
 
 <script setup lang="ts">
 import { CloudArrowDownIcon } from '@heroicons/vue/24/outline'
-import { IReceiverModelCard } from '~/lib/bindings/definitions/IReceiveBinding'
+import { IReceiverModelCard } from '~/lib/models/card/receiver'
 import { VersionsSelectItemType } from '~/lib/form/select/types'
 import { useGetModelDetails, useProjectVersionUpdated } from '~/lib/graphql/composables'
 import { ProjectModelGroup, useHostAppStore } from '~/store/hostApp'

--- a/packages/dui3/components/common/ModelSender.vue
+++ b/packages/dui3/components/common/ModelSender.vue
@@ -40,8 +40,8 @@
 </template>
 <script setup lang="ts">
 import { CloudArrowUpIcon, FunnelIcon } from '@heroicons/vue/24/outline'
+import { ISenderModelCard } from '~~/lib/models/card/send'
 import { useGetModelDetails } from '~~/lib/graphql/composables'
-import { ISenderModelCard } from '~~/lib/bindings/definitions/ISendBinding'
 import { ProjectModelGroup, useHostAppStore } from '~~/store/hostApp'
 
 const store = useHostAppStore()

--- a/packages/dui3/lib/bindings/definitions/IBasicConnectorBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IBasicConnectorBinding.ts
@@ -2,11 +2,8 @@
 
 import { BaseBridge } from '~~/lib/bridge/base'
 import { IBinding } from '~~/lib/bindings/definitions/IBinding'
-import { IDiscriminatedObject } from '~~/lib/bindings/definitions/common'
-import {
-  ISendFilter,
-  ModelProgressArgs
-} from '~~/lib/bindings/definitions/ISendBinding'
+import { IModelCard } from '~~/lib/models/card'
+import { ISendFilter } from '~~/lib/models/card/send'
 
 export const IBasicConnectorBindingKey = 'baseBinding'
 
@@ -35,22 +32,6 @@ export interface IBasicConnectorBindingHostEvents {
 export type DocumentModelStore = {
   models: IModelCard[]
 }
-
-//
-// Model cards
-//
-export interface IModelCard extends IDiscriminatedObject {
-  id: string
-  modelId: string
-  projectId: string
-  accountId: string
-  expired?: boolean
-  lastLocalUpdate?: string
-  notification?: ToastInfo
-  progress?: ModelProgressArgs
-}
-
-export type ModelCardTypeDiscriminators = 'SenderModelCard' | 'ReceiverModelCard'
 
 export type DocumentInfo = {
   location: string

--- a/packages/dui3/lib/bindings/definitions/IReceiveBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IReceiveBinding.ts
@@ -1,4 +1,5 @@
-import { IModelCard, ToastInfo } from 'lib/bindings/definitions/IBasicConnectorBinding'
+import { ModelCardNotification } from 'lib/models/card/notification'
+import { ModelCardProgress } from 'lib/models/card/progress'
 import { IBinding } from '~~/lib/bindings/definitions/IBinding'
 
 export const IReceiveBindingKey = 'receiveBinding'
@@ -10,21 +11,6 @@ export interface IReceiveBinding extends IBinding<IReceiveBindingEvents> {
 }
 
 export interface IReceiveBindingEvents {
-  receiverProgress: (args: ReceiverProgressArgs) => void
-  notify: (args: ToastInfo) => void
-}
-
-export interface IReceiverModelCard extends IModelCard {
-  typeDiscriminator: 'ReceiverModelCard'
-  referencedObject: string
-  modelName: string
-  projectName: string
-  sourceApp: string
-  receiving?: boolean
-}
-
-export type ReceiverProgressArgs = {
-  id: string
-  status?: string
-  progress?: number
+  receiverProgress: (args: ModelCardProgress) => void
+  notify: (args: ModelCardNotification) => void
 }

--- a/packages/dui3/lib/bindings/definitions/ISendBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/ISendBinding.ts
@@ -1,5 +1,6 @@
-import { IModelCard, ToastInfo } from 'lib/bindings/definitions/IBasicConnectorBinding'
-import { IDiscriminatedObject } from '~~/lib/bindings/definitions/common'
+import { ModelCardNotification } from '~~/lib/models/card/notification'
+import { ModelCardProgress } from '~~/lib/models/card/progress'
+import { ISendFilter } from '~~/lib/models/card/send'
 import { IBinding } from '~~/lib/bindings/definitions/IBinding'
 
 export const ISendBindingKey = 'sendBinding'
@@ -13,27 +14,9 @@ export interface ISendBinding extends IBinding<ISendBindingEvents> {
 export interface ISendBindingEvents {
   filtersNeedRefresh: () => void
   sendersExpired: (args: string[]) => void
-  senderProgress: (args: SenderProgressArgs) => void
-  notify: (args: ToastInfo) => void
+  senderProgress: (args: ModelCardProgress) => void
+  notify: (args: ModelCardNotification) => void
   createVersion: (args: CreateVersionArgs) => void
-}
-
-export interface ISenderModelCard extends IModelCard {
-  typeDiscriminator: 'SenderModelCard'
-  sendFilter: ISendFilter
-  sending?: boolean
-}
-
-export type ModelProgressArgs = {
-  id: string
-  status?: string
-  progress?: number
-}
-
-export type SenderProgressArgs = {
-  id: string
-  status?: string
-  progress?: number
 }
 
 export type CreateVersionArgs = {
@@ -44,13 +27,4 @@ export type CreateVersionArgs = {
   objectId: string
   message?: string
   sourceApplication?: string
-}
-
-export interface ISendFilter extends IDiscriminatedObject {
-  name: string
-  summary: string
-}
-
-export interface IDirectSelectionSendFilter extends ISendFilter {
-  selectedObjectIds: string[]
 }

--- a/packages/dui3/lib/bridge/sketchup.ts
+++ b/packages/dui3/lib/bridge/sketchup.ts
@@ -283,4 +283,8 @@ export class SketchupBridge extends BaseBridge {
       'Sketchup cannot do this. The dev tools menu is accessible via a right click.'
     )
   }
+
+  public openUrl(url: string) {
+    window.open(url)
+  }
 }

--- a/packages/dui3/lib/models/card.ts
+++ b/packages/dui3/lib/models/card.ts
@@ -1,0 +1,16 @@
+import { IDiscriminatedObject } from '~~/lib/bindings/definitions/common'
+import { ModelCardNotification } from '~~/lib/models/card/notification'
+import { ModelCardProgress } from '~~/lib/models/card/progress'
+
+export type ModelCardTypeDiscriminators = 'SenderModelCard' | 'ReceiverModelCard'
+
+export interface IModelCard extends IDiscriminatedObject {
+  id: string
+  modelId: string
+  projectId: string
+  accountId: string
+  expired?: boolean
+  lastLocalUpdate?: string
+  notifications?: ModelCardNotification[]
+  progress?: ModelCardProgress
+}

--- a/packages/dui3/lib/models/card/notification.ts
+++ b/packages/dui3/lib/models/card/notification.ts
@@ -1,0 +1,14 @@
+export type ModelCardNotification = {
+  id: string
+  modelCardId: string
+  text: string
+  level: 'info' | 'danger' | 'warning' | 'success'
+  action?: ModelCardNotificationAction
+  timeout?: number
+  visible?: boolean
+}
+
+export type ModelCardNotificationAction = {
+  url: string
+  name: string
+}

--- a/packages/dui3/lib/models/card/progress.ts
+++ b/packages/dui3/lib/models/card/progress.ts
@@ -1,0 +1,5 @@
+export type ModelCardProgress = {
+  id: string
+  status?: string
+  progress?: number
+}

--- a/packages/dui3/lib/models/card/receiver.ts
+++ b/packages/dui3/lib/models/card/receiver.ts
@@ -1,0 +1,10 @@
+import { IModelCard } from '~~/lib/models/card'
+
+export interface IReceiverModelCard extends IModelCard {
+  typeDiscriminator: 'ReceiverModelCard'
+  referencedObject: string
+  modelName: string
+  projectName: string
+  sourceApp: string
+  receiving?: boolean
+}

--- a/packages/dui3/lib/models/card/send.ts
+++ b/packages/dui3/lib/models/card/send.ts
@@ -1,0 +1,17 @@
+import { IDiscriminatedObject } from '~~/lib/bindings/definitions/common'
+import { IModelCard } from '~~/lib/models/card'
+
+export interface ISenderModelCard extends IModelCard {
+  typeDiscriminator: 'SenderModelCard'
+  sendFilter: ISendFilter
+  sending?: boolean
+}
+
+export interface ISendFilter extends IDiscriminatedObject {
+  name: string
+  summary: string
+}
+
+export interface IDirectSelectionSendFilter extends ISendFilter {
+  selectedObjectIds: string[]
+}

--- a/packages/dui3/pages/onboarding/receive.vue
+++ b/packages/dui3/pages/onboarding/receive.vue
@@ -64,7 +64,7 @@ import {
   ModelsSelectItemType,
   VersionsSelectItemType
 } from 'lib/form/select/types'
-import { IReceiverModelCard } from 'lib/bindings/definitions/IReceiveBinding'
+import { IReceiverModelCard } from '~~/lib/models/card/receiver'
 
 const { defaultAccount } = storeToRefs(useAccountStore())
 const hostAppStore = useHostAppStore()
@@ -107,7 +107,8 @@ const receive = async () => {
     referencedObject: selectedVersion.value?.referencedObject as string,
     modelName: selectedModel.value?.name as string,
     projectName: selectedProject.value?.name as string,
-    sourceApp: selectedVersion.value?.sourceApplication as string
+    sourceApp: selectedVersion.value?.sourceApplication as string,
+    notifications: []
   }
 
   await hostAppStore.addModel(modelCard)

--- a/packages/dui3/pages/onboarding/send.vue
+++ b/packages/dui3/pages/onboarding/send.vue
@@ -72,10 +72,10 @@ import { SelectionInfo } from '~~/lib/bindings/definitions/ISelectionBinding'
 import { useSelectionStore } from '~~/store/selection'
 import { useAccountStore } from '~~/store/accounts'
 import { useHostAppStore } from '~~/store/hostApp'
-import { ISendFilter, ISenderModelCard } from '~~/lib/bindings/definitions/ISendBinding'
 import { nanoid } from 'nanoid'
 import { ValidationHelpers } from '@speckle/ui-components'
 import { ModelsSelectItemType, ProjectsSelectItemType } from 'lib/form/select/types'
+import { ISendFilter, ISenderModelCard } from '~~/lib/models/card/send'
 
 const store = useHostAppStore()
 const router = useRouter()
@@ -141,7 +141,8 @@ const getOrCreateModelCard = async () => {
       modelId: selectedModel.value?.id as string,
       projectId: selectedProject.value?.id as string,
       accountId: defaultAccount.value.accountInfo.id,
-      sendFilter: sendFilter as ISendFilter
+      sendFilter: sendFilter as ISendFilter,
+      notifications: []
     }
 
     await store.addModel(modelCard)


### PR DESCRIPTION
Host app can send multiple notifications i.e. one for succesful operations one for failed operations. We can show them sequentially now and store into card if they want to see them later again. Before notifications was disappered after timeout. Also some types extracted with better organization.