### PR TITLE
Bugfix - Mobile Project cards not filling width of mobile

### DIFF
--- a/packages/frontend-2/components/projects/ProjectDashboardCard.vue
+++ b/packages/frontend-2/components/projects/ProjectDashboardCard.vue
@@ -36,7 +36,7 @@
         </div>
       </div>
       <div
-        class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 flex-grow col-span-4 lg:col-span-3"
+        class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 flex-grow col-span-4 lg:col-span-3 w-full"
       >
         <ProjectPageModelsCard
           v-for="pendingModel in pendingModels"


### PR DESCRIPTION
[Bug raised here](https://spockle.atlassian.net/browse/WBX-395)

Fix:
<img width="114" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/84af7a7c-3caf-4c51-9a5d-5da56f7f8ab5">
