### PR TITLE
Onboarding Speedup

### DIFF
--- a/packages/server/modules/core/graph/resolvers/projects.ts
+++ b/packages/server/modules/core/graph/resolvers/projects.ts
@@ -19,7 +19,7 @@ import {
   updateStreamAndNotify,
   updateStreamRoleAndNotify
 } from '@/modules/core/services/streams/management'
-import { ensureOnboardingStream } from '@/modules/core/services/streams/onboarding'
+import { createOnboardingStream } from '@/modules/core/services/streams/onboarding'
 import { removeStreamCollaborator } from '@/modules/core/services/streams/streamAccessService'
 import { cancelStreamInvite } from '@/modules/serverinvites/services/inviteProcessingService'
 import {
@@ -69,7 +69,7 @@ export = {
       return await deleteStreamAndNotify(id, userId!)
     },
     async createForOnboarding(_parent, _args, { userId }) {
-      return await ensureOnboardingStream(userId!)
+      return await createOnboardingStream(userId!)
     },
     async update(_parent, { update }, { userId }) {
       await authorizeResolver(userId, update.id, Roles.Stream.Owner)

--- a/packages/server/modules/core/repositories/streams.ts
+++ b/packages/server/modules/core/repositories/streams.ts
@@ -971,7 +971,10 @@ export async function markOnboardingBaseStream(streamId: string, version: string
   if (!stream) {
     throw new Error(`Stream ${streamId} not found`)
   }
-
+  await updateStream({
+    id: streamId,
+    name: 'Onboarding Stream Local Source - Do Not Delete'
+  })
   const meta = metaHelpers(Streams)
   await meta.set(streamId, Streams.meta.metaKey.onboardingBaseStream, version)
 }
@@ -988,33 +991,4 @@ export async function getOnboardingBaseStream(version: string) {
     .first()
 
   return await q
-}
-
-/**
- * Get user's own onboarding stream, if any
- */
-export async function getUserOnboardingStream(userId: string) {
-  const q = Users.meta
-    .knex()
-    .select<StreamRecord[]>(Streams.cols)
-    .innerJoin(
-      Streams.name,
-      Streams.col.id,
-      knex.raw(`?? #>> '{}'`, [Users.meta.col.value])
-    )
-    .where(Users.meta.col.userId, userId)
-    .andWhere(Users.meta.col.key, Users.meta.metaKey.onboardingStreamId)
-    .first()
-
-  return await q
-}
-
-export async function markUserOnboardingStream(userId: string, streamId: string) {
-  const stream = await getStream({ streamId })
-  if (!stream) {
-    throw new Error(`Stream ${streamId} not found`)
-  }
-
-  const meta = metaHelpers(Users)
-  await meta.set(userId, Users.meta.metaKey.onboardingStreamId, streamId)
 }

--- a/packages/server/modules/core/services/streams/clone.ts
+++ b/packages/server/modules/core/services/streams/clone.ts
@@ -129,6 +129,7 @@ async function cloneStreamObjects(state: CloneStreamInitialState, newStreamId: s
   }
 }
 
+// For sample onboarding stream, goes from 25s to ~250ms vs `cloneStreamObjects`
 async function cloneStreamObjectsGrug(
   state: CloneStreamInitialState,
   newStreamId: string

--- a/packages/server/modules/core/services/streams/onboarding.ts
+++ b/packages/server/modules/core/services/streams/onboarding.ts
@@ -5,14 +5,11 @@ import { StreamRecord } from '@/modules/core/helpers/types'
 import { logger } from '@/logging/logging'
 import { createStreamReturnRecord } from '@/modules/core/services/streams/management'
 import { getOnboardingBaseProject } from '@/modules/cross-server-sync/services/onboardingProject'
-import {
-  getUserOnboardingStream,
-  markUserOnboardingStream
-} from '@/modules/core/repositories/streams'
+import { updateStream } from '../../repositories/streams'
+import { getUser } from '../users'
 
 export async function createOnboardingStream(targetUserId: string) {
   const sourceStream = await getOnboardingBaseProject()
-
   // clone from base
   let newStream: Optional<StreamRecord> = undefined
   if (sourceStream) {
@@ -22,25 +19,18 @@ export async function createOnboardingStream(targetUserId: string) {
       if (!(e instanceof StreamCloneError)) {
         throw e
       } else {
-        logger.warn(e, 'Stream clone failed')
+        logger.warn(e, 'Onboarding stream clone failed')
       }
     }
   }
 
   // clone failed, just create empty stream
   if (!newStream) {
+    logger.warn('Fallback: Creating a blank stream for onboarding')
     newStream = await createStreamReturnRecord({ ownerId: targetUserId })
   }
-
-  // mark as onboarding stream
-  await markUserOnboardingStream(targetUserId, newStream.id)
-
+  const user = await getUser(targetUserId)
+  const name = user.name.split(' ')[0]
+  await updateStream({ id: newStream.id, name: `${name}'s First Project` })
   return newStream
-}
-
-export async function ensureOnboardingStream(targetUserId: string) {
-  return (
-    (await getUserOnboardingStream(targetUserId)) ||
-    (await createOnboardingStream(targetUserId))
-  )
 }

--- a/packages/server/modules/core/services/streams/onboarding.ts
+++ b/packages/server/modules/core/services/streams/onboarding.ts
@@ -14,7 +14,9 @@ export async function createOnboardingStream(targetUserId: string) {
   let newStream: Optional<StreamRecord> = undefined
   if (sourceStream) {
     try {
+      logger.info('Cloning onboarding stream')
       newStream = await cloneStream(targetUserId, sourceStream.id)
+      logger.info('Done cloning onboarding stream')
     } catch (e) {
       if (!(e instanceof StreamCloneError)) {
         throw e
@@ -29,8 +31,11 @@ export async function createOnboardingStream(targetUserId: string) {
     logger.warn('Fallback: Creating a blank stream for onboarding')
     newStream = await createStreamReturnRecord({ ownerId: targetUserId })
   }
+
+  logger.info('Updating onboarding stream title')
   const user = await getUser(targetUserId)
   const name = user.name.split(' ')[0]
   await updateStream({ id: newStream.id, name: `${name}'s First Project` })
+  logger.info('Done updating onboarding stream title')
   return newStream
 }

--- a/packages/server/modules/cross-server-sync/services/onboardingProject.ts
+++ b/packages/server/modules/cross-server-sync/services/onboardingProject.ts
@@ -43,7 +43,7 @@ export async function ensureOnboardingProject() {
     getFirstAdmin()
   ])
   if (existingStream) {
-    logger.debug('Onboarding stream already exists, skipping...')
+    logger.info('Onboarding stream already exists, skipping...')
     return existingStream
   }
   if (!admin) {
@@ -51,7 +51,7 @@ export async function ensureOnboardingProject() {
     return undefined
   }
 
-  logger.debug('Onboarding stream not found, pulling from target server...')
+  logger.info('Onboarding stream not found, pulling from target server...')
   const res = await downloadProject(
     {
       projectUrl: metadata.url,
@@ -61,7 +61,7 @@ export async function ensureOnboardingProject() {
     { logger }
   )
 
-  logger.debug('Marking stream as onboarding base...')
+  logger.info('Marking stream as onboarding base...')
   await markOnboardingBaseStream(res.projectId, metadata.version)
 
   logger.info('Onboarding base stream created successfully!')


### PR DESCRIPTION
- ensures an onboarding stream is always created, regardless of whether a user went through the process before 
- keeps original dates for commits/versions, ensuring we always load the correct version during onboarding
- optimises stream cloning (obj duplication: from **25s to 270ms**)