### PR TITLE
Add ArrowUpTray Icon

### DIFF
--- a/packages/frontend-2/components/project/page/models/Actions.vue
+++ b/packages/frontend-2/components/project/page/models/Actions.vue
@@ -35,7 +35,8 @@ import {
   TrashIcon,
   PencilIcon,
   LinkIcon,
-  FingerPrintIcon
+  FingerPrintIcon,
+  ArrowUpTrayIcon
 } from '@heroicons/vue/24/outline'
 import { graphql } from '~~/lib/common/generated/gql'
 import { useMixpanel } from '~~/lib/core/composables/mp'
@@ -87,7 +88,7 @@ const actionsItems = computed<LayoutMenuItem[][]>(() => [
       title: 'Upload new version',
       id: ActionTypes.UploadVersion,
       disabled: !props.canEdit,
-      icon: TrashIcon
+      icon: ArrowUpTrayIcon
     }
   ],
   [


### PR DESCRIPTION
Really quick one - we were showing the Trash Icon for "Upload new Version".

I imported and added the correct version. 