### PR TITLE
FE2 - Title Bar Improvements

### DIFF
--- a/packages/frontend-2/components/header/NavBar.vue
+++ b/packages/frontend-2/components/header/NavBar.vue
@@ -1,29 +1,34 @@
 <template>
-  <nav class="fixed z-20 top-0 h-14 bg-foundation shadow hover:shadow-md transition">
-    <div class="flex items-center justify-between h-full w-screen px-4">
-      <div class="flex items-center truncate">
-        <HeaderLogoBlock :active="false" />
-        <HeaderNavLink
-          to="/"
-          name="Dashboard"
-          :separator="true"
-          class="hidden md:inline-block"
-        />
-        <PortalTarget name="navigation"></PortalTarget>
-      </div>
-      <div class="flex items-center">
-        <div class="hidden sm:flex">
-          <PortalTarget name="secondary-actions"></PortalTarget>
-          <PortalTarget name="primary-actions"></PortalTarget>
+  <div>
+    <div class="px-4">
+      <nav
+        class="fixed z-20 top-0 h-14 bg-foundation shadow hover:shadow-md transition"
+      >
+        <div class="flex items-center justify-between h-full w-screen px-4">
+          <div class="flex items-center truncate">
+            <HeaderLogoBlock :active="false" />
+            <HeaderNavLink
+              to="/"
+              name="Dashboard"
+              :separator="true"
+              class="hidden md:inline-block"
+            />
+            <PortalTarget name="navigation"></PortalTarget>
+          </div>
+          <div class="flex items-center">
+            <PortalTarget name="secondary-actions"></PortalTarget>
+            <PortalTarget name="primary-actions"></PortalTarget>
+            <!-- Notifications dropdown -->
+            <HeaderNavNotifications />
+            <!-- Profile dropdown -->
+            <HeaderNavUserMenu />
+          </div>
         </div>
-        <!-- Notifications dropdown -->
-        <HeaderNavNotifications />
-        <!-- Profile dropdown -->
-        <HeaderNavUserMenu />
-      </div>
+        <PopupsSignIn v-if="!activeUser" />
+      </nav>
     </div>
-    <PopupsSignIn v-if="!activeUser" />
-  </nav>
+    <div class="h-14"></div>
+  </div>
 </template>
 <script setup lang="ts">
 import { useActiveUser } from '~~/lib/auth/composables/activeUser'

--- a/packages/frontend-2/components/header/NavBar.vue
+++ b/packages/frontend-2/components/header/NavBar.vue
@@ -1,33 +1,25 @@
 <template>
-  <nav
-    class="fixed top-0 h-14 bg-foundation max-w-full w-full shadow hover:shadow-md transition z-20"
-  >
-    <div class="px-4">
-      <div class="flex items-center h-14 transition-all justify-between">
-        <div class="flex items-center">
-          <HeaderLogoBlock :active="false" class="mr-0" />
-          <div class="flex flex-shrink-0 items-center -ml-2 md:ml-0">
-            <HeaderNavLink
-              to="/"
-              name="Dashboard"
-              :separator="true"
-              class="hidden md:inline-block"
-            />
-            <PortalTarget name="navigation"></PortalTarget>
-          </div>
+  <nav class="fixed z-20 top-0 h-14 bg-foundation shadow hover:shadow-md transition">
+    <div class="flex items-center justify-between h-full w-screen px-4">
+      <div class="flex items-center truncate">
+        <HeaderLogoBlock :active="false" />
+        <HeaderNavLink
+          to="/"
+          name="Dashboard"
+          :separator="true"
+          class="hidden md:inline-block"
+        />
+        <PortalTarget name="navigation"></PortalTarget>
+      </div>
+      <div class="flex items-center">
+        <div class="hidden sm:flex">
+          <PortalTarget name="secondary-actions"></PortalTarget>
+          <PortalTarget name="primary-actions"></PortalTarget>
         </div>
-        <div>
-          <div class="flex items-center">
-            <div class="hidden sm:flex">
-              <PortalTarget name="secondary-actions"></PortalTarget>
-              <PortalTarget name="primary-actions"></PortalTarget>
-            </div>
-            <!-- Notifications dropdown -->
-            <HeaderNavNotifications />
-            <!-- Profile dropdown -->
-            <HeaderNavUserMenu />
-          </div>
-        </div>
+        <!-- Notifications dropdown -->
+        <HeaderNavNotifications />
+        <!-- Profile dropdown -->
+        <HeaderNavUserMenu />
       </div>
     </div>
     <PopupsSignIn v-if="!activeUser" />

--- a/packages/frontend-2/components/header/NavBar.vue
+++ b/packages/frontend-2/components/header/NavBar.vue
@@ -1,32 +1,28 @@
 <template>
   <div>
-    <div class="px-4">
-      <nav
-        class="fixed z-20 top-0 h-14 bg-foundation shadow hover:shadow-md transition"
-      >
-        <div class="flex items-center justify-between h-full w-screen px-4">
-          <div class="flex items-center truncate">
-            <HeaderLogoBlock :active="false" />
-            <HeaderNavLink
-              to="/"
-              name="Dashboard"
-              :separator="true"
-              class="hidden md:inline-block"
-            />
-            <PortalTarget name="navigation"></PortalTarget>
-          </div>
-          <div class="flex items-center">
-            <PortalTarget name="secondary-actions"></PortalTarget>
-            <PortalTarget name="primary-actions"></PortalTarget>
-            <!-- Notifications dropdown -->
-            <HeaderNavNotifications />
-            <!-- Profile dropdown -->
-            <HeaderNavUserMenu />
-          </div>
+    <nav class="fixed z-20 top-0 h-14 bg-foundation shadow hover:shadow-md transition">
+      <div class="flex items-center justify-between h-full w-screen px-4">
+        <div class="flex items-center truncate">
+          <HeaderLogoBlock :active="false" />
+          <HeaderNavLink
+            to="/"
+            name="Dashboard"
+            :separator="true"
+            class="hidden md:inline-block"
+          />
+          <PortalTarget name="navigation"></PortalTarget>
         </div>
-        <PopupsSignIn v-if="!activeUser" />
-      </nav>
-    </div>
+        <div class="flex items-center">
+          <PortalTarget name="secondary-actions"></PortalTarget>
+          <PortalTarget name="primary-actions"></PortalTarget>
+          <!-- Notifications dropdown -->
+          <HeaderNavNotifications />
+          <!-- Profile dropdown -->
+          <HeaderNavUserMenu />
+        </div>
+      </div>
+      <PopupsSignIn v-if="!activeUser" />
+    </nav>
     <div class="h-14"></div>
   </div>
 </template>

--- a/packages/frontend-2/components/header/NavLink.vue
+++ b/packages/frontend-2/components/header/NavLink.vue
@@ -3,12 +3,12 @@
     <NuxtLink
       :to="to"
       class="flex gap-1 items-center text-sm ml-0.5"
-      active-class="text-primary font-bold active-class"
+      active-class="text-primary font-bold group is-active"
     >
       <div v-if="separator">
         <ChevronRightIcon class="flex w-4 h-4" />
       </div>
-      <div class="maybe-truncate">
+      <div class="group-[.is-active]:truncate">
         {{ name || to }}
       </div>
     </NuxtLink>
@@ -31,11 +31,3 @@ defineProps({
   }
 })
 </script>
-
-<style>
-.active-class .maybe-truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-</style>

--- a/packages/frontend-2/components/header/NavLink.vue
+++ b/packages/frontend-2/components/header/NavLink.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="transition text-foreground hover:text-primary-focus">
+  <div class="overflow-x-auto text-foreground hover:text-primary-focus transition">
     <NuxtLink
       :to="to"
-      class="flex items-center text-sm"
+      class="flex gap-1 items-center text-sm ml-0.5"
       active-class="text-primary font-bold"
     >
       <div v-if="separator">
-        <ChevronRightIcon class="flex w-4 h-4 mt-[3px] mx-0 md:mx-1" />
+        <ChevronRightIcon class="flex w-4 h-4" />
       </div>
-      <div class="max-w-[120px] md:max-w-[200px] lg:max-w-[300px] truncate">
+      <div class="truncate">
         {{ name || to }}
       </div>
     </NuxtLink>

--- a/packages/frontend-2/components/header/NavLink.vue
+++ b/packages/frontend-2/components/header/NavLink.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="overflow-x-auto text-foreground hover:text-primary-focus transition">
+  <div class="text-foreground hover:text-primary-focus transition last:truncate">
     <NuxtLink
       :to="to"
       class="flex gap-1 items-center text-sm ml-0.5"
-      active-class="text-primary font-bold"
+      active-class="text-primary font-bold active-class"
     >
       <div v-if="separator">
         <ChevronRightIcon class="flex w-4 h-4" />
       </div>
-      <div class="truncate">
+      <div class="maybe-truncate">
         {{ name || to }}
       </div>
     </NuxtLink>
@@ -31,3 +31,11 @@ defineProps({
   }
 })
 </script>
+
+<style>
+.active-class .maybe-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/packages/frontend-2/components/header/NavNotifications.vue
+++ b/packages/frontend-2/components/header/NavNotifications.vue
@@ -5,7 +5,7 @@
         <div class="cursor-pointer">
           <span class="sr-only">Open notifications menu</span>
           <div class="relative">
-            <div v-if="hasNotifications && !menuOpen" class="scale-90">
+            <div v-if="hasNotifications && !menuOpen" class="scale-75">
               <div
                 class="absolute top-1 right-1 w-3 h-3 rounded-full bg-primary animate-ping"
               ></div>

--- a/packages/frontend-2/components/header/NavNotifications.vue
+++ b/packages/frontend-2/components/header/NavNotifications.vue
@@ -5,7 +5,7 @@
         <div class="cursor-pointer">
           <span class="sr-only">Open notifications menu</span>
           <div class="relative">
-            <div v-if="hasNotifications && !menuOpen">
+            <div v-if="hasNotifications && !menuOpen" class="scale-90">
               <div
                 class="absolute top-1 right-1 w-3 h-3 rounded-full bg-primary animate-ping"
               ></div>
@@ -30,7 +30,7 @@
         leave-to-class="transform opacity-0 scale-95"
       >
         <MenuItems
-          class="absolute z-50 right-0 md:right-14 top-14 md:top-16 w-full md:w-64 origin-top-right bg-foundation-2 outline outline-2 outline-primary-muted rounded-md shadow-lg overflow-hidden"
+          class="absolute z-50 right-0 md:right-16 top-14 sm:top-16 w-full sm:w-64 origin-top-right bg-foundation-2 outline outline-2 outline-primary-muted rounded-md shadow-lg overflow-hidden"
         >
           <div class="p-2 text-sm font-bold bg-gray-50 dark:bg-foundation mb-2">
             Notifications

--- a/packages/frontend-2/components/viewer/explorer/NavbarLink.vue
+++ b/packages/frontend-2/components/viewer/explorer/NavbarLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="truncate">
     <HeaderNavLink
       v-if="lastBreadcrumbName"
       :to="route.fullPath"


### PR DESCRIPTION
## Description & motivation
Part of the feedback received from SOM was that they placed a lot of importance on the naming of models. They had an issue where we had a max-width and truncate set on the Model name in breadcrumbs. When a model name was longer than the max-width, we obscured a lot of the model name which made it hard for them getting context on where the nested model is. This happened, even when there was plenty of screen space in the title bar. 

There will be a larger project in future to look into further improvements for the breadcrumbs. 


## Changes:
Most of the edits are in:
- HeaderNavBar
- HeaderNavLink

The model name now has no max-width, and will fill the available space. The earlier items in the breadcrumb will also truncate on smaller screens. 

There is also a change in:
- HeaderNavNotifications

I fixed an alignment issue, and scaled down the notification ping by 25%. 


## Screenshots:
Before:
<img width="1440" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/bbc76bb4-ea18-49e4-8d33-728a511fcded">

After:
<img width="1435" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/f80769d7-f38f-4da3-96e2-6b8e2cbf58d4">
<img width="925" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/5abf0fbb-fef2-4552-a89c-239eef66f421">
