### PR TITLE
Update Grid/List view toggle component to make the active item clearer

### DIFF
--- a/packages/frontend-2/components/project/page/LatestItems.vue
+++ b/packages/frontend-2/components/project/page/LatestItems.vue
@@ -25,7 +25,7 @@
       <slot v-if="!hideFilters" name="filters">
         <div class="flex space-x-4 items-center grow justify-end flex-wrap">
           <slot name="filters" />
-          <LayoutGridListToggle v-model="gridOrList" v-tippy="'Swap Grid/Card View'" />
+          <LayoutGridListToggle v-model="gridOrList" />
         </div>
       </slot>
     </div>

--- a/packages/frontend-2/components/project/page/discussions/Header.vue
+++ b/packages/frontend-2/components/project/page/discussions/Header.vue
@@ -9,11 +9,7 @@
           :value="true"
           label="Include resolved"
         />
-        <LayoutGridListToggle
-          v-model="finalGridOrList"
-          v-tippy="'Swap Grid/Card View'"
-          class="shrink-0"
-        />
+        <LayoutGridListToggle v-model="finalGridOrList" class="shrink-0" />
       </div>
     </div>
   </div>

--- a/packages/frontend-2/components/project/page/latest-items/Models.vue
+++ b/packages/frontend-2/components/project/page/latest-items/Models.vue
@@ -49,10 +49,7 @@
               @change="($event) => updateSearchImmediately($event.value)"
               @update:model-value="updateDebouncedSearch"
             ></FormTextInput>
-            <LayoutGridListToggle
-              v-model="gridOrList"
-              v-tippy="'Swap Grid/Card View'"
-            />
+            <LayoutGridListToggle v-model="gridOrList" />
           </div>
           <div class="flex items-center space-x-2">
             <FormButton

--- a/packages/frontend-2/components/project/page/models/Header.vue
+++ b/packages/frontend-2/components/project/page/models/Header.vue
@@ -63,11 +63,7 @@
               clearable
               fixed-height
             />
-            <LayoutGridListToggle
-              v-model="finalGridOrList"
-              v-tippy="'Swap Grid/Card View'"
-              class="shrink-0"
-            />
+            <LayoutGridListToggle v-model="finalGridOrList" class="shrink-0" />
           </div>
           <FormButton
             color="secondary"

--- a/packages/ui-components/src/components/layout/GridListToggle.vue
+++ b/packages/ui-components/src/components/layout/GridListToggle.vue
@@ -1,18 +1,17 @@
 <template>
   <button
-    class="max-w-max transition flex justify-center items-center gap-2 outline-none select-none h-8 text-foreground border-2 bg-foundation border-foundation-2 rounded-md hover:ring-2 active:scale-[0.97] grow"
+    class="max-w-max transition flex justify-center items-center gap-2 outline-none select-none h-8 text-foreground border-2 border-primary-muted dark:border-foundation bg-primary-muted rounded-md active:scale-[0.97] grow"
     @click="onClick"
   >
-    <div class="relative flex bg-foundation rounded-md">
+    <div class="relative flex bg-primary-muted rounded-md">
       <div
-        class="absolute -top-[2px] -left-[2px] transition"
+        class="absolute transition"
         :class="{
           'translate-x-7': value !== GridListToggleValue.Grid
         }"
       >
         <div
-          :class="value !== GridListToggleValue.Grid ? 'rounded-r-md' : 'rounded-l-md'"
-          class="w-8 h-8 bg-primary-muted shadow-inner transition"
+          class="w-7 h-7 bg-foundation dark:bg-foundation-2 transition rounded shadow"
         />
       </div>
       <div class="relative z-10 flex gap-1 items-center p-1 rounded-l">

--- a/packages/ui-components/src/components/layout/GridListToggle.vue
+++ b/packages/ui-components/src/components/layout/GridListToggle.vue
@@ -14,10 +14,16 @@
           class="w-7 h-7 bg-foundation dark:bg-foundation-2 transition rounded shadow"
         />
       </div>
-      <div class="relative z-10 flex gap-1 items-center p-1 rounded-l">
+      <div
+        v-tippy="'Grid View'"
+        class="relative z-10 flex gap-1 items-center p-1 rounded-l"
+      >
         <Squares2X2Icon class="h-5 w-5" />
       </div>
-      <div class="relative z-10 flex gap-1 items-center p-1 rounded-r">
+      <div
+        v-tippy="'List View'"
+        class="relative z-10 flex gap-1 items-center p-1 rounded-r"
+      >
         <Bars3Icon class="h-5 w-5" />
       </div>
     </div>


### PR DESCRIPTION
I've updated the Grid/List view toggle component to make it clearer which item is the active item. The old design made it appear as if the inactive item was the active item.

### Changes

- The active item has the light background color, some spacing around it, and a shadow.
- Updated tippy to have one for each of the two toggle items. "Grid View" / "List View"
- Note: I've used a few `dark:` Tailwind classes to tweak the colors in dark mode. I've heard from Andrew we don't want to do this but it didn't work well in dark mode without it.

### Screenshots

#### Before
The item with the darker background below is the active item even though you'd think it's the white one.

![CleanShot 2024-03-08 at 08 10 35@2x](https://github.com/specklesystems/speckle-server/assets/2694102/116526ec-f26c-4ca6-810b-9bc07731d6ae)

![CleanShot 2024-03-08 at 08 12 30@2x](https://github.com/specklesystems/speckle-server/assets/2694102/028ad870-54a3-4399-8dd7-227f55c1a472)

#### After

![CleanShot 2024-03-08 at 08 10 18@2x](https://github.com/specklesystems/speckle-server/assets/2694102/39241d19-9517-468b-a977-bedd5babd64c)

![CleanShot 2024-03-08 at 08 12 00@2x](https://github.com/specklesystems/speckle-server/assets/2694102/ec072827-13ee-4f3d-8c5f-ac37c66871b1)
