### PR TITLE
Small bugfix - Windows showing clipped project titles

### DIFF
--- a/packages/frontend-2/components/common/EditableTitleDescription.vue
+++ b/packages/frontend-2/components/common/EditableTitleDescription.vue
@@ -114,7 +114,7 @@ const debouncedEmitDescription = debounce(emitDescription, 2000)
 
 const titleInputClasses = computed(() => [
   'h3 tracking-tight border-0 border-b-2 transition focus:border-outline-3 max-w-full',
-  'p-0 bg-transparent border-transparent focus:outline-none focus:ring-0'
+  'p-0 pb-1 bg-transparent border-transparent focus:outline-none focus:ring-0'
 ])
 
 const descriptionInputClasses = computed(() => [


### PR DESCRIPTION
On Windows & Edge, there was a small bug where the title was clipping the bottom few pixels of some characters.
<img width="265" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/4c846ac5-187e-4cc0-a19e-004cbab48b60">
I added a small amount of padding to the textarea to fix this. Confirmed to work when testing on BrowserStack. 