### PR TITLE
Bugfix - Remove translate which caused problems in certain views

### DIFF
--- a/packages/frontend-2/components/viewer/GlobalFilterReset.vue
+++ b/packages/frontend-2/components/viewer/GlobalFilterReset.vue
@@ -1,7 +1,7 @@
 <template>
   <div
+    v-if="hasAnyFiltersApplied"
     class="bg-pink-300/0 flex justify-center items-center pointer-events-none transition-all duration-300 ease-in overflow-hidden h-8"
-    :class="hasAnyFiltersApplied ? 'translate-y-0' : 'translate-y-16'"
   >
     <FormButton size="sm" class="pointer-events-auto" @click="trackAndResetFilters">
       Reset Filters


### PR DESCRIPTION
## Description & motivation
I noticed a bug where the viewer would be skewed when a lot of comments were added, and a filter applied. 

This seems to stem from the animation added to the Reset Filters button. I have removed this, will investigate further in another ticket. 