### PR TITLE
Fix desktop view of onboarding banner

### DIFF
--- a/packages/frontend-2/components/onboarding/checklist/v1.vue
+++ b/packages/frontend-2/components/onboarding/checklist/v1.vue
@@ -154,7 +154,7 @@
       </div>
       <div
         v-else
-        class="flex flex-col items-center justify-center flex-1 space-x-2 py-4"
+        class="flex flex-col sm:flex-row items-center justify-center flex-1 space-x-2 py-4"
       >
         <div class="w-6 h-6">
           <!-- <CheckCircleIcon class="absolute w-6 h-6 text-primary" /> -->
@@ -168,7 +168,7 @@
           </FormButton>
           is there to help!
         </div>
-        <div class="mt-2">
+        <div class="mt-2 sm:mt-0">
           <FormButton text size="sm" @click="closeChecklist()">Close</FormButton>
         </div>
       </div>


### PR DESCRIPTION
## Description & motivation
![image](https://github.com/specklesystems/speckle-server/assets/139135120/315cf7d8-a8b0-4e91-9849-a626ce9c0a98)

Responsive class for onboarding banner was dropped. Re-add. 


## Checklist:
- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.