### PR TITLE
Bugfix - Segmentation Reappears after Completion - Add showSegmentation state

### DIFF
--- a/packages/frontend-2/components/onboarding/checklist/v1.vue
+++ b/packages/frontend-2/components/onboarding/checklist/v1.vue
@@ -4,7 +4,7 @@
     <div
       :class="`${
         background ? 'mx-2 sm:mx-auto px-2 bg-foundation rounded-md shadow-xl' : ''
-      } ${allCompleted ? 'max-w-lg' : ''}`"
+      } ${allCompleted ? 'max-w-lg mx-auto' : ''}`"
     >
       <div
         v-if="!allCompleted"

--- a/packages/frontend-2/components/tour/Onboarding.vue
+++ b/packages/frontend-2/components/tour/Onboarding.vue
@@ -2,7 +2,10 @@
   <div
     class="relative max-w-4xl w-screen h-screen flex items-center justify-center z-50"
   >
-    <TourSegmentation v-if="step === 0" @next="step++" />
+    <TourSegmentation
+      v-if="tourState.showSegmentation && step === 0"
+      @next="step++, (tourState.showSegmentation = false)"
+    />
     <TourSlideshow v-if="step === 1" @next="step++" />
     <!-- <OnboardingDialogManager v-if="step === 2" allow-escape @cancel="step++" /> -->
     <div
@@ -27,6 +30,8 @@ const hasCompletedChecklistV1 = useSynchronizedCookie<boolean>(
   `hasCompletedChecklistV1`,
   { default: () => false }
 )
+
+const tourState = useTourStageState()
 
 const mp = useMixpanel()
 watch(step, (val) => {

--- a/packages/frontend-2/components/tour/Onboarding.vue
+++ b/packages/frontend-2/components/tour/Onboarding.vue
@@ -2,10 +2,7 @@
   <div
     class="relative max-w-4xl w-screen h-screen flex items-center justify-center z-50"
   >
-    <TourSegmentation
-      v-if="tourState.showSegmentation && step === 0"
-      @next="step++, (tourState.showSegmentation = false)"
-    />
+    <TourSegmentation v-if="tourState.showSegmentation && step === 0" @next="step++" />
     <TourSlideshow v-if="step === 1" @next="step++" />
     <!-- <OnboardingDialogManager v-if="step === 2" allow-escape @cancel="step++" /> -->
     <div

--- a/packages/frontend-2/components/tour/Segmentation.vue
+++ b/packages/frontend-2/components/tour/Segmentation.vue
@@ -84,6 +84,7 @@ const {
 const onboardingState = ref<OnboardingState>({ industry: undefined, role: undefined })
 
 const { activeUser } = useActiveUser()
+const tourState = useTourStageState()
 
 const emit = defineEmits(['next'])
 
@@ -101,6 +102,7 @@ function setRole(val: OnboardingRole) {
   nextView()
   // NOTE: workaround for being able to view this in storybook
   if (activeUser.value?.id) setMixpanelSegments(onboardingState.value)
+  tourState.value.showSegmentation = false
   emit('next')
 }
 

--- a/packages/frontend-2/composables/states.ts
+++ b/packages/frontend-2/composables/states.ts
@@ -5,5 +5,6 @@ export const useTourStageState = () =>
   useState('global-ui-element-state', () => ({
     showNavbar: true,
     showViewerControls: true,
-    showTour: false
+    showTour: false,
+    showSegmentation: true
   }))


### PR DESCRIPTION
## Description & motivation
There was an issue with the onboarding flow where the Tour would keep showing, after the user had already completed it. A refresh fixed this problem, but is very annoying for new users. 

If the user has completed the segmentation and tour, but not the checklist, the whole tour will continue to show when the user opens a model, until they refresh.

## Changes:
I added a new state called showSegmentation. This is default true, but is set to false when the user finishes the final step of segmentation.

## To-do before merge:
Confirm that the user selections in Segmentation is captured by mixpanel. I don't see any graphql calls storing this. 

## Checklist:
- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.