### PR TITLE
Fix: Allow files with uppercase file formats. Maintain casing from upload in UI. 

### DIFF
--- a/packages/frontend-2/lib/core/helpers/file.ts
+++ b/packages/frontend-2/lib/core/helpers/file.ts
@@ -49,7 +49,7 @@ export function validateFileType(
   if (!fileExt) return new MissingFileExtensionError()
 
   for (const allowedExtension of allowedExtensions) {
-    if (allowedExtension === fileExt) return true
+    if (allowedExtension === fileExt.toLowerCase()) return true
   }
 
   return new ForbiddenFileTypeError()

--- a/packages/frontend/src/main/lib/common/file-upload/fileUploadHelper.ts
+++ b/packages/frontend/src/main/lib/common/file-upload/fileUploadHelper.ts
@@ -111,7 +111,7 @@ export function validateFileType(
   if (!fileExt) return new MissingFileExtensionError()
 
   for (const allowedExtension of allowedExtensions) {
-    if (allowedExtension === fileExt) return true
+    if (allowedExtension === fileExt.toLowerCase()) return true
   }
 
   return new ForbiddenFileTypeError()

--- a/packages/server/modules/fileuploads/index.js
+++ b/packages/server/modules/fileuploads/index.js
@@ -38,7 +38,7 @@ exports.init = async (app) => {
     '/api/file/:fileType/:streamId/:branchName?',
     authMiddlewareCreator(streamWritePermissions),
     async (req, res) => {
-      const branchName = (req.params.branchName || 'main').toLowerCase()
+      const branchName = req.params.branchName || 'main'
       req.log = req.log.child({
         streamId: req.params.streamId,
         userId: req.context.userId,


### PR DESCRIPTION
## Description & motivation
[Notion Ticket
](https://www.notion.so/speckle/446c312165c144cfbea3140935d6d27c?v=b6f6140d25e14672a40f3a50644129a7&p=220e94045c064a528ed5e26b8a39ee11&pm=s)

Iain noticed that you could not upload files with an uppercase character in the file extension. This problem existed in FE1 and FE2.

## Changes:
- Add `toLowercase` to the uploaded file extension when comparing the uploaded file with the allowed extension list.
- The above was done to the relevant file in both FE1 and FE2 respectively. 
- Change to server, remove "toLowercase" so the casing of the upload file will be consistent throughout the UI. 

## Screenshots:
<img width="965" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/8041de33-8f04-46b1-85a4-468fc26ce79a">

## Checklist:
- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.
