### PR TITLE
Fix unnecessary scroll

### DIFF
--- a/packages/frontend-2/components/header/NavBar.vue
+++ b/packages/frontend-2/components/header/NavBar.vue
@@ -32,6 +32,7 @@
     </div>
     <PopupsSignIn v-if="!activeUser" />
   </nav>
+  <div class="h-14" />
 </template>
 <script setup lang="ts">
 import { useActiveUser } from '~~/lib/auth/composables/activeUser'

--- a/packages/frontend-2/layouts/default.vue
+++ b/packages/frontend-2/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="min-h-full">
     <HeaderNavBar />
-    <main class="my-4 layout-container pb-20 mt-20">
+    <main class="my-4 layout-container pb-20">
       <slot />
     </main>
   </div>


### PR DESCRIPTION
## Description & motivation
We have an absolutely positioned header bar. The main body is relatively positioned, and without adding margins, it will sit under the header bar. 

We currently have a mt-20 to manage this, but it has a side-effect where on pages where there isn't enough content to fill the browser window, the mt-20 adds a scroll, with nothing to scroll to. 

You can see this on latest.speckle.systems. Go to a model with 4 or less (or 0) versions. Hover on the model, and click the blue version button. This page should not have a scroll, but it currently does. 

## Changes:
Remove mt-20

Add div with h-20 to Header Bar component. 