### PR TITLE
[WBX-281] - 2049 Hardcoded URL in Create Application Success Dialog

### DIFF
--- a/packages/frontend-2/components/developer-settings/CreateApplicationSuccessDialog.vue
+++ b/packages/frontend-2/components/developer-settings/CreateApplicationSuccessDialog.vue
@@ -56,7 +56,11 @@ const {
 
 const authUrl = computed(() => {
   if (props.application?.id) {
-    return `${baseUrl}/authn/verify/${props.application.id}/{code_challenge}`
+    const url = new URL(`/authn/verify/${props.application.id}`, baseUrl)
+
+    const finalUrl = `${url.toString()}/{code_challenge}`
+
+    return finalUrl
   }
   return null
 })

--- a/packages/frontend-2/components/developer-settings/CreateApplicationSuccessDialog.vue
+++ b/packages/frontend-2/components/developer-settings/CreateApplicationSuccessDialog.vue
@@ -28,11 +28,7 @@
             <strong>Note:</strong>
             To authenticate users inside your app, direct them to
           </p>
-          <CommonClipboardInputWithToast
-            v-if="props.application?.secret"
-            :value="`https://latest.speckle.dev/authn/verify/${props.application?.id}/{code_challenge}`"
-            is-multiline
-          />
+          <CommonClipboardInputWithToast v-if="authUrl" :value="authUrl" is-multiline />
           <p>
             `{code_challenge}` is an OAuth2 plain code challenge that your app needs to
             generate for each authentication request.
@@ -53,6 +49,17 @@ const props = defineProps<{
 }>()
 
 const isOpen = defineModel<boolean>('open', { required: true })
+
+const {
+  public: { baseUrl }
+} = useRuntimeConfig()
+
+const authUrl = computed(() => {
+  if (props.application?.id) {
+    return `${baseUrl}/authn/verify/${props.application.id}/{code_challenge}`
+  }
+  return null
+})
 
 const dialogButtons = computed(() => [
   {

--- a/packages/frontend-2/components/developer-settings/CreateApplicationSuccessDialog.vue
+++ b/packages/frontend-2/components/developer-settings/CreateApplicationSuccessDialog.vue
@@ -56,7 +56,15 @@ const {
 
 const authUrl = computed(() => {
   if (props.application?.id) {
-    return `${baseUrl}/authn/verify/${props.application.id}/{code_challenge}`
+    const url = new URL(
+      `/authn/verify/${encodeURIComponent(props.application.id)}`,
+      baseUrl
+    )
+
+    // Add the placeholder for code_challenge
+    url.hash = `{code_challenge}`
+
+    return url.toString()
   }
   return null
 })

--- a/packages/frontend-2/components/developer-settings/CreateApplicationSuccessDialog.vue
+++ b/packages/frontend-2/components/developer-settings/CreateApplicationSuccessDialog.vue
@@ -56,15 +56,7 @@ const {
 
 const authUrl = computed(() => {
   if (props.application?.id) {
-    const url = new URL(
-      `/authn/verify/${encodeURIComponent(props.application.id)}`,
-      baseUrl
-    )
-
-    // Add the placeholder for code_challenge
-    url.hash = `{code_challenge}`
-
-    return url.toString()
+    return `${baseUrl}/authn/verify/${props.application.id}/{code_challenge}`
   }
   return null
 })


### PR DESCRIPTION
[JIRA TICKET
](https://spockle.atlassian.net/jira/software/c/projects/WBX/issues/WBX-281?filter=myopenissues)

## Description & motivation
User reported the hardcoded url. Updated to use NUXT_PUBLIC_BASE_URL.

## Changes:
- Use NUXT_PUBLIC_BASE_URL to build URL

## To do before merge:
- The hardcoded url was the FE1 string. I need to confirm that this was not intentional. It is as the docs suggest, so I need to make sure this also works with the FE2 url. 

## Screenshots:
<img width="647" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/3098b4a7-3c69-406e-bc0d-db99446acfbb">
