### PR TITLE
fix(helm chart/file import): use objects service instead of server

### DIFF
--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -66,7 +66,7 @@ spec:
 
         env:
           - name: SPECKLE_SERVER_URL
-            value: {{ printf "http://%s:%s" ( include "server.service.fqdn" $ ) ( include "server.port" $ ) }}
+            value: {{ printf "http://%s:%s" ( include "objects.service.fqdn" $ ) ( include "objects.port" $ ) }}
 
           - name: PG_CONNECTION_STRING
             valueFrom:

--- a/utils/helm/speckle-server/templates/fileimport_service/networkpolicy.cilium.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/networkpolicy.cilium.yml
@@ -34,7 +34,7 @@ spec:
               protocol: UDP
           rules:
             dns:
-              - matchName: {{ include "server.service.fqdn" $ }}
+              - matchName: {{ include "objects.service.fqdn" $ }}
 {{ include "speckle.networkpolicy.dns.postgres.cilium" $ | indent 14 }}
     # allow egress to speckle-server
     - toServices:


### PR DESCRIPTION
## Description & motivation

We have introduced a new service, `objects`, to deal with the `/objects` and `/api` endpoints. The file import service had not been amended to use that new service. This PR updates it.

This will prevent load from the file import service interacting with traffic to the `/graphql` endpoint, which is served by the `server` pods.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
