### PR TITLE
Remove `findAll` when matching ids

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/ui.ts
+++ b/packages/frontend-2/lib/viewer/composables/ui.ts
@@ -228,20 +228,15 @@ export function useSelectionUtilities() {
   } = useInjectedViewer()
 
   const setSelectionFromObjectIds = (objectIds: string[]) => {
-    const res = worldTree.value
-      ? worldTree.value.findAll((node: TreeNode) => {
-          const t = node.model as Record<string, unknown>
-          const raw = t.raw as Record<string, unknown>
-          const id = raw.id as string
-          if (!raw || !id) return false
-          if (objectIds.includes(id)) return true
-          return false
-        })
-      : []
-
-    const objs = res.map(
-      (node: TreeNode) => (node.model as Record<string, unknown>).raw as SpeckleObject
-    )
+    const objs: Array<SpeckleObject> = []
+    objectIds.forEach((value: string) => {
+      objs.push(
+        ...(worldTree.value?.findId(value) as unknown as TreeNode[]).map(
+          (node: TreeNode) =>
+            (node.model as Record<string, unknown>).raw as SpeckleObject
+        )
+      )
+    })
     selectedObjects.value = objs
   }
 


### PR DESCRIPTION

<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation
In FE2 when clicking on any of the items highlighted in the image below

![finaAll1](https://github.com/specklesystems/speckle-server/assets/11405391/0ff01ce9-d1a6-48db-bef6-b9051321b15a)

Which would make all the objects of the selected type to become 'selected', for a large number of objects the main thread would get blocked for tens of seconds. 

60% of the execution time was taken up by using `findAll` when going over very many string ids, to get the tree node from the viewer. In API 2.0, this is no longer needed. Instead you use `findId` which is incomparably faster since it's just one or two lookups. After making this change, the viewer overhead was completely gone. However there is still some FE2 related overhead, accounting for approx 30% of the total inital overhead. 

I'm leaving two profiler recordings, one before the change, one after the change. The FE2 related overhead is visible in both, and it seems to be the same one mentioned [here](https://www.notion.so/speckle/Update-to-the-Viewer-API-2-0-76d56381e6c448fbbeea1d8e88f00ac2?pvs=4#ad9f9a6da5c24681b54050591bb8613d)
<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:
- No more using `findAll` when trying to match object ids. Replaced with `findId`
<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:
**Before:**
![2024-01-26 (1)](https://github.com/specklesystems/speckle-server/assets/11405391/a6e35557-2ba8-45c8-9489-6a7e2e8e5807)

**After:**
![2024-01-26 (3)](https://github.com/specklesystems/speckle-server/assets/11405391/acc4aae3-1f8e-4b5e-b3d1-139a68c92218)



<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
