### PR TITLE
Add mount-menu-on-body to Events select

### DIFF
--- a/packages/frontend-2/components/project/webhooks-page/CreateOrEditDialog.vue
+++ b/packages/frontend-2/components/project/webhooks-page/CreateOrEditDialog.vue
@@ -43,6 +43,7 @@
           name="triggers"
           label="Events"
           placeholder="Choose Events"
+          mount-menu-on-body
           help="Choose what events will trigger this webhook."
           show-required
           :rules="[isItemSelected]"


### PR DESCRIPTION
## Description & motivation
"Choose Events" select in "Add new Webhook" does not overflow the dialog as it should.

Old:
<img width="682" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/0ec8854a-4886-4170-86f7-fc74ae16f9a8">

New:
<img width="771" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/23dc13ce-7939-4e62-a50b-f1e74a841293">

## Checklist:
- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

