### PR TITLE
[WBX-389] Change default view to List from Grid

### DIFF
--- a/packages/frontend-2/lib/projects/composables/projectPages.ts
+++ b/packages/frontend-2/lib/projects/composables/projectPages.ts
@@ -16,9 +16,9 @@ export function useProjectPageItemViewType(contentType: string) {
   const viewTypeCookie = useSynchronizedCookie(`projectPage-${contentType}-viewType`)
   const gridOrList = computed({
     get: () =>
-      viewTypeCookie.value === GridListToggleValue.List
-        ? GridListToggleValue.List
-        : GridListToggleValue.Grid,
+      viewTypeCookie.value === GridListToggleValue.Grid
+        ? GridListToggleValue.Grid
+        : GridListToggleValue.List,
     set: (newVal) => {
       viewTypeCookie.value = newVal
     }


### PR DESCRIPTION
## Description & motivation
- It was decided that List view should be the default view for models etc. 
- There is some cookie functionality, but this will not interfere. We check for the cookie, if it has been set to grid, the user will still get grid. If no preference for grid, we'll now show list. 

## Changes:
- Update useProjectPageItemViewType to default to List