### PR TITLE
Update text and fix checkbox name

### DIFF
--- a/packages/frontend-2/components/auth/RegisterWithEmailBlock.vue
+++ b/packages/frontend-2/components/auth/RegisterWithEmailBlock.vue
@@ -52,8 +52,8 @@
        -->
       <FormCheckbox
         v-model="newsletterConsent"
-        name="test"
-        label="I want to receive tips and tricks on how to use Speckle"
+        name="newsletter"
+        label="Opt in for exclusive Speckle news and tips"
       />
     </div>
     <div


### PR DESCRIPTION
[Notion Ticket
](https://www.notion.so/speckle/446c312165c144cfbea3140935d6d27c?v=b6f6140d25e14672a40f3a50644129a7&p=c5f2b26a44844a8eaf0aea3819d891e8&pm=s)

## Description & motivation
Matteo reported that signups were not coming through to Mailchimp. 

Checking network tab during registration showed:
<img width="337" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/ed741908-f29d-45b9-bfc6-b59460326ba0">

After changing "name" of the Checkbox from "test" to "newsletter":
<img width="334" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/fc168337-c14c-4722-b296-0c8c8814ce92">

## Changes:
Updated Checkbox name
Updated consent text to new text provided by Matteo. 


## Validation of changes:
This was hard to test locally. With such a small (and obvious) change, I was hoping we could merge and test it properly on live?

## Checklist:
- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [x] I have updated or added relevant documentation.
