### PR TITLE
Headerbar Consistency - Post merge

### DIFF
--- a/packages/frontend-2/components/header/NavBar.vue
+++ b/packages/frontend-2/components/header/NavBar.vue
@@ -12,7 +12,7 @@
           />
           <PortalTarget name="navigation"></PortalTarget>
         </div>
-        <div class="flex items-center gap-1.5 sm:gap-2">
+        <div class="flex items-center gap-2.5 sm:gap-2">
           <PortalTarget name="secondary-actions"></PortalTarget>
           <PortalTarget name="primary-actions"></PortalTarget>
           <!-- Notifications dropdown -->

--- a/packages/frontend-2/components/header/NavShare.vue
+++ b/packages/frontend-2/components/header/NavShare.vue
@@ -4,7 +4,12 @@
     class="flex items-center relative sm:border-r border-outline-1 sm:pr-4"
   >
     <MenuButton as="div">
-      <FormButton class="hidden sm:flex" outlined :icon-right="ChevronDownIcon">
+      <FormButton
+        class="hidden sm:flex"
+        size="sm"
+        outlined
+        :icon-right="ChevronDownIcon"
+      >
         Share
       </FormButton>
       <button class="sm:hidden mt-1.5">

--- a/packages/frontend-2/components/viewer/AnchoredPoints.vue
+++ b/packages/frontend-2/components/viewer/AnchoredPoints.vue
@@ -5,6 +5,7 @@
   >
     <!-- Add new thread bubble -->
     <ViewerAnchoredPointNewThread
+      v-if="!isEmbedEnabled"
       v-model="buttonState"
       :can-post-comment="canPostComment"
       class="z-[13]"

--- a/packages/frontend-2/components/viewer/AnchoredPoints.vue
+++ b/packages/frontend-2/components/viewer/AnchoredPoints.vue
@@ -5,7 +5,6 @@
   >
     <!-- Add new thread bubble -->
     <ViewerAnchoredPointNewThread
-      v-if="canPostComment && !isEmbedEnabled"
       v-model="buttonState"
       :can-post-comment="canPostComment"
       class="z-[13]"


### PR DESCRIPTION
After merging in Embed, Benjamin noticed we can potentially have 1 buttons in the headerbar. One is sized smaller, and looked like a bug. I have readjust the size of the Share button to sm to match the Sign in button. 

Also increased gap on items in headerbar on mobile. 

Also removed canPostComment condition in v-if on ViewerAnchoredPointNewThread to ensure user can still try to comment on embed, but will be asked to login. 