### PR TITLE
[WBX-56] - Bugfix - Menu to manage project members is cut off

### DIFF
--- a/packages/frontend-2/components/project/page/team/PermissionSelect.vue
+++ b/packages/frontend-2/components/project/page/team/PermissionSelect.vue
@@ -11,6 +11,7 @@
     hide-checkmarks
     by="id"
     class="min-w-[85px]"
+    mount-menu-on-body
   >
     <template #something-selected="{ value }">
       <div class="text-normal text-right">


### PR DESCRIPTION
[JIRA Ticket](https://spockle.atlassian.net/jira/software/c/projects/WBX/issues/WBX-56?filter=myopenissues)

Quick change to add mount-menu-on-body to the user role permission select in the manage project dialog. 