### PR TITLE
Move "Stop Following" button to the "Pocket"

### DIFF
--- a/packages/frontend-2/components/viewer/AnchoredPoints.vue
+++ b/packages/frontend-2/components/viewer/AnchoredPoints.vue
@@ -89,25 +89,27 @@
         class="w-full h-full outline -outline-offset-0 outline-8 rounded-md outline-blue-500/40"
       >
         <div class="absolute bottom-4 right-4 p-2 pointer-events-auto">
-          <FormButton
-            v-if="spotlightUserSessionId && spotlightUser"
-            size="xs"
-            class="truncate"
-            @click="() => (spotlightUserSessionId = null)"
-          >
-            <span>Stop Following {{ spotlightUser?.userName.split(' ')[0] }}</span>
-          </FormButton>
-          <div
-            v-else
-            v-tippy="followers.map((u) => u.name).join(', ')"
-            class="text-xs p-2 font-bold text-primary"
-          >
-            Followed by {{ followers[0].name.split(' ')[0] }}
-            <span v-if="followers.length > 1">
-              & {{ followers.length - 1 }}
-              {{ followers.length - 1 === 1 ? 'other' : 'others' }}
-            </span>
-          </div>
+          <Portal to="pocket-right">
+            <FormButton
+              v-if="spotlightUserSessionId && spotlightUser"
+              size="xs"
+              class="truncate"
+              @click="() => (spotlightUserSessionId = null)"
+            >
+              <span>Stop Following {{ spotlightUser?.userName.split(' ')[0] }}</span>
+            </FormButton>
+            <div
+              v-else
+              v-tippy="followers.map((u) => u.name).join(', ')"
+              class="text-xs p-2 font-bold text-primary"
+            >
+              Followed by {{ followers[0].name.split(' ')[0] }}
+              <span v-if="followers.length > 1">
+                & {{ followers.length - 1 }}
+                {{ followers.length - 1 === 1 ? 'other' : 'others' }}
+              </span>
+            </div>
+          </Portal>
         </div>
       </div>
     </div>

--- a/packages/frontend-2/components/viewer/GlobalFilterReset.vue
+++ b/packages/frontend-2/components/viewer/GlobalFilterReset.vue
@@ -11,11 +11,7 @@
       leave-from-class="opacity-100"
       leave-to-class="opacity-0"
     >
-      <FormButton
-        :size="isEmbedEnabled ? 'xs' : 'sm'"
-        class="pointer-events-auto"
-        @click="trackAndResetFilters"
-      >
+      <FormButton size="xs" class="pointer-events-auto" @click="trackAndResetFilters">
         Reset Filters
       </FormButton>
     </Transition>
@@ -24,14 +20,12 @@
 <script setup lang="ts">
 import { useMixpanel } from '~~/lib/core/composables/mp'
 import { useFilterUtilities } from '~~/lib/viewer/composables/ui'
-import { useEmbed } from '~/lib/viewer/composables/setup/embed'
 
 const {
   resetFilters,
   filters: { hasAnyFiltersApplied }
 } = useFilterUtilities()
 
-const { isEnabled: isEmbedEnabled } = useEmbed()
 const mp = useMixpanel()
 const trackAndResetFilters = () => {
   resetFilters()

--- a/packages/frontend-2/components/viewer/PreSetupWrapper.vue
+++ b/packages/frontend-2/components/viewer/PreSetupWrapper.vue
@@ -63,14 +63,22 @@
             </div>
           </Transition>
           <div
-            class="absolute z-10 w-screen flex flex-col items-center justify-center gap-2"
+            class="absolute z-10 w-screen px-8 grid grid-cols-3 gap-2"
             :class="isEmbedEnabled ? 'bottom-16 mb-1' : 'bottom-6'"
           >
-            <PortalTarget name="pocket-tip"></PortalTarget>
-            <div class="flex gap-3">
-              <PortalTarget name="pocket-actions"></PortalTarget>
-              <!-- Shows up when filters are applied for an easy return to normality -->
-              <ViewerGlobalFilterReset class="z-20" :embed="!!isEmbedEnabled" />
+            <div class="flex items-end">
+              <PortalTarget name="pocket-left"></PortalTarget>
+            </div>
+            <div class="flex flex-col gap-2 items-center justify-end">
+              <PortalTarget name="pocket-tip"></PortalTarget>
+              <div class="flex gap-3">
+                <PortalTarget name="pocket-actions"></PortalTarget>
+                <!-- Shows up when filters are applied for an easy return to normality -->
+                <ViewerGlobalFilterReset class="z-20" :embed="!!isEmbedEnabled" />
+              </div>
+            </div>
+            <div class="flex items-end justify-end">
+              <PortalTarget name="pocket-right"></PortalTarget>
             </div>
           </div>
         </ClientOnly>

--- a/packages/frontend-2/components/viewer/PreSetupWrapper.vue
+++ b/packages/frontend-2/components/viewer/PreSetupWrapper.vue
@@ -63,10 +63,10 @@
             </div>
           </Transition>
           <div
-            class="absolute z-10 w-screen px-8 grid grid-cols-3 gap-2"
+            class="absolute z-10 w-screen px-8 grid grid-cols-1 sm:grid-cols-3 gap-2"
             :class="isEmbedEnabled ? 'bottom-16 mb-1' : 'bottom-6'"
           >
-            <div class="flex items-end">
+            <div class="flex items-end justify-center sm:justify-start">
               <PortalTarget name="pocket-left"></PortalTarget>
             </div>
             <div class="flex flex-col gap-2 items-center justify-end">
@@ -77,7 +77,7 @@
                 <ViewerGlobalFilterReset class="z-20" :embed="!!isEmbedEnabled" />
               </div>
             </div>
-            <div class="flex items-end justify-end">
+            <div class="flex items-end justify-center sm:justify-end">
               <PortalTarget name="pocket-right"></PortalTarget>
             </div>
           </div>

--- a/packages/frontend-2/components/viewer/measurements/Options.vue
+++ b/packages/frontend-2/components/viewer/measurements/Options.vue
@@ -75,7 +75,7 @@
       </div>
     </div>
     <Portal to="pocket-tip">
-      <ViewerTip>
+      <ViewerTip class="hidden sm:flex">
         <strong>Tip:</strong>
         Right click to cancel measurement
       </ViewerTip>

--- a/packages/frontend-2/components/viewer/measurements/Options.vue
+++ b/packages/frontend-2/components/viewer/measurements/Options.vue
@@ -81,7 +81,7 @@
       </ViewerTip>
     </Portal>
     <Portal to="pocket-actions">
-      <FormButton size="sm" @click="() => clearMeasurements()">
+      <FormButton size="xs" @click="() => clearMeasurements()">
         Reset Measurements
       </FormButton>
     </Portal>

--- a/packages/frontend-2/components/viewer/selection/Sidebar.vue
+++ b/packages/frontend-2/components/viewer/selection/Sidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <ViewerCommentsPortalOrDiv v-if="objects.length !== 0" to="bottomPanel">
     <div
-      :class="`sm:bg-foundation simple-scrollbar z-10 relative sm:fixed sm:right-4 sm:right-4 sm:mb-4 sm:max-w-64 min-h-[3rem] sm:min-h-[4.75rem] max-h-[50vh] sm:max-h-[calc(100vh-5.5rem)] w-full sm:w-64 overflow-y-auto sm:rounded-md sm:shadow transition ${
+      :class="`sm:bg-foundation simple-scrollbar z-20 relative sm:fixed sm:right-4 sm:right-4 sm:mb-4 sm:max-w-64 min-h-[3rem] sm:min-h-[4.75rem] max-h-[50vh] sm:max-h-[calc(100vh-5.5rem)] w-full sm:w-64 overflow-y-auto sm:rounded-md sm:shadow transition ${
         objects.length !== 0
           ? 'translate-x-0 opacity-100'
           : 'translate-x-[120%] opacity-0'


### PR DESCRIPTION
As part of another (merged) ticket, I created a "pocket" portal. This is the area in the viewer that can house tips or buttons. 

I created this pocket, as previously we were just adding these buttons throughout the app where needed. By using the portals, we can centralise the layout logic to ensure all buttons/tips have the correct positioning and z-indexs. 

It was noticed that when a user is following someone with filters applied, you can no longer click "Stop Following..". This is because this button is not part of the pocket. It was positioned absolutely, rather than using the portal.

I moved this button to the Pocket, and created new left and right pockets. I used grid to make sure these are always equal widths to ensure alignment. 