### PR TITLE
Fix Projects and Discussions Pages

### DIFF
--- a/packages/frontend-2/pages/projects/[id]/discussions.vue
+++ b/packages/frontend-2/pages/projects/[id]/discussions.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <div v-if="project">
-      <ProjectDiscussionsPageHeader
+      <ProjectPageDiscussionsHeader
         v-model:grid-or-list="gridOrList"
         v-model:include-archived="includeArchived"
         :project="project"
       />
-      <ProjectDiscussionsPageResults
+      <ProjectPageDiscussionsResults
         :grid-or-list="gridOrList"
         :project="project"
         :include-archived="!!includeArchived"

--- a/packages/frontend-2/pages/projects/[id]/models/index.vue
+++ b/packages/frontend-2/pages/projects/[id]/models/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="project">
-      <ProjectModelsPageHeader
+      <ProjectPageModelsHeader
         v-model:selected-apps="selectedApps"
         v-model:selected-members="selectedMembers"
         v-model:grid-or-list="gridOrList"
@@ -10,7 +10,7 @@
         :disabled="loading"
         class="z-[1] relative"
       />
-      <ProjectModelsPageResults
+      <ProjectPageModelsResults
         v-model:grid-or-list="gridOrList"
         v-model:search="search"
         v-model:loading="loading"


### PR DESCRIPTION
## Description & motivation
While the tabs navigation are being developed, I fixed up the models and discussions pages, so any links here would still work. 

This is a temporary solution until Tab navigation is complete. 

## Changes:
Update pages to use components in new location. 