### PR TITLE
Double limit of branches to ensure all are visible

### DIFF
--- a/packages/frontend/src/graphql/branch.js
+++ b/packages/frontend/src/graphql/branch.js
@@ -10,7 +10,7 @@ export const streamNavBranchesQuery = gql`
   query StreamAllBranches($streamId: String!, $cursor: String) {
     stream(id: $streamId) {
       id
-      branches(limit: 100, cursor: $cursor) {
+      branches(limit: 200, cursor: $cursor) {
         totalCount
         cursor
         items {


### PR DESCRIPTION
Based on request from client:

When we create more branches the counter showing the total number of branches goes up, but they don’t show up in the interface under nycx, or appear in the list below. We currently have 102 branches and 356 commits in the stream. But only 99 show up.

Very simple update, changing the limit from 100 to 200. 