### PR TITLE
[WBX-284] Bugfix - Controls Z-Index not being enforced

### DIFF
--- a/packages/frontend-2/components/viewer/PreSetupWrapper.vue
+++ b/packages/frontend-2/components/viewer/PreSetupWrapper.vue
@@ -42,14 +42,14 @@
           </div>
 
           <!-- Global loading bar -->
-          <ViewerLoadingBar class="z-20" />
+          <ViewerLoadingBar class="relative z-20" />
 
           <!-- Sidebar controls -->
           <Transition
             enter-from-class="opacity-0"
             enter-active-class="transition duration-1000"
           >
-            <ViewerControls v-show="showControls" class="z-20" />
+            <ViewerControls v-show="showControls" class="relative z-20" />
           </Transition>
 
           <!-- Viewer Object Selection Info Display -->


### PR DESCRIPTION
## Description & motivation
The z-index on controls was z-20, with the new "pocket" (lower content area in viewer) at z-10. But the z-index wasn't being enforced as the position wasn't set. This caused the reset filters div to sit on top of the controls, blocking some functionality. 

Reported by Dim here:
https://spockle.atlassian.net/browse/WBX-284

## Changes:
-Add relative to 2 cases where z index was set without position