### PR TITLE
feat: various observability improvements

### DIFF
--- a/packages/frontend-2/.env.example
+++ b/packages/frontend-2/.env.example
@@ -4,6 +4,9 @@ PORT=8081
 NUXT_PUBLIC_LOG_LEVEL=debug
 NUXT_PUBLIC_LOG_PRETTY=true
 
+# Whether to emit extra properties (bindings) that would be sent to seq to the console in CSR
+NUXT_PUBLIC_LOG_CSR_EMIT_PROPS=false
+
 NUXT_PUBLIC_API_ORIGIN=http://127.0.0.1:3000
 
 NUXT_PUBLIC_BASE_URL=http://127.0.0.1:8081

--- a/packages/frontend-2/app.vue
+++ b/packages/frontend-2/app.vue
@@ -13,6 +13,7 @@
 import { useTheme } from '~~/lib/core/composables/theme'
 import { useAuthManager } from '~~/lib/auth/composables/auth'
 import { useMixpanelInitialization } from '~~/lib/core/composables/mp'
+
 const { isDarkTheme } = useTheme()
 
 useHead({

--- a/packages/frontend-2/components/error/page/Renderer.vue
+++ b/packages/frontend-2/components/error/page/Renderer.vue
@@ -4,16 +4,17 @@
     <ErrorPageProjectInviteBanner />
     <h1 class="h1 font-bold">Error {{ error.statusCode || 500 }}</h1>
     <h2 class="h3 text-foreground-2 mx-4 break-words">
-      {{ capitalize(error.message || '') }}
+      {{ finalError.message }}
     </h2>
     <div v-if="isDev && error.stack" class="max-w-xl" v-html="error.stack" />
     <FormButton :to="homeRoute" size="xl">Go Home</FormButton>
   </div>
 </template>
 <script setup lang="ts">
+import { formatAppError } from '~/lib/core/helpers/observability'
 import { homeRoute } from '~~/lib/common/helpers/route'
 
-defineProps<{
+const props = defineProps<{
   error: {
     statusCode: number
     message: string
@@ -22,6 +23,5 @@ defineProps<{
 }>()
 
 const isDev = ref(process.dev)
-
-const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
+const finalError = computed(() => formatAppError(props.error))
 </script>

--- a/packages/frontend-2/components/error/page/Renderer.vue
+++ b/packages/frontend-2/components/error/page/Renderer.vue
@@ -2,11 +2,11 @@
 <template>
   <div class="flex flex-col items-center space-y-8">
     <ErrorPageProjectInviteBanner />
-    <h1 class="h1 font-bold">Error {{ error.statusCode || 500 }}</h1>
+    <h1 class="h1 font-bold">Error {{ finalError.statusCode || 500 }}</h1>
     <h2 class="h3 text-foreground-2 mx-4 break-words">
       {{ finalError.message }}
     </h2>
-    <div v-if="isDev && error.stack" class="max-w-xl" v-html="error.stack" />
+    <div v-if="isDev && finalError.stack" class="max-w-xl" v-html="finalError.stack" />
     <FormButton :to="homeRoute" size="xl">Go Home</FormButton>
   </div>
 </template>

--- a/packages/frontend-2/error.vue
+++ b/packages/frontend-2/error.vue
@@ -10,6 +10,7 @@
 <script setup lang="ts">
 import type { NuxtError } from '#app'
 import { useTheme } from '~/lib/core/composables/theme'
+import { formatAppError } from '~/lib/core/helpers/observability'
 
 /**
  * Any errors thrown while rendering this page will cause Nuxt to revert to the default
@@ -21,9 +22,10 @@ const props = defineProps<{
 }>()
 
 const { isDarkTheme } = useTheme()
+const finalError = computed(() => formatAppError(props.error))
 
 useHead({
-  title: computed(() => `${props.error.statusCode} - ${props.error.message}`),
+  title: computed(() => `${finalError.value.statusCode} - ${finalError.value.message}`),
   bodyAttrs: {
     class: 'simple-scrollbar bg-foundation-page text-foreground'
   },

--- a/packages/frontend-2/lib/auth/composables/activeUser.ts
+++ b/packages/frontend-2/lib/auth/composables/activeUser.ts
@@ -22,6 +22,16 @@ export const activeUserQuery = graphql(`
 `)
 
 /**
+ * Lightweight composable to read user id from cache imperatively (useful for logging)
+ */
+export function useReadUserId() {
+  const client = useApolloClient().client
+  return () => {
+    return client.readQuery({ query: activeUserQuery })?.activeUser?.id
+  }
+}
+
+/**
  * Get active user.
  * undefined - not yet resolved
  * null - resolved that user is a guest

--- a/packages/frontend-2/lib/core/composables/appErrorState.ts
+++ b/packages/frontend-2/lib/core/composables/appErrorState.ts
@@ -16,7 +16,7 @@ export function useAppErrorState() {
       const epm = state.errorRpm.hit()
 
       if (!state.inErrorState.value && epm >= ENTER_STATE_AT_ERRORS_PER_MIN) {
-        logger.error(
+        logger.fatal(
           `Too many errors (${epm} errors per minute), entering app error state!`
         )
         state.inErrorState.value = true

--- a/packages/frontend-2/lib/core/composables/server.ts
+++ b/packages/frontend-2/lib/core/composables/server.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@vue/apollo-composable'
 import { nanoid } from 'nanoid'
 import { graphql } from '~~/lib/common/generated/gql'
 import type { H3Event } from 'h3'
+import type { Optional } from '@speckle/shared'
 
 export const mainServerInfoDataQuery = graphql(`
   query MainServerInfoData {
@@ -58,4 +59,18 @@ export function useRequestId(params?: {
     const state = useState('app_request_correlation_id', () => id)
     return state.value
   }
+}
+
+/**
+ * Resolve the user's geolocation, if possible (only supported wherever we host behind Cloudflare)
+ */
+export function useUserCountry() {
+  const nuxt = useNuxtApp()
+  const state = useState('active_user_country', () => {
+    // The client side should not need to resolve this info, as it should come from the serialized SSR state
+    if (process.client || !nuxt.ssrContext) return undefined
+    return nuxt.ssrContext.event.node.req.headers['cf-ipcountry'] as Optional<string>
+  })
+
+  return computed(() => state.value)
 }

--- a/packages/frontend-2/lib/core/composables/server.ts
+++ b/packages/frontend-2/lib/core/composables/server.ts
@@ -34,6 +34,8 @@ export function useServerInfo() {
 
 /**
  * Get the req.id that is/was used in the initial SSR request
+ *
+ * Note: In SSR, this can only be used after the 001-logging middleware, cause that's when the ID is set
  */
 export function useServerRequestId() {
   const nuxt = useNuxtApp()

--- a/packages/frontend-2/lib/core/composables/server.ts
+++ b/packages/frontend-2/lib/core/composables/server.ts
@@ -33,6 +33,20 @@ export function useServerInfo() {
 }
 
 /**
+ * Get the req.id that is/was used in the initial SSR request
+ */
+export function useServerRequestId() {
+  const nuxt = useNuxtApp()
+  const state = useState('server_request_id', () => {
+    // The client side should not need to resolve this info, as it should come from the serialized SSR state
+    if (process.client || !nuxt.ssrContext) return undefined
+    return nuxt.ssrContext.event.node.req.id as string
+  })
+
+  return computed(() => state.value)
+}
+
+/**
  * Get the value that should be used as the request correlation ID
  *
  * Note: In SSR, this can only be used after the 001-logging middleware, cause that's when the ID is set, otherwise

--- a/packages/frontend-2/lib/core/configs/apollo.ts
+++ b/packages/frontend-2/lib/core/configs/apollo.ts
@@ -389,7 +389,7 @@ function createLink(params: {
     const name = operation.operationName
 
     nuxtApp.$logger.debug(
-      { operation: name },
+      { operation: name, graphql: true },
       `Apollo operation {operation} started...`
     )
     return forward(operation).map((result) => {
@@ -400,7 +400,8 @@ function createLink(params: {
         {
           operation: name,
           elapsed,
-          success
+          success,
+          graphql: true
         },
         `Apollo operation {operation} finished in {elapsed}ms`
       )

--- a/packages/frontend-2/lib/core/configs/apollo.ts
+++ b/packages/frontend-2/lib/core/configs/apollo.ts
@@ -313,7 +313,8 @@ function createLink(params: {
           ...omit(res, ['forward', 'response']),
           networkErrorMessage: res.networkError?.message,
           gqlErrorMessages: res.graphQLErrors?.map((e) => e.message),
-          errorMessage: errMsg
+          errorMessage: errMsg,
+          graphql: true
         },
         'Apollo Client error: {errorMessage}'
       )

--- a/packages/frontend-2/lib/core/helpers/observability.ts
+++ b/packages/frontend-2/lib/core/helpers/observability.ts
@@ -98,14 +98,22 @@ export const formatAppError = (err: SimpleError) => {
   const { statusCode, message, stack } = err
 
   let finalMessage = message || ''
-  if (finalMessage.toLowerCase() === 'fetch failed') {
+  let finalStatusCode = statusCode || 500
+
+  if (finalMessage.match(/^fetch failed$/i)) {
     finalMessage = 'Internal API call failed, please contact site administrators'
+  }
+
+  if (finalMessage.match(/status code 429/i)) {
+    finalMessage =
+      'You are sending too many requests. You have been rate limited. Please try again later.'
+    finalStatusCode = 429
   }
 
   finalMessage = upperFirst(finalMessage)
 
   return {
-    statusCode,
+    statusCode: finalStatusCode,
     message: finalMessage,
     stack
   }

--- a/packages/frontend-2/lib/core/helpers/observability.ts
+++ b/packages/frontend-2/lib/core/helpers/observability.ts
@@ -4,7 +4,15 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 import { Observability } from '@speckle/shared'
-import { get, isBoolean, isNumber, isObjectLike, isString, noop } from 'lodash-es'
+import {
+  upperFirst,
+  get,
+  isBoolean,
+  isNumber,
+  isObjectLike,
+  isString,
+  noop
+} from 'lodash-es'
 
 /**
  * Add pino-pretty like formatting
@@ -78,4 +86,27 @@ export function buildFakePinoLogger(
   logger.child = () => logger as any
 
   return logger
+}
+
+export type SimpleError = {
+  statusCode: number
+  message: string
+  stack?: string
+}
+
+export const formatAppError = (err: SimpleError) => {
+  const { statusCode, message, stack } = err
+
+  let finalMessage = message || ''
+  if (finalMessage.toLowerCase() === 'fetch failed') {
+    finalMessage = 'Internal API call failed, please contact site administrators'
+  }
+
+  finalMessage = upperFirst(finalMessage)
+
+  return {
+    statusCode,
+    message: finalMessage,
+    stack
+  }
 }

--- a/packages/frontend-2/nuxt.config.ts
+++ b/packages/frontend-2/nuxt.config.ts
@@ -48,6 +48,7 @@ export default defineNuxtConfig({
       mixpanelTokenId: 'UNDEFINED',
       logLevel: NUXT_PUBLIC_LOG_LEVEL,
       logPretty: isLogPretty,
+      logCsrEmitProps: false,
       logClientApiToken: '',
       logClientApiEndpoint: '',
       speckleServerVersion: SPECKLE_SERVER_VERSION || 'unknown',

--- a/packages/frontend-2/plugins/001-logger.ts
+++ b/packages/frontend-2/plugins/001-logger.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { isString, omit } from 'lodash-es'
 import { useReadUserId } from '~/lib/auth/composables/activeUser'
-import { useRequestId } from '~/lib/core/composables/server'
+import { useRequestId, useUserCountry } from '~/lib/core/composables/server'
 import { isObjectLike } from '~~/lib/common/helpers/type'
 import { buildFakePinoLogger } from '~~/lib/core/helpers/observability'
 
@@ -25,6 +25,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   const router = useRouter()
   const reqId = useRequestId()
   const getUserId = useReadUserId()
+  const country = useUserCountry()
 
   const collectMainInfo = (params: { isBrowser: boolean }) => {
     const info = {
@@ -35,7 +36,8 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       route: route?.path,
       routeDefinition: route.matched?.[route.matched.length - 1]?.path,
       req: { id: reqId },
-      userId: getUserId()
+      userId: getUserId(),
+      country: country.value
     }
     return info
   }

--- a/packages/frontend-2/plugins/001-logger.ts
+++ b/packages/frontend-2/plugins/001-logger.ts
@@ -189,16 +189,16 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     }
   }
 
-  // Set up global error handler
+  // Set up global vue error handler
   nuxtApp.vueApp.config.errorHandler = (err, _vm, info) => {
     logger.error(err, 'Unhandled error in Vue app', info)
   }
 
   // Uncaught routing error handler
   router.onError((err, to, from) => {
-    // skip 404
+    // skip 404, 403, 401
     if (isObjectLike(err) && 'statusCode' in err) {
-      if ([404].includes(err.statusCode as number)) return
+      if ([404, 403, 401].includes(err.statusCode as number)) return
     }
 
     logger.error(err, 'Unhandled error in routing', {

--- a/packages/frontend-2/plugins/001-logger.ts
+++ b/packages/frontend-2/plugins/001-logger.ts
@@ -63,6 +63,10 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       ])
     })
   } else {
+    const localTimeFormat = new Intl.DateTimeFormat('en-GB', {
+      dateStyle: 'full',
+      timeStyle: 'long'
+    })
     const collectBrowserInfo = () => {
       const {
         userAgent,
@@ -70,8 +74,23 @@ export default defineNuxtPlugin(async (nuxtApp) => {
         vendor: navigatorVendor
       } = navigator
       const url = window.location.href
+      const localTime = localTimeFormat.format(new Date())
 
-      return { userAgent, navigatorPlatform, navigatorVendor, url }
+      // Get browser dimensions & screen dimensions
+      const { innerWidth: browserWidth, innerHeight: browserHeight } = window
+      const { width: screenWidth, height: screenHeight } = window.screen
+
+      return {
+        userAgent,
+        navigatorPlatform,
+        navigatorVendor,
+        url,
+        localTime,
+        dimensions: {
+          browser: { width: browserWidth, height: browserHeight },
+          screen: { width: screenWidth, height: screenHeight }
+        }
+      }
     }
 
     const collectCoreInfo = () => ({

--- a/packages/frontend-2/plugins/001-logger.ts
+++ b/packages/frontend-2/plugins/001-logger.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { isString, omit } from 'lodash-es'
 import { useReadUserId } from '~/lib/auth/composables/activeUser'
-import { useRequestId, useUserCountry } from '~/lib/core/composables/server'
+import {
+  useRequestId,
+  useServerRequestId,
+  useUserCountry
+} from '~/lib/core/composables/server'
 import { isObjectLike } from '~~/lib/common/helpers/type'
 import { buildFakePinoLogger } from '~~/lib/core/helpers/observability'
 
@@ -24,6 +28,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   const route = useRoute()
   const router = useRouter()
   const reqId = useRequestId()
+  const serverReqId = useServerRequestId()
   const getUserId = useReadUserId()
   const country = useUserCountry()
 
@@ -37,7 +42,8 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       routeDefinition: route.matched?.[route.matched.length - 1]?.path,
       req: { id: reqId },
       userId: getUserId(),
-      country: country.value
+      country: country.value,
+      serverReqId: serverReqId.value
     }
     return info
   }

--- a/packages/frontend-2/plugins/001-logger.ts
+++ b/packages/frontend-2/plugins/001-logger.ts
@@ -49,6 +49,14 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     logger = enableDynamicBindings(buildLogger(logLevel, logPretty).child({}), () =>
       collectMainInfo({ isBrowser: false })
     )
+
+    // Collect bindings for pino-http logger
+    nuxtApp.hook('app:rendered', () => {
+      if (!nuxtApp.ssrContext) return
+      nuxtApp.ssrContext.event.node.res.vueLoggerBindings = {
+        userId: getUserId()
+      }
+    })
   } else {
     const collectBrowserInfo = () => {
       const {

--- a/packages/frontend-2/server/lib/core/helpers/observability.ts
+++ b/packages/frontend-2/server/lib/core/helpers/observability.ts
@@ -21,11 +21,17 @@ export function enableDynamicBindings(
       ) {
         const logMethod = get(target, prop) as (...args: unknown[]) => void
         return (...args: unknown[]) => {
-          // Re-setting bindings on every log call, cause there's no other way to make them dynamic
-          const boundVals = bindings()
-          target.setBindings(boundVals)
+          const log = logMethod.bind(target)
 
-          logMethod.bind(target)(...args)
+          // Re-setting bindings on every log call, cause there's no other way to make them dynamic
+          try {
+            const boundVals = bindings()
+            target.setBindings(boundVals)
+          } catch (e) {
+            target.error(e, 'Failed to set dynamic bindings')
+          }
+
+          return log(...args)
         }
       }
 

--- a/packages/frontend-2/server/lib/core/helpers/observability.ts
+++ b/packages/frontend-2/server/lib/core/helpers/observability.ts
@@ -1,5 +1,32 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Observability } from '@speckle/shared'
+import { get } from 'lodash-es'
+import type { Logger } from 'pino'
 
 export function buildLogger(logLevel: string = 'info', logPretty: boolean = false) {
   return Observability.getLogger(logLevel, logPretty)
+}
+
+export function enableDynamicBindings(
+  logger: Logger,
+  bindings: () => Record<string, unknown>
+): Logger {
+  return new Proxy(logger, {
+    get(target, prop) {
+      if (
+        ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].includes(prop as string)
+      ) {
+        const logMethod = get(target, prop) as (...args: unknown[]) => void
+        return (...args: unknown[]) => {
+          // Re-setting bindings on every log call, cause there's no other way to make them dynamic
+          const boundVals = bindings()
+          target.setBindings(boundVals)
+
+          logMethod.bind(target)(...args)
+        }
+      }
+
+      return get(target, prop)
+    }
+  })
 }

--- a/packages/frontend-2/server/middleware/001-logging.ts
+++ b/packages/frontend-2/server/middleware/001-logging.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'crypto'
 import type { IncomingHttpHeaders } from 'http'
 import { REQUEST_ID_HEADER } from '~~/server/lib/core/helpers/constants'
 import { get } from 'lodash'
+import { serializeRequest } from '~/server/lib/core/helpers/observability'
 
 /**
  * Server request logger
@@ -31,8 +32,6 @@ const logger = Observability.getLogger(
   useRuntimeConfig().public.logLevel,
   useRuntimeConfig().public.logPretty
 )
-
-const redactedHeaders = ['authorization', 'cookie']
 
 export const LoggingMiddleware = pinoHttp({
   logger,
@@ -68,10 +67,13 @@ export const LoggingMiddleware = pinoHttp({
     const isCompleted = !req.readableAborted && res.writableEnded
     const requestStatus = isCompleted ? 'completed' : 'aborted'
     const requestPath = req.url?.split('?')[0] || 'unknown'
+    const appBindings = res.vueLoggerBindings || {}
+
     return {
       ...val,
       requestStatus,
-      requestPath
+      requestPath,
+      ...appBindings
     }
   },
 
@@ -81,10 +83,13 @@ export const LoggingMiddleware = pinoHttp({
   customErrorObject(req, res, err, val: Record<string, unknown>) {
     const requestStatus = 'failed'
     const requestPath = req.url?.split('?')[0] || 'unknown'
+    const appBindings = res.vueLoggerBindings || {}
+
     return {
       ...val,
       requestStatus,
-      requestPath
+      requestPath,
+      ...appBindings
     }
   },
 
@@ -92,24 +97,7 @@ export const LoggingMiddleware = pinoHttp({
   // as we do not know what headers may be sent in a request by a user or client
   // we have to allow list selected headers
   serializers: {
-    req: pino.stdSerializers.wrapRequestSerializer((req) => {
-      return {
-        id: req.raw.id,
-        method: req.raw.method,
-        path: req.raw.url?.split('?')[0], // Remove query params which might be sensitive
-        // Allowlist useful headers
-        headers: Object.keys(req.raw.headers).reduce((obj, key) => {
-          let valueToPrint = req.raw.headers[key]
-          if (redactedHeaders.includes(key.toLocaleLowerCase())) {
-            valueToPrint = `REDACTED[length: ${valueToPrint ? valueToPrint.length : 0}]`
-          }
-          return {
-            ...obj,
-            [key]: valueToPrint
-          }
-        }, {})
-      }
-    }),
+    req: pino.stdSerializers.wrapRequestSerializer((req) => serializeRequest(req.raw)),
     res: pino.stdSerializers.wrapResponseSerializer((res) => {
       const resRaw = res as SerializedResponse & {
         raw: {
@@ -124,8 +112,7 @@ export const LoggingMiddleware = pinoHttp({
         statusCode: res.raw.statusCode,
         // Allowlist useful headers
         headers: resRaw.headers,
-        isRequestAborted,
-        ...(realRaw.vueLoggerBindings || {})
+        isRequestAborted
       }
     })
   }

--- a/packages/frontend-2/server/middleware/001-logging.ts
+++ b/packages/frontend-2/server/middleware/001-logging.ts
@@ -124,7 +124,8 @@ export const LoggingMiddleware = pinoHttp({
         statusCode: res.raw.statusCode,
         // Allowlist useful headers
         headers: resRaw.headers,
-        isRequestAborted
+        isRequestAborted,
+        ...(realRaw.vueLoggerBindings || {})
       }
     })
   }

--- a/packages/frontend-2/type-augmentations/server.d.ts
+++ b/packages/frontend-2/type-augmentations/server.d.ts
@@ -1,0 +1,7 @@
+declare module 'http' {
+  interface ServerResponse {
+    vueLoggerBindings: Record<string, unknown>
+  }
+}
+
+export {}

--- a/packages/server/logging/apolloPlugin.js
+++ b/packages/server/logging/apolloPlugin.js
@@ -22,6 +22,8 @@ module.exports = {
     return {
       didResolveOperation(ctx) {
         let logger = ctx.context.log || graphqlLogger
+        const auth = ctx.context
+        const userId = auth?.userId
 
         const op = `GQL ${ctx.operation.operation} ${ctx.operation.selectionSet.selections[0].name.value}`
         const name = `GQL ${ctx.operation.selectionSet.selections[0].name.value}`
@@ -34,7 +36,8 @@ module.exports = {
           graphql_query: query,
           graphql_variables: redactSensitiveVariables(variables),
           graphql_operation_value: op,
-          graphql_operation_name: name
+          graphql_operation_name: name,
+          userId
         })
 
         const transaction = Sentry.startTransaction({

--- a/packages/server/logging/expressLogging.ts
+++ b/packages/server/logging/expressLogging.ts
@@ -7,6 +7,7 @@ import pino, { SerializedResponse } from 'pino'
 import { GenReqId } from 'pino-http'
 import { get } from 'lodash'
 import type { ServerResponse } from 'http'
+import { Optional } from '@speckle/shared'
 
 const REQUEST_ID_HEADER = 'x-request-id'
 
@@ -44,10 +45,13 @@ export const LoggingExpressMiddleware = HttpLogger({
     const isCompleted = !req.readableAborted && res.writableEnded
     const requestStatus = isCompleted ? 'completed' : 'aborted'
     const requestPath = req.url?.split('?')[0] || 'unknown'
+    const country = req.headers['cf-ipcountry'] as Optional<string>
+
     return {
       ...val,
       requestStatus,
-      requestPath
+      requestPath,
+      country
     }
   },
 
@@ -57,10 +61,13 @@ export const LoggingExpressMiddleware = HttpLogger({
   customErrorObject(req, res, err, val: Record<string, unknown>) {
     const requestStatus = 'failed'
     const requestPath = req.url?.split('?')[0] || 'unknown'
+    const country = req.headers['cf-ipcountry'] as Optional<string>
+
     return {
       ...val,
       requestStatus,
-      requestPath
+      requestPath,
+      country
     }
   },
 

--- a/packages/server/logging/expressLogging.ts
+++ b/packages/server/logging/expressLogging.ts
@@ -5,6 +5,8 @@ import { IncomingMessage } from 'http'
 import { NextFunction, Response } from 'express'
 import pino, { SerializedResponse } from 'pino'
 import { GenReqId } from 'pino-http'
+import { get } from 'lodash'
+import type { ServerResponse } from 'http'
 
 const REQUEST_ID_HEADER = 'x-request-id'
 
@@ -94,10 +96,14 @@ export const LoggingExpressMiddleware = HttpLogger({
           headers: Record<string, string>
         }
       }
+      const serverRes = get(res, 'raw.raw') as ServerResponse
+      const auth = serverRes.req.context
+
       return {
         statusCode: res.raw.statusCode,
         // Allowlist useful headers
-        headers: resRaw.raw.headers
+        headers: resRaw.raw.headers,
+        userId: auth?.userId
       }
     })
   }

--- a/packages/server/type-augmentations/express.d.ts
+++ b/packages/server/type-augmentations/express.d.ts
@@ -15,4 +15,10 @@ declare module 'express-serve-static-core' {
   }
 }
 
+declare module 'http' {
+  interface IncomingMessage {
+    context?: AuthContext
+  }
+}
+
 export {}


### PR DESCRIPTION
- Better error page when 1) api calls fail 2) you're being rate limited. Previously you got a vague message like "fetch failed" or "status code 429"
- Added userId to server & FE2 logs
- Added country & server request ID (the req.id of the initial SSR req) to FE2 logs
- Made FE2 log payloads more cohesive and alike irregardless of whether they come from the vue app or server side routes
- 