### PR TITLE
Dim/fe onboarding fix

### DIFF
--- a/packages/frontend-2/components/auth/RegisterWithEmailBlock.vue
+++ b/packages/frontend-2/components/auth/RegisterWithEmailBlock.vue
@@ -7,7 +7,7 @@
         name="name"
         label="Full Name"
         placeholder="My Name"
-        :size="isSmallerOrEqualSM ? 'lg' : 'xl'"
+        :size="isSmallerOrEqualSm ? 'lg' : 'xl'"
         :rules="nameRules"
         :custom-icon="UserIcon"
         show-label
@@ -19,7 +19,7 @@
         name="email"
         label="Email"
         placeholder="example@email.com"
-        :size="isSmallerOrEqualSM ? 'lg' : 'xl'"
+        :size="isSmallerOrEqualSm ? 'lg' : 'xl'"
         :rules="emailRules"
         show-label
         :disabled="loading"
@@ -30,7 +30,7 @@
         name="password"
         label="Password"
         placeholder="Type a strong password"
-        :size="isSmallerOrEqualSM ? 'lg' : 'xl'"
+        :size="isSmallerOrEqualSm ? 'lg' : 'xl'"
         :rules="passwordRules"
         show-label
         :disabled="loading"
@@ -82,8 +82,6 @@ import { passwordRules } from '~~/lib/auth/helpers/validation'
 import { graphql } from '~~/lib/common/generated/gql'
 import { ServerTermsOfServicePrivacyPolicyFragmentFragment } from '~~/lib/common/generated/gql/graphql'
 import { UserIcon, ArrowRightIcon } from '@heroicons/vue/20/solid'
-import { useBreakpoints } from '@vueuse/core'
-import { TailwindBreakpoints } from '~~/lib/common/helpers/tailwind'
 
 /**
  * TODO:
@@ -106,7 +104,6 @@ const props = defineProps<{
 
 const { handleSubmit } = useForm<FormValues>()
 const router = useRouter()
-const breakpoints = useBreakpoints(TailwindBreakpoints)
 
 const loading = ref(false)
 const password = ref('')
@@ -121,7 +118,7 @@ const newsletterConsent = inject<Ref<boolean>>('newsletterconsent')
 
 const pwdFocused = ref(false)
 
-const isSmallerOrEqualSM = computed(() => breakpoints.smallerOrEqual('sm').value)
+const { isSmallerOrEqualSm } = useIsSmallerOrEqualThanBreakpoint()
 
 const finalLoginRoute = computed(() => {
   const result = router.resolve({

--- a/packages/frontend-2/components/onboarding/checklist/v1.vue
+++ b/packages/frontend-2/components/onboarding/checklist/v1.vue
@@ -4,7 +4,7 @@
     <div
       :class="`${
         background ? 'mx-2 sm:mx-auto px-2 bg-foundation rounded-md shadow-xl' : ''
-      } ${allCompleted ? 'max-w-lg' : ''}`"
+      } ${allCompleted ? 'max-w-lg mx-auto' : ''}`"
     >
       <div
         v-if="!allCompleted"

--- a/packages/frontend-2/components/tour/Onboarding.vue
+++ b/packages/frontend-2/components/tour/Onboarding.vue
@@ -10,10 +10,18 @@
       class="relative w-full pointer-events-auto space-y-2 z-50"
     >
       <div
+        v-if="!isSmallerOrEqualSM"
         class="pointer-events-none fixed inset-0 bg-neutral-100/70 dark:bg-neutral-900/70 transition-opacity z-50"
       />
-      <div class="relative z-50">
+      <div v-if="!isSmallerOrEqualSM" class="relative z-50">
         <OnboardingChecklistV1 show-bottom-escape background @dismiss="step++" />
+      </div>
+      <div v-else class="fixed bottom-10 left-0 w-screen z-50 p-10">
+        <div class="bg-foundation p-2 rounded-md text-sm">
+          There's more to Speckle - be sure to visit on a computer. Since you're on a
+          mobile device, feel free to keep exploring the web app!
+          <FormButton class="w-full mt-4" @click="step++">Let's go!</FormButton>
+        </div>
       </div>
     </div>
   </div>
@@ -21,6 +29,11 @@
 <script setup lang="ts">
 import { useSynchronizedCookie } from '~~/lib/common/composables/reactiveCookie'
 import { useMixpanel } from '~~/lib/core/composables/mp'
+import { useBreakpoints } from '@vueuse/core'
+import { TailwindBreakpoints } from '~~/lib/common/helpers/tailwind'
+
+const breakpoints = useBreakpoints(TailwindBreakpoints)
+const isSmallerOrEqualSM = computed(() => breakpoints.smallerOrEqual('sm').value)
 
 const step = ref(0)
 const hasCompletedChecklistV1 = useSynchronizedCookie<boolean>(

--- a/packages/frontend-2/components/tour/Onboarding.vue
+++ b/packages/frontend-2/components/tour/Onboarding.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="relative max-w-4xl w-screen h-screen flex items-center justify-center z-50"
+    class="relative max-w-4xl w-screen h-[100dvh] flex items-center justify-center z-50"
   >
     <TourSegmentation v-if="tourState.showSegmentation && step === 0" @next="step++" />
     <TourSlideshow v-if="step === 1" @next="step++" />

--- a/packages/frontend-2/components/tour/Onboarding.vue
+++ b/packages/frontend-2/components/tour/Onboarding.vue
@@ -10,10 +10,10 @@
       class="relative w-full pointer-events-auto space-y-2 z-50"
     >
       <div
-        v-if="!isSmallerOrEqualSM"
+        v-if="!isSmallerOrEqualSm"
         class="pointer-events-none fixed inset-0 bg-neutral-100/70 dark:bg-neutral-900/70 transition-opacity z-50"
       />
-      <div v-if="!isSmallerOrEqualSM" class="relative z-50">
+      <div v-if="!isSmallerOrEqualSm" class="relative z-50">
         <OnboardingChecklistV1 show-bottom-escape background @dismiss="step++" />
       </div>
       <div v-else class="fixed bottom-10 left-0 w-screen z-50 p-10">
@@ -29,11 +29,8 @@
 <script setup lang="ts">
 import { useSynchronizedCookie } from '~~/lib/common/composables/reactiveCookie'
 import { useMixpanel } from '~~/lib/core/composables/mp'
-import { useBreakpoints } from '@vueuse/core'
-import { TailwindBreakpoints } from '~~/lib/common/helpers/tailwind'
 
-const breakpoints = useBreakpoints(TailwindBreakpoints)
-const isSmallerOrEqualSM = computed(() => breakpoints.smallerOrEqual('sm').value)
+const { isSmallerOrEqualSm } = useIsSmallerOrEqualThanBreakpoint()
 
 const step = ref(0)
 const hasCompletedChecklistV1 = useSynchronizedCookie<boolean>(

--- a/packages/frontend-2/components/tour/Onboarding.vue
+++ b/packages/frontend-2/components/tour/Onboarding.vue
@@ -2,7 +2,10 @@
   <div
     class="relative max-w-4xl w-screen h-screen flex items-center justify-center z-50"
   >
-    <TourSegmentation v-if="step === 0" @next="step++" />
+    <TourSegmentation
+      v-if="tourState.showSegmentation && step === 0"
+      @next="step++, (tourState.showSegmentation = false)"
+    />
     <TourSlideshow v-if="step === 1" @next="step++" />
     <!-- <OnboardingDialogManager v-if="step === 2" allow-escape @cancel="step++" /> -->
     <div
@@ -27,6 +30,8 @@ const hasCompletedChecklistV1 = useSynchronizedCookie<boolean>(
   `hasCompletedChecklistV1`,
   { default: () => false }
 )
+
+const tourState = useTourStageState()
 
 const mp = useMixpanel()
 watch(step, (val) => {

--- a/packages/frontend-2/components/tour/Onboarding.vue
+++ b/packages/frontend-2/components/tour/Onboarding.vue
@@ -2,10 +2,7 @@
   <div
     class="relative max-w-4xl w-screen h-screen flex items-center justify-center z-50"
   >
-    <TourSegmentation
-      v-if="tourState.showSegmentation && step === 0"
-      @next="step++, (tourState.showSegmentation = false)"
-    />
+    <TourSegmentation v-if="tourState.showSegmentation && step === 0" @next="step++" />
     <TourSlideshow v-if="step === 1" @next="step++" />
     <!-- <OnboardingDialogManager v-if="step === 2" allow-escape @cancel="step++" /> -->
     <div

--- a/packages/frontend-2/components/tour/Segmentation.vue
+++ b/packages/frontend-2/components/tour/Segmentation.vue
@@ -84,6 +84,7 @@ const {
 const onboardingState = ref<OnboardingState>({ industry: undefined, role: undefined })
 
 const { activeUser } = useActiveUser()
+const tourState = useTourStageState()
 
 const emit = defineEmits(['next'])
 
@@ -101,6 +102,7 @@ function setRole(val: OnboardingRole) {
   nextView()
   // NOTE: workaround for being able to view this in storybook
   if (activeUser.value?.id) setMixpanelSegments(onboardingState.value)
+  tourState.value.showSegmentation = false
   emit('next')
 }
 

--- a/packages/frontend-2/components/tour/Slideshow.vue
+++ b/packages/frontend-2/components/tour/Slideshow.vue
@@ -12,8 +12,8 @@
       :item="item"
       :index="index"
       class="absolute"
-      :class="isSmallerOrEqualSM ? 'bottom-0 left-0 w-screen' : ''"
-      :style="isSmallerOrEqualSM ? undefined : item.style"
+      :class="isSmallerOrEqualSm ? 'bottom-0 left-0 w-screen' : ''"
+      :style="isSmallerOrEqualSm ? undefined : item.style"
       :show-controls="item.showControls"
       @skip="finishSlideshow()"
     >
@@ -60,8 +60,6 @@ import BasicViewerNavigation from '~~/components/tour/content/BasicViewerNavigat
 import OverlayModel from '~~/components/tour/content/OverlayModel.vue'
 import { useCameraUtilities } from '~~/lib/viewer/composables/ui'
 import { useMixpanel } from '~~/lib/core/composables/mp'
-import { useBreakpoints } from '@vueuse/core'
-import { TailwindBreakpoints } from '~~/lib/common/helpers/tailwind'
 
 const emit = defineEmits(['next'])
 
@@ -79,9 +77,9 @@ provide('slideshowItems', slideshowItems)
 
 const lastOpenIndex = ref(0)
 const mp = useMixpanel()
-const breakpoints = useBreakpoints(TailwindBreakpoints)
 
-const isSmallerOrEqualSM = computed(() => breakpoints.smallerOrEqual('sm').value)
+// const isSmallerOrEqualSm = computed(() => breakpoints.smallerOrEqual('sm').value)
+const { isSmallerOrEqualSm } = useIsSmallerOrEqualThanBreakpoint()
 
 const next = (currentIndex: number) => {
   if (currentIndex + 1 >= slideshowItems.value.length) {

--- a/packages/frontend-2/components/tour/Slideshow.vue
+++ b/packages/frontend-2/components/tour/Slideshow.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="parentEl"
-    class="fixed z-30 left-0 top-0 w-screen h-screen pointer-events-none overflow-hidden"
+    class="fixed z-30 left-0 top-0 w-screen h-[100dvh] pointer-events-none overflow-hidden"
   >
     <!--     
       Tour Slideshow 

--- a/packages/frontend-2/components/viewer/Controls.vue
+++ b/packages/frontend-2/components/viewer/Controls.vue
@@ -175,15 +175,11 @@ import {
   useCameraUtilities,
   useSectionBoxUtilities
 } from '~~/lib/viewer/composables/ui'
-import { useBreakpoints } from '@vueuse/core'
-import { TailwindBreakpoints } from '~~/lib/common/helpers/tailwind'
-
 import {
   onKeyboardShortcut,
   ModifierKeys,
   getKeyboardShortcutTitle
 } from '@speckle/ui-components'
-
 import {
   useInjectedViewerLoadedResources,
   useInjectedViewerInterfaceState
@@ -201,8 +197,6 @@ import { AutomationRunStatus, AutomationRun } from '~~/lib/common/generated/gql/
 const { resourceItems, modelsAndVersionIds } = useInjectedViewerLoadedResources()
 
 const { toggleSectionBox, isSectionBoxEnabled } = useSectionBoxUtilities()
-
-const breakpoints = useBreakpoints(TailwindBreakpoints)
 
 const allAutomationRuns = computed(() => {
   const allAutomationStatuses = modelsAndVersionIds.value
@@ -302,7 +296,7 @@ const sectionBoxShortcut = ref(
   `Section Box (${getKeyboardShortcutTitle([ModifierKeys.AltOrOpt, 'b'])})`
 )
 
-const isSmallerOrEqualSM = computed(() => breakpoints.smallerOrEqual('sm').value)
+const { isSmallerOrEqualSm } = useIsSmallerOrEqualThanBreakpoint()
 
 const toggleActiveControl = (control: ActiveControl) =>
   activeControl.value === control
@@ -367,10 +361,10 @@ const scrollControlsToBottom = () => {
 }
 
 onMounted(() => {
-  activeControl.value = isSmallerOrEqualSM.value ? 'none' : 'models'
+  activeControl.value = isSmallerOrEqualSm.value ? 'none' : 'models'
 })
 
-watch(isSmallerOrEqualSM, (newVal) => {
+watch(isSmallerOrEqualSm, (newVal) => {
   activeControl.value = newVal ? 'none' : 'models'
 })
 </script>

--- a/packages/frontend-2/composables/browser.ts
+++ b/packages/frontend-2/composables/browser.ts
@@ -1,7 +1,8 @@
 import { ensureError } from '@speckle/shared'
 import { useClipboard as coreUseClipboard } from '@vueuse/core'
 import { ToastNotificationType, useGlobalToast } from '~~/lib/common/composables/toast'
-
+import { useBreakpoints } from '@vueuse/core'
+import { TailwindBreakpoints } from '~~/lib/common/helpers/tailwind'
 /**
  * A wrapper over vueuse's useClipboard that also triggers toast notifications
  */
@@ -36,5 +37,16 @@ export const useClipboard = () => {
         })
       }
     }
+  }
+}
+
+export const useIsSmallerOrEqualThanBreakpoint = () => {
+  const breakpoints = useBreakpoints(TailwindBreakpoints)
+  return {
+    isSmallerOrEqualSm: computed(() => breakpoints.smallerOrEqual('sm').value),
+    isSmallerOrEqualMd: computed(() => breakpoints.smallerOrEqual('md').value),
+    isSmallerOrEqualLg: computed(() => breakpoints.smallerOrEqual('lg').value),
+    isSmallerOrEqualXl: computed(() => breakpoints.smallerOrEqual('xl').value),
+    isSmallerOrEqual2xl: computed(() => breakpoints.smallerOrEqual('2xl').value)
   }
 }

--- a/packages/frontend-2/composables/states.ts
+++ b/packages/frontend-2/composables/states.ts
@@ -5,5 +5,6 @@ export const useTourStageState = () =>
   useState('global-ui-element-state', () => ({
     showNavbar: true,
     showViewerControls: true,
-    showTour: false
+    showTour: false,
+    showSegmentation: true
   }))

--- a/packages/frontend-2/layouts/onboarding.vue
+++ b/packages/frontend-2/layouts/onboarding.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-screen h-screen overflow-hidden">
+  <div class="w-screen h-[100dvh] overflow-hidden">
     <ClientOnly>
       <slot />
     </ClientOnly>

--- a/packages/frontend-2/layouts/viewer.vue
+++ b/packages/frontend-2/layouts/viewer.vue
@@ -34,7 +34,7 @@
     >
       <HeaderNavBar v-show="tourState.showNavbar" class="relative z-20 mb-6" />
     </Transition>
-    <main class="absolute top-0 left-0 z-10 h-screen w-screen">
+    <main class="absolute top-0 left-0 z-10 h-[100dvh] w-screen">
       <slot />
     </main>
   </div>

--- a/packages/frontend-2/pages/projects/[id]/models/[modelId]/index.vue
+++ b/packages/frontend-2/pages/projects/[id]/models/[modelId]/index.vue
@@ -63,6 +63,7 @@
     </div>
   </ViewerPostSetupWrapper>
   <div
+    v-if="tourState.showViewerControls"
     class="sm:hidden shadow-t fixed bottom-0 left-0 max-h-[65vh] w-screen z-50 transition-all duration-300 empty:-bottom-[65vh]"
   >
     <PortalTarget name="bottomPanel"></PortalTarget>

--- a/packages/frontend-2/pages/projects/[id]/models/[modelId]/index.vue
+++ b/packages/frontend-2/pages/projects/[id]/models/[modelId]/index.vue
@@ -1,6 +1,6 @@
 <template>
   <ViewerPostSetupWrapper>
-    <div class="absolute top-0 left-0 w-screen h-screen">
+    <div class="absolute top-0 left-0 w-screen h-[100dvh]">
       <!-- Nav -->
       <Portal to="navigation">
         <ViewerScope :state="state">
@@ -23,12 +23,12 @@
         <!-- Tour host -->
         <div
           v-if="tourState.showTour"
-          class="fixed w-full h-full flex justify-center items-center pointer-events-none z-[100]"
+          class="fixed w-full h-[100dvh] flex justify-center items-center pointer-events-none z-[100]"
         >
           <TourOnboarding />
         </div>
         <!-- Viewer host -->
-        <div class="special-gradient absolute w-screen h-screen z-10 overflow-hidden">
+        <div class="special-gradient absolute w-screen h-[100dvh] z-10 overflow-hidden">
           <ViewerBase />
           <Transition
             enter-from-class="opacity-0"


### PR DESCRIPTION
- fixes mobile onboarding comments being not fully visible (swapped to `dvh` units - finally!) (cc @andrewwallacespeckle) 

![image](https://github.com/specklesystems/speckle-server/assets/7696515/b9a522cc-bcd9-461d-a074-3dc70a951880)

- no longer shows selection info if user would select an object during onboarding (cc @andrewwallacespeckle) 
- changes last mobile onboarding step from the full checklist, to just a go explore prompt 
- some DRY changes re `isSmallerOrEqualSm` breakpoint, which i copy pasted around post andrew's first go at it
