### PR TITLE
fix(server): exit with non-zero code if init fails

### DIFF
--- a/packages/server/bin/ts-www
+++ b/packages/server/bin/ts-www
@@ -12,6 +12,11 @@ const { init, startHttp } = require('../app')
 
 init()
   .then(({ app, server }) => startHttp(server, app))
-  .catch((err) => logger.error(err))
+  .catch((err) => {
+    logger.error(err, 'Failed to start server. Exiting with non-zero exit code...')
+
+    // kill it with fire 🔥
+    process.exit(1)
+  })
 
 // 💥

--- a/packages/server/bin/www
+++ b/packages/server/bin/www
@@ -6,6 +6,11 @@ const { init, startHttp } = require('../dist/app')
 
 init()
   .then(({ app, server }) => startHttp(server, app))
-  .catch((err) => logger.error(err))
+  .catch((err) => {
+    logger.error(err, 'Failed to start server. Exiting with non-zero exit code...')
+
+    // kill it with fire 🔥
+    process.exit(1)
+  })
 
 // 💥


### PR DESCRIPTION
## Description & motivation

If a server failed during `init()`, it did not exit and remained running. The server was unresponsive, and it would not be cleaned up until the liveness probe started 10 minutes later.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
