### PR TITLE
Bugfix: Wrong Condition on Local Strategy Label

### DIFF
--- a/packages/frontend-2/components/auth/RegisterPanel.vue
+++ b/packages/frontend-2/components/auth/RegisterPanel.vue
@@ -33,7 +33,7 @@
         />
         <div>
           <div
-            v-if="hasThirdPartyStrategies"
+            v-if="hasLocalStrategy"
             class="text-center label text-foreground-2 mb-3 text-xs font-normal"
           >
             Or sign up with your email

--- a/packages/frontend-2/components/auth/RegisterPanel.vue
+++ b/packages/frontend-2/components/auth/RegisterPanel.vue
@@ -33,7 +33,7 @@
         />
         <div>
           <div
-            v-if="hasLocalStrategy"
+            v-if="hasThirdPartyStrategies && hasLocalStrategy"
             class="text-center label text-foreground-2 mb-3 text-xs font-normal"
           >
             Or sign up with your email


### PR DESCRIPTION
We have a "Or sign up with your email" in the login, displayed when third party auth strategies are defined. 

Currently, it still shows, even when no local strategy is defined, meaning the label shows, but not form. 

I updated the condition to also check for local strategies.