### PR TITLE
Add breadcrumbs to discussions and models. Temp change to routing

### DIFF
--- a/packages/frontend-2/lib/common/helpers/route.ts
+++ b/packages/frontend-2/lib/common/helpers/route.ts
@@ -22,10 +22,13 @@ export const modelRoute = (
   }`
 export const modelVersionsRoute = (projectId: string, modelId: string) =>
   `/projects/${projectId}/models/${modelId}/versions`
-export const allProjectModelsRoute = (projectId: string) =>
-  `/projects/${projectId}/models`
-export const projectDiscussionsRoute = (projectId: string) =>
-  `/projects/${projectId}/discussions`
+
+// Temp change to allProjectModelsRoute until tab routing is implemented
+export const allProjectModelsRoute = (projectId: string) => `/projects/${projectId}`
+
+// Temp change to projectDiscussionsRoute until tab routing is implemented
+export const projectDiscussionsRoute = (projectId: string) => `/projects/${projectId}`
+
 export const projectWebhooksRoute = (projectId: string) =>
   `/projects/${projectId}/webhooks`
 

--- a/packages/frontend-2/pages/projects/[id]/discussions.vue
+++ b/packages/frontend-2/pages/projects/[id]/discussions.vue
@@ -3,6 +3,7 @@
     <div>
       <Portal to="navigation">
         <HeaderNavLink
+          v-if="project"
           :to="projectRoute(project.id)"
           :name="project.name"
         ></HeaderNavLink>

--- a/packages/frontend-2/pages/projects/[id]/discussions.vue
+++ b/packages/frontend-2/pages/projects/[id]/discussions.vue
@@ -1,5 +1,14 @@
 <template>
   <div>
+    <div>
+      <Portal to="navigation">
+        <HeaderNavLink
+          :to="projectRoute(project.id)"
+          :name="project.name"
+        ></HeaderNavLink>
+      </Portal>
+    </div>
+
     <div v-if="project">
       <ProjectPageDiscussionsHeader
         v-model:grid-or-list="gridOrList"
@@ -17,6 +26,7 @@
 <script setup lang="ts">
 import { useQuery } from '@vue/apollo-composable'
 import type { Optional } from '~~/../shared/dist-esm'
+import { projectRoute } from '~~/lib/common/helpers/route'
 import {
   useGeneralProjectPageUpdateTracking,
   useProjectPageItemViewType

--- a/packages/frontend-2/pages/projects/[id]/models/index.vue
+++ b/packages/frontend-2/pages/projects/[id]/models/index.vue
@@ -1,5 +1,14 @@
 <template>
   <div>
+    <div>
+      <Portal to="navigation">
+        <HeaderNavLink
+          :to="projectRoute(project.id)"
+          :name="project.name"
+        ></HeaderNavLink>
+      </Portal>
+    </div>
+
     <div v-if="project">
       <ProjectPageModelsHeader
         v-model:selected-apps="selectedApps"
@@ -25,6 +34,7 @@
 </template>
 <script setup lang="ts">
 import { useQuery } from '@vue/apollo-composable'
+import { projectRoute } from '~~/lib/common/helpers/route'
 import type { SourceAppDefinition } from '@speckle/shared'
 import type { FormUsersSelectItemFragment } from '~~/lib/common/generated/gql/graphql'
 import { projectModelsPageQuery } from '~~/lib/projects/graphql/queries'

--- a/packages/frontend-2/pages/projects/[id]/models/index.vue
+++ b/packages/frontend-2/pages/projects/[id]/models/index.vue
@@ -3,6 +3,7 @@
     <div>
       <Portal to="navigation">
         <HeaderNavLink
+          v-if="project"
           :to="projectRoute(project.id)"
           :name="project.name"
         ></HeaderNavLink>


### PR DESCRIPTION
## Changes:
- Update projectDiscussionsRoute & allProjectModelsRoute so they go to project page. This is temporary until the Tab routing is done. 
- Add breadcrumbs to both models and discussions page, incase someone has a bookmark saved, they can still use breadcrumbs to navigate. 