### PR TITLE
Add OIDC auth strategy button

### DIFF
--- a/packages/frontend-2/components/auth/LoginPanel.vue
+++ b/packages/frontend-2/components/auth/LoginPanel.vue
@@ -23,7 +23,10 @@
         :app-id="appId"
       />
       <div>
-        <div class="text-center label text-foreground-2 mb-3 text-xs font-normal">
+        <div
+          v-if="hasLocalStrategy"
+          class="text-center label text-foreground-2 mb-3 text-xs font-normal"
+        >
           {{
             hasThirdPartyStrategies
               ? 'Or login with your email'

--- a/packages/frontend-2/components/auth/third-party/LoginBlock.vue
+++ b/packages/frontend-2/components/auth/third-party/LoginBlock.vue
@@ -53,6 +53,7 @@ const newsletterConsent = inject<Ref<boolean>>('newsletterconsent')
 const NuxtLink = resolveComponent('NuxtLink')
 const GoogleButton = resolveComponent('AuthThirdPartyLoginButtonGoogle')
 const MicrosoftButton = resolveComponent('AuthThirdPartyLoginButtonMicrosoft')
+const OIDCButton = resolveComponent('AuthThirdPartyLoginButtonOIDC')
 const GithubButton = resolveComponent('AuthThirdPartyLoginButtonGithub')
 
 const thirdPartyStrategies = computed(() =>
@@ -84,6 +85,8 @@ const getButtonComponent = (strat: StrategyType) => {
       return GithubButton
     case AuthStrategy.AzureAD:
       return MicrosoftButton
+    case AuthStrategy.OIDC:
+      return OIDCButton
   }
 
   return NuxtLink

--- a/packages/frontend-2/components/auth/third-party/LoginButtonGithub.vue
+++ b/packages/frontend-2/components/auth/third-party/LoginButtonGithub.vue
@@ -5,7 +5,7 @@
       alt="GitHub Sign In"
       class="w-4 dark:invert"
     />
-    <div>Github</div>
+    <div class="ml-3">Github</div>
   </AuthThirdPartyLoginButtonBase>
 </template>
 <script setup lang="ts">

--- a/packages/frontend-2/components/auth/third-party/LoginButtonOIDC.vue
+++ b/packages/frontend-2/components/auth/third-party/LoginButtonOIDC.vue
@@ -1,13 +1,23 @@
 <template>
   <AuthThirdPartyLoginButtonBase :to="to" class="dark:bg-[#2F2F2F]">
     <IdentificationIcon class="h-4" />
-    <div>OIDC</div>
+    <div class="ml-3">{{ oidcName }}</div>
   </AuthThirdPartyLoginButtonBase>
 </template>
 <script setup lang="ts">
 import { IdentificationIcon } from '@heroicons/vue/24/outline'
+import { useQuery } from '@vue/apollo-composable'
+import { loginServerInfoQuery } from '~~/lib/auth/graphql/queries'
 
 defineProps<{
   to: string
 }>()
+
+const { result } = useQuery(loginServerInfoQuery)
+const authStrategies = computed(() => result.value?.serverInfo.authStrategies)
+
+const oidcName = computed(() => {
+  const oidcStrategy = authStrategies.value?.find((strategy) => strategy.id === 'oidc')
+  return oidcStrategy ? oidcStrategy.name : 'Log in'
+})
 </script>

--- a/packages/frontend-2/components/auth/third-party/LoginButtonOIDC.vue
+++ b/packages/frontend-2/components/auth/third-party/LoginButtonOIDC.vue
@@ -1,0 +1,13 @@
+<template>
+  <AuthThirdPartyLoginButtonBase :to="to" class="dark:bg-[#2F2F2F]">
+    <IdentificationIcon class="h-4" />
+    <div>OIDC</div>
+  </AuthThirdPartyLoginButtonBase>
+</template>
+<script setup lang="ts">
+import { IdentificationIcon } from '@heroicons/vue/24/outline'
+
+defineProps<{
+  to: string
+}>()
+</script>

--- a/packages/frontend-2/lib/auth/helpers/strategies.ts
+++ b/packages/frontend-2/lib/auth/helpers/strategies.ts
@@ -7,5 +7,6 @@ export enum AuthStrategy {
   Local = 'local',
   Google = 'google',
   Github = 'github',
-  AzureAD = 'azuread'
+  AzureAD = 'azuread',
+  OIDC = 'oidc'
 }

--- a/packages/frontend-2/lib/common/generated/gql/graphql.ts
+++ b/packages/frontend-2/lib/common/generated/gql/graphql.ts
@@ -1542,6 +1542,19 @@ export type ProjectCreateInput = {
   visibility?: InputMaybe<ProjectVisibility>;
 };
 
+export type ProjectFileImportUpdatedMessage = {
+  __typename?: 'ProjectFileImportUpdatedMessage';
+  /** Upload ID */
+  id: Scalars['String'];
+  type: ProjectFileImportUpdatedMessageType;
+  upload: FileUpload;
+};
+
+export enum ProjectFileImportUpdatedMessageType {
+  Created = 'CREATED',
+  Updated = 'UPDATED'
+}
+
 export type ProjectInviteCreateInput = {
   /** Either this or userId must be filled */
   email?: InputMaybe<Scalars['String']>;
@@ -2356,6 +2369,8 @@ export type Subscription = {
    * updates regarding comments for those resources.
    */
   projectCommentsUpdated: ProjectCommentsUpdatedMessage;
+  /** Subscribe to changes to any of a project's file imports */
+  projectFileImportUpdated: ProjectFileImportUpdatedMessage;
   /** Subscribe to changes to a project's models. Optionally specify modelIds to track. */
   projectModelsUpdated: ProjectModelsUpdatedMessage;
   /** Subscribe to changes to a project's pending models */
@@ -2445,6 +2460,11 @@ export type SubscriptionProjectAutomationsStatusUpdatedArgs = {
 
 export type SubscriptionProjectCommentsUpdatedArgs = {
   target: ViewerUpdateTrackingTarget;
+};
+
+
+export type SubscriptionProjectFileImportUpdatedArgs = {
+  id: Scalars['String'];
 };
 
 


### PR DESCRIPTION
## Description & motivation
It was raised by @iainsproat that Aurecon could not log in to their server as they had enabled OIDC login, which is not supported in FE2. Instead, they got an empty login screen.

## Changes:
- Add Button component for OIDC
- Added OIDC to AuthStrategy ENUM
- Added OIDC to Login Page
- Added "v-if" so "Login with email..." text only appears when local login is true

## Validation of changes:
NONE - unable to test locally. Enabling OIDC in env requires valid app data