### PR TITLE
feat(fe2): alt apiOrigin for SSR

### DIFF
--- a/packages/frontend-2/components/auth/third-party/LoginBlock.vue
+++ b/packages/frontend-2/components/auth/third-party/LoginBlock.vue
@@ -44,9 +44,7 @@ const props = defineProps<{
   appId: string
 }>()
 
-const {
-  public: { apiOrigin }
-} = useRuntimeConfig()
+const apiOrigin = useApiOrigin()
 const mixpanel = useMixpanel()
 const { inviteToken } = useAuthManager()
 

--- a/packages/frontend-2/composables/env.ts
+++ b/packages/frontend-2/composables/env.ts
@@ -1,0 +1,11 @@
+export const useApiOrigin = () => {
+  const {
+    public: { apiOrigin, backendApiOrigin }
+  } = useRuntimeConfig()
+
+  if (process.server && backendApiOrigin.length > 1) {
+    return backendApiOrigin
+  }
+
+  return apiOrigin
+}

--- a/packages/frontend-2/lib/auth/composables/auth.ts
+++ b/packages/frontend-2/lib/auth/composables/auth.ts
@@ -52,10 +52,7 @@ export const useAuthCookie = () =>
   })
 
 export const useAuthManager = () => {
-  const {
-    public: { apiOrigin }
-  } = useRuntimeConfig()
-
+  const apiOrigin = useApiOrigin()
   const resetAuthState = useResetAuthState()
   const route = useRoute()
   const goHome = useNavigateToHome()

--- a/packages/frontend-2/lib/auth/composables/passwordReset.ts
+++ b/packages/frontend-2/lib/auth/composables/passwordReset.ts
@@ -7,9 +7,7 @@ import {
 import { ToastNotificationType, useGlobalToast } from '~~/lib/common/composables/toast'
 
 export function usePasswordReset() {
-  const {
-    public: { apiOrigin }
-  } = useRuntimeConfig()
+  const apiOrigin = useApiOrigin()
   const { triggerNotification } = useGlobalToast()
   const { logout } = useAuthManager()
 

--- a/packages/frontend-2/lib/core/composables/fileImport.ts
+++ b/packages/frontend-2/lib/core/composables/fileImport.ts
@@ -15,9 +15,7 @@ export function useFileImport(params: {
 
   const { maxSizeInBytes } = useServerFileUploadLimit()
   const authToken = useAuthCookie()
-  const {
-    public: { apiOrigin }
-  } = useRuntimeConfig()
+  const apiOrigin = useApiOrigin()
 
   const accept = ref('.ifc,.stl,.obj')
   const upload = ref(null as Nullable<UploadFileItem>)

--- a/packages/frontend-2/lib/core/composables/fileUpload.ts
+++ b/packages/frontend-2/lib/core/composables/fileUpload.ts
@@ -14,9 +14,7 @@ import { differenceBy, isUndefined } from 'lodash-es'
 
 export function useFileUpload() {
   const token = useAuthCookie()
-  const {
-    public: { apiOrigin }
-  } = useRuntimeConfig()
+  const apiOrigin = useApiOrigin()
 
   return {
     deleteFile: (blobId: string, principal: BlobUploadPrincipal) =>
@@ -38,9 +36,7 @@ export function useFileUpload() {
 
 export function useFileDownload() {
   const token = useAuthCookie()
-  const {
-    public: { apiOrigin }
-  } = useRuntimeConfig()
+  const apiOrigin = useApiOrigin()
 
   return {
     download: (params: { blobId: string; fileName: string; projectId: string }) =>

--- a/packages/frontend-2/lib/core/configs/apollo.ts
+++ b/packages/frontend-2/lib/core/configs/apollo.ts
@@ -376,8 +376,9 @@ function createLink(params: {
 
 const defaultConfigResolver: ApolloConfigResolver = async () => {
   const {
-    public: { apiOrigin, speckleServerVersion = 'unknown' }
+    public: { speckleServerVersion = 'unknown' }
   } = useRuntimeConfig()
+  const apiOrigin = useApiOrigin()
   const nuxtApp = useNuxtApp()
 
   const httpEndpoint = `${apiOrigin}/graphql`

--- a/packages/frontend-2/lib/viewer/composables/viewer.ts
+++ b/packages/frontend-2/lib/viewer/composables/viewer.ts
@@ -288,9 +288,9 @@ export function useSelectionEvents(
 }
 
 export function useGetObjectUrl() {
-  const config = useRuntimeConfig()
+  const apiOrigin = useApiOrigin()
   return (projectId: string, objectId: string) =>
-    `${config.public.apiOrigin}/streams/${projectId}/objects/${objectId}`
+    `${apiOrigin}/streams/${projectId}/objects/${objectId}`
 }
 
 export function useOnViewerLoadComplete(

--- a/packages/frontend-2/nuxt.config.ts
+++ b/packages/frontend-2/nuxt.config.ts
@@ -35,6 +35,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       apiOrigin: 'UNDEFINED',
+      backendApiOrigin: '',
       mixpanelApiHost: 'UNDEFINED',
       mixpanelTokenId: 'UNDEFINED',
       logLevel: 'info',

--- a/packages/frontend-2/pages/authn/verify/[appId]/[challenge]/index.vue
+++ b/packages/frontend-2/pages/authn/verify/[appId]/[challenge]/index.vue
@@ -107,9 +107,7 @@ definePageMeta({
   name: 'authorize-app'
 })
 
-const {
-  public: { apiOrigin }
-} = useRuntimeConfig()
+const apiOrigin = useApiOrigin()
 const route = useRoute()
 const { activeUser } = useActiveUser()
 const authToken = useAuthCookie()

--- a/packages/frontend-2/pages/developer-settings.vue
+++ b/packages/frontend-2/pages/developer-settings.vue
@@ -229,9 +229,7 @@ import {
 } from '~~/lib/developer-settings/graphql/queries'
 import { useQuery } from '@vue/apollo-composable'
 
-const {
-  public: { apiOrigin }
-} = useRuntimeConfig()
+const apiOrigin = useApiOrigin()
 
 const { result: tokensResult, refetch: refetchTokens } = useQuery(
   developerSettingsAccessTokensQuery

--- a/packages/frontend-2/server/routes/graphql.ts
+++ b/packages/frontend-2/server/routes/graphql.ts
@@ -12,9 +12,7 @@ function getConfigStringForHtml(config: Record<string, unknown>) {
 }
 
 export default defineEventHandler(() => {
-  const {
-    public: { apiOrigin }
-  } = useRuntimeConfig()
+  const apiOrigin = useApiOrigin()
 
   const version = '_latest'
   const embeddedExplorerParams = {


### PR DESCRIPTION
@iainsproat You can define a `NUXT_PUBLIC_BACKEND_API_ORIGIN` env var with this (optionally), to make the serverside use a different value from the clientside