### PR TITLE
chore(logging): allow mixins to be provided to observability.getLogger

### DIFF
--- a/packages/shared/src/observability/index.ts
+++ b/packages/shared/src/observability/index.ts
@@ -3,8 +3,13 @@ import type { LoggerOptions } from 'pino'
 import { toClef, clefLevels } from './pinoClef'
 
 let logger: pino.Logger
+type MixinFn = (mergeObject: object, level: number) => object
 
-export function getLogger(logLevel = 'info', pretty = false): pino.Logger {
+export function getLogger(
+  logLevel = 'info',
+  pretty = false,
+  mixin?: MixinFn
+): pino.Logger {
   if (logger) return logger
 
   const pinoOptions: LoggerOptions = {
@@ -22,6 +27,7 @@ export function getLogger(logLevel = 'info', pretty = false): pino.Logger {
             },
       log: (logObject) => (pretty ? logObject : toClef(logObject))
     },
+    mixin,
     // when not pretty, to produce a clef format, we need the message to be the message template key
     messageKey: pretty ? 'msg' : '@mt',
     level: logLevel,


### PR DESCRIPTION
## Description & motivation

It should be possible to pass mixins to the logger.

For example, Tracing requires the ability to pass a mixin to the logger, allowing certain properties to be created or merged by the tracing component.

https://github.com/pinojs/pino/blob/master/docs/api.md#mixin-function

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
