### PR TITLE
fix(helm): resolves mismatched template names in "frontend_2" templates and network policies.

### DIFF
--- a/utils/helm/speckle-server/templates/frontend/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/frontend/networkpolicy.kubernetes.yml
@@ -1,5 +1,5 @@
 {{- if not .Values.frontend_2.enabled -}}
-{{- if (and (.Values.fileimport_service.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
+{{- if (and (.Values.frontend.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/utils/helm/speckle-server/templates/frontend_2/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/frontend_2/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "frontend-2.name" -}}
+{{- define "frontend_2.name" -}}
 {{- default "speckle-frontend-2" .Values.frontend_2.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "frontend-2.fullname" -}}
+{{- define "frontend_2.fullname" -}}
 {{- if .Values.frontend_2.fullnameOverride }}
 {{- .Values.frontend_2.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,27 +26,27 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Common labels
 */}}
-{{- define "frontend-2.labels" -}}
+{{- define "frontend_2.labels" -}}
 {{ include "speckle.commonLabels" . }}
-app.kubernetes.io/component: {{ include "frontend-2.name" . }}
-{{ include "frontend-2.selectorLabels" . }}
+app.kubernetes.io/component: {{ include "frontend_2.name" . }}
+{{ include "frontend_2.selectorLabels" . }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
-{{- define "frontend-2.selectorLabels" -}}
-app: {{ include "frontend-2.name" . }}
-app.kubernetes.io/name: {{ include "frontend-2.name" . }}
+{{- define "frontend_2.selectorLabels" -}}
+app: {{ include "frontend_2.name" . }}
+app.kubernetes.io/name: {{ include "frontend_2.name" . }}
 {{ include "speckle.commonSelectorLabels" . }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "frontend-2.serviceAccountName" -}}
+{{- define "frontend_2.serviceAccountName" -}}
 {{- if .Values.frontend_2.serviceAccount.create }}
-{{- default (include "frontend-2.fullname" .) .Values.frontend_2.serviceAccount.name }}
+{{- default (include "frontend_2.fullname" .) .Values.frontend_2.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.frontend_2.serviceAccount.name }}
 {{- end }}

--- a/utils/helm/speckle-server/templates/frontend_2/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend_2/deployment.yml
@@ -5,18 +5,18 @@ metadata:
   name: speckle-frontend-2
   namespace: {{ .Values.namespace }}
   labels:
-{{ include "frontend-2.labels" . | indent 4 }}
+{{ include "frontend_2.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.frontend_2.replicas }}
   selector:
     matchLabels:
-{{ include "frontend-2.selectorLabels" . | indent 6 }}
+{{ include "frontend_2.selectorLabels" . | indent 6 }}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-{{ include "frontend-2.labels" . | indent 8 }}
+{{ include "frontend_2.labels" . | indent 8 }}
     spec:
       containers:
       - name: main
@@ -83,6 +83,6 @@ spec:
       topologySpreadConstraints: {{- include "speckle.renderTpl" (dict "value" .Values.frontend_2.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.frontend_2.serviceAccount.create }}
-      serviceAccountName: {{ include "frontend-2.name" $ }}
+      serviceAccountName: {{ include "frontend_2.name" $ }}
       {{- end }}
 {{- end }}

--- a/utils/helm/speckle-server/templates/frontend_2/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/frontend_2/networkpolicy.kubernetes.yml
@@ -1,5 +1,5 @@
 {{- if .Values.frontend_2.enabled -}}
-{{- if (and (.Values.fileimport_service.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
+{{- if (and (.Values.frontend_2.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/utils/helm/speckle-server/templates/frontend_2/service.yml
+++ b/utils/helm/speckle-server/templates/frontend_2/service.yml
@@ -5,7 +5,7 @@ metadata:
   name: speckle-frontend-2
   namespace: {{ .Values.namespace }}
   labels:
-{{ include "frontend-2.labels" . | indent 4 }}
+{{ include "frontend_2.labels" . | indent 4 }}
 spec:
   selector:
     app: speckle-frontend-2

--- a/utils/helm/speckle-server/templates/frontend_2/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/frontend_2/serviceaccount.yml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "frontend-2.name" $ }}
+  name: {{ include "frontend_2.name" $ }}
   namespace: {{ .Values.namespace | quote }}
   labels:
-{{ include "frontend-2.labels" $ | indent 4 }}
+{{ include "frontend_2.labels" $ | indent 4 }}
   annotations:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false

--- a/utils/helm/speckle-server/templates/monitoring/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/monitoring/networkpolicy.kubernetes.yml
@@ -1,4 +1,4 @@
-{{- if (and (.Values.fileimport_service.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
+{{- if (and (.Values.monitoring.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/utils/helm/speckle-server/templates/preview_service/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/preview_service/networkpolicy.kubernetes.yml
@@ -1,4 +1,4 @@
-{{- if (and (.Values.fileimport_service.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
+{{- if (and (.Values.preview_service.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/server/networkpolicy.kubernetes.yml
@@ -1,4 +1,4 @@
-{{- if (and (.Values.fileimport_service.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
+{{- if (and (.Values.server.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/utils/helm/speckle-server/templates/tests/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/tests/networkpolicy.kubernetes.yml
@@ -1,4 +1,4 @@
-{{- if (and (.Values.fileimport_service.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
+{{- if (and (.Values.test.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/utils/helm/speckle-server/templates/webhook_service/networkpolicy.kubernetes.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/networkpolicy.kubernetes.yml
@@ -1,4 +1,4 @@
-{{- if (and (.Values.fileimport_service.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
+{{- if (and (.Values.webhook_service.networkPolicy.enabled) (eq .Values.networkPlugin.type "kubernetes")) -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
## Description & motivation

Running `helm upgrade` with kubernetes network policies and frontend_2 enabled causes the error below. This is happening because the names of the partials defined in `frontend_2/_helpers.tpl`  are declared in kebab case (`frontend-2.name`, `frontend-2.labels`, `frontend-2.selectorLabels`), while the names used in the networkpolicy.kubernetes.yml and networkpolicy.cilium.yml are in snake case (`frontend_2.name`, `frontend_2.labels`, `frontend_2.selectorLabels`), so the values defined in the helper aren't picked up by the downstream templates.

```
Error: UPGRADE FAILED: template: speckle-server/templates/frontend_2/networkpolicy.kubernetes.yml:6:11: executing "speckle-server/templates/frontend_2/networkpolicy.kubernetes.yml" at <include "frontend_2.name" $>: error calling include: template: no template "frontend_2.name" associated with template "gotpl"
```

It's also confusing that the values.yaml uses snake case for fe2 (`frontend_2`) but the namespaces in the subtemplates/partials in _helpers.tpl suddenly switch to kebab case (`frontend-2`). This may have contributed to the confusion that caused the first issue.

Also, a few kubernetes network policy templates are only implemented if the network policy for the fileimport_service is enabled. Each service's network policy should be implemented if it is enabled for its respective service in the values.yaml.  For example, the kubernetes network policy for frontend_2 is only implemented if `.Values.fileimport_service.networkPolicy.enabled` is true. This means that the network policy for frontend_2 can only be enabled by enabling the network policy for fileimport_service, meanwhile the networkPolicy toggle for frontend_2 doesn't actually implement anything.

I don't think this is the intended behavior. See diagram in [PR909].(https://github.com/specklesystems/speckle-server/pull/909)

## Changes:
 - Replaced references to `fileimport_service` in the kubernetes network policies of frontend, frontend_2, monitoring, preview_service, server, tests and webhook_service to reference the correct service/resource.
 - Changed namespace of all defined templates in `frontend_2` templates to use snake case (`frontend_2`) instead of kebab case (`frontend-2`) to match the values.yaml and the template names used in the existing network policies.

## Validation of changes:

The test job's network policy was also dependent on the networkPolicy for fileimport_service. This has been updated to `.Values.test.networkPolicy.enabled`.

It's not ideal, but you could add tests to `run_tests.py` that attempt to curl pods that should be unreachable from the test deployment if certain network policies are enabled. Happy to work on this or a better solution.

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [x ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

