### PR TITLE
Change expiration of hasDismissedChecklistForever to 2 years

### DIFF
--- a/packages/frontend-2/components/projects/Dashboard.vue
+++ b/packages/frontend-2/components/projects/Dashboard.vue
@@ -259,6 +259,9 @@ watch(search, (newVal) => {
 
 watch(areQueriesLoading, (newVal) => (showLoadingBar.value = newVal))
 
+const twoYearsFromNow = new Date()
+twoYearsFromNow.setFullYear(twoYearsFromNow.getFullYear() + 2)
+
 const hasCompletedChecklistV1 = useSynchronizedCookie<boolean>(
   `hasCompletedChecklistV1`,
   { default: () => false }
@@ -271,7 +274,10 @@ const hasDismissedChecklistTime = useSynchronizedCookie<string | undefined>(
 
 const hasDismissedChecklistForever = useSynchronizedCookie<boolean | undefined>(
   `hasDismissedChecklistForever`,
-  { default: () => false }
+  {
+    default: () => false,
+    expires: twoYearsFromNow
+  }
 )
 
 const hasDismissedChecklistTimeAgo = computed(() => {


### PR DESCRIPTION
## Description & motivation

[NOTION TICKET](https://www.notion.so/speckle/446c312165c144cfbea3140935d6d27c?v=b6f6140d25e14672a40f3a50644129a7&p=a4e557c6e8634945b579ec1a226ba48b&pm=s)

The "Start Checklist" is displayed when the `hasDismissedChecklistForever` cookie is false. Currently clicking "Don't show again" sets this to true, but the expiration is set to session, so it reappears every new session. 

I have changed this so it now persists for 2 years from when you click the "Don't show again" button. 


## Screenshots:
<img width="428" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/1ad67314-7e92-4240-b83e-f5112cbe8fd3">
<img width="550" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/7dc15a23-2b61-435b-a040-3dc685d236f8">

## Checklist:
- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.
