### PR TITLE
feat(fe2): FE2 viewer SSR optimizations

### DIFF
--- a/packages/frontend-2/components/header/NavBar.vue
+++ b/packages/frontend-2/components/header/NavBar.vue
@@ -10,11 +10,15 @@
             :separator="true"
             class="hidden md:inline-block"
           />
-          <PortalTarget name="navigation"></PortalTarget>
+          <ClientOnly>
+            <PortalTarget name="navigation"></PortalTarget>
+          </ClientOnly>
         </div>
         <div class="flex items-center gap-2.5 sm:gap-2">
-          <PortalTarget name="secondary-actions"></PortalTarget>
-          <PortalTarget name="primary-actions"></PortalTarget>
+          <ClientOnly>
+            <PortalTarget name="secondary-actions"></PortalTarget>
+            <PortalTarget name="primary-actions"></PortalTarget>
+          </ClientOnly>
           <!-- Notifications dropdown -->
           <HeaderNavNotifications />
           <FormButton

--- a/packages/frontend-2/components/viewer/PreSetupWrapper.vue
+++ b/packages/frontend-2/components/viewer/PreSetupWrapper.vue
@@ -13,75 +13,75 @@
           </ViewerScope>
         </Portal>
 
-        <ClientOnly>
-          <!-- Tour host -->
-          <div
-            v-if="showTour"
-            class="fixed w-full h-[100dvh] flex justify-center items-center pointer-events-none z-[100]"
-          >
-            <TourOnboarding />
-          </div>
-          <!-- Viewer host -->
-          <div
-            class="viewer special-gradient absolute z-10 overflow-hidden w-screen"
-            :class="
-              isEmbedEnabled
-                ? isTransparent
-                  ? 'viewer-transparent h-[100dvh]'
-                  : 'h-[calc(100dvh-3.5rem)]'
-                : 'h-[100dvh]'
-            "
-          >
+        <!-- Tour host -->
+        <div
+          v-if="showTour"
+          class="fixed w-full h-[100dvh] flex justify-center items-center pointer-events-none z-[100]"
+        >
+          <TourOnboarding />
+        </div>
+        <!-- Viewer host -->
+        <div
+          class="viewer special-gradient absolute z-10 overflow-hidden w-screen"
+          :class="
+            isEmbedEnabled
+              ? isTransparent
+                ? 'viewer-transparent h-[100dvh]'
+                : 'h-[calc(100dvh-3.5rem)]'
+              : 'h-[100dvh]'
+          "
+        >
+          <ClientOnly>
             <ViewerBase />
-            <Transition
-              enter-from-class="opacity-0"
-              enter-active-class="transition duration-1000"
-            >
-              <ViewerAnchoredPoints v-show="showControls" />
-            </Transition>
-          </div>
-
-          <!-- Global loading bar -->
-          <ViewerLoadingBar class="relative z-20" />
-
-          <!-- Sidebar controls -->
+          </ClientOnly>
           <Transition
             enter-from-class="opacity-0"
             enter-active-class="transition duration-1000"
           >
-            <ViewerControls v-show="showControls" class="relative z-20" />
+            <ViewerAnchoredPoints v-show="showControls" />
           </Transition>
+        </div>
 
-          <!-- Viewer Object Selection Info Display -->
-          <Transition
-            v-if="!hideSelectionInfo"
-            enter-from-class="opacity-0"
-            enter-active-class="transition duration-1000"
-          >
-            <div v-show="showControls">
-              <ViewerSelectionSidebar class="z-20" />
-            </div>
-          </Transition>
-          <div
-            class="absolute z-10 w-screen px-8 grid grid-cols-1 sm:grid-cols-3 gap-2"
-            :class="isEmbedEnabled ? 'bottom-16 mb-1' : 'bottom-6'"
-          >
-            <div class="flex items-end justify-center sm:justify-start">
-              <PortalTarget name="pocket-left"></PortalTarget>
-            </div>
-            <div class="flex flex-col gap-2 items-center justify-end">
-              <PortalTarget name="pocket-tip"></PortalTarget>
-              <div class="flex gap-3">
-                <PortalTarget name="pocket-actions"></PortalTarget>
-                <!-- Shows up when filters are applied for an easy return to normality -->
-                <ViewerGlobalFilterReset class="z-20" :embed="!!isEmbedEnabled" />
-              </div>
-            </div>
-            <div class="flex items-end justify-center sm:justify-end">
-              <PortalTarget name="pocket-right"></PortalTarget>
+        <!-- Global loading bar -->
+        <ViewerLoadingBar class="relative z-20" />
+
+        <!-- Sidebar controls -->
+        <Transition
+          enter-from-class="opacity-0"
+          enter-active-class="transition duration-1000"
+        >
+          <ViewerControls v-show="showControls" class="relative z-20" />
+        </Transition>
+
+        <!-- Viewer Object Selection Info Display -->
+        <Transition
+          v-if="!hideSelectionInfo"
+          enter-from-class="opacity-0"
+          enter-active-class="transition duration-1000"
+        >
+          <div v-show="showControls">
+            <ViewerSelectionSidebar class="z-20" />
+          </div>
+        </Transition>
+        <div
+          class="absolute z-10 w-screen px-8 grid grid-cols-1 sm:grid-cols-3 gap-2"
+          :class="isEmbedEnabled ? 'bottom-16 mb-1' : 'bottom-6'"
+        >
+          <div class="flex items-end justify-center sm:justify-start">
+            <PortalTarget name="pocket-left"></PortalTarget>
+          </div>
+          <div class="flex flex-col gap-2 items-center justify-end">
+            <PortalTarget name="pocket-tip"></PortalTarget>
+            <div class="flex gap-3">
+              <PortalTarget name="pocket-actions"></PortalTarget>
+              <!-- Shows up when filters are applied for an easy return to normality -->
+              <ViewerGlobalFilterReset class="z-20" :embed="!!isEmbedEnabled" />
             </div>
           </div>
-        </ClientOnly>
+          <div class="flex items-end justify-center sm:justify-end">
+            <PortalTarget name="pocket-right"></PortalTarget>
+          </div>
+        </div>
       </div>
     </ViewerPostSetupWrapper>
     <ViewerEmbedFooter

--- a/packages/frontend-2/components/viewer/Sidebar.vue
+++ b/packages/frontend-2/components/viewer/Sidebar.vue
@@ -106,23 +106,25 @@ const startResizing = (event: MouseEvent) => {
   startWidth = width.value
 }
 
-useEventListener(resizeHandle, 'mousedown', startResizing)
+if (process.client) {
+  useEventListener(resizeHandle, 'mousedown', startResizing)
 
-useEventListener(document, 'mousemove', (event) => {
-  if (isResizing.value) {
-    const diffX = startX - event.clientX
-    width.value = Math.max(
-      300,
-      Math.min(startWidth + diffX, (parseInt('75vw') * window.innerWidth) / 100)
-    )
-  }
-})
+  useEventListener(document, 'mousemove', (event) => {
+    if (isResizing.value) {
+      const diffX = startX - event.clientX
+      width.value = Math.max(
+        300,
+        Math.min(startWidth + diffX, (parseInt('75vw') * window.innerWidth) / 100)
+      )
+    }
+  })
 
-useEventListener(document, 'mouseup', () => {
-  if (isResizing.value) {
-    isResizing.value = false
-  }
-})
+  useEventListener(document, 'mouseup', () => {
+    if (isResizing.value) {
+      isResizing.value = false
+    }
+  })
+}
 
 const minimize = () => {
   width.value = 300

--- a/packages/frontend-2/components/viewer/embed/Footer.vue
+++ b/packages/frontend-2/components/viewer/embed/Footer.vue
@@ -1,33 +1,32 @@
 <template>
-  <ClientOnly>
-    <div
-      v-if="isEmbedEnabled"
-      class="select-none fixed bottom-0 left-0 w-full z-20 flex gap-3 px-4 h-14 items-center"
-      :class="isTransparent ? 'bg-transparent' : 'bg-foundation'"
-    >
-      <HeaderLogoBlock
-        large-icon
-        to="https://speckle.systems/"
-        target="_blank"
-        show-text-on-mobile
-        :active="false"
-      />
-      <div class="h-6 w-px bg-outline-3"></div>
-      <div class="flex flex-col">
-        <NuxtLink :to="url" target="_blank" class="leading-3">
-          <div class="flex items-center gap-1 w-full">
-            <h2 class="font-bold text-base text-sm truncate text-foreground">
-              {{ name }}
-            </h2>
-            <ArrowTopRightOnSquareIcon class="h-3 w-3" />
-          </div>
-          <span v-if="date" class="text-xs text-foreground-2">
-            {{ date }}
-          </span>
-        </NuxtLink>
-      </div>
+  <div
+    v-if="isEmbedEnabled"
+    class="select-none fixed bottom-0 left-0 w-full z-20 flex gap-3 px-4 h-14 items-center"
+    :class="isTransparent ? 'bg-transparent' : 'bg-foundation'"
+  >
+    <HeaderLogoBlock
+      large-icon
+      to="https://speckle.systems/"
+      target="_blank"
+      show-text-on-mobile
+      :active="false"
+    />
+    <div class="h-6 w-px bg-outline-3"></div>
+    <div class="flex flex-col">
+      <NuxtLink :to="url" target="_blank" class="leading-3">
+        <div class="flex items-center gap-1 w-full">
+          <h2 class="font-bold text-base text-sm truncate text-foreground">
+            {{ name }}
+          </h2>
+          <ArrowTopRightOnSquareIcon class="h-3 w-3" />
+        </div>
+        <span v-if="date" class="text-xs text-foreground-2">
+          {{ date }}
+        </span>
+      </NuxtLink>
     </div>
-  </ClientOnly>
+  </div>
+  <div v-else />
 </template>
 
 <script setup lang="ts">

--- a/packages/frontend-2/components/viewer/resources/VersionCard.vue
+++ b/packages/frontend-2/components/viewer/resources/VersionCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <button
+  <div
     :class="`bg-foundation group relative block w-full space-y-2 rounded-md pb-2 text-left transition ${
       clickable
         ? 'hover:bg-gray-100 dark:hover:bg-gray-700'
@@ -8,6 +8,7 @@
     ${isLoaded ? '' : ''}
     `"
     @click="handleClick"
+    @keypress="keyboardClick(handleClick)"
   >
     <!-- Timeline left border -->
     <div
@@ -66,10 +67,11 @@
         </div>
       </div>
     </div>
-  </button>
+  </div>
 </template>
 <script setup lang="ts">
 import { ChevronDownIcon } from '@heroicons/vue/24/solid'
+import { keyboardClick } from '@speckle/ui-components'
 import dayjs from 'dayjs'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import type { ViewerModelVersionCardItemFragment } from '~~/lib/common/generated/gql/graphql'

--- a/packages/frontend-2/layouts/viewer.vue
+++ b/packages/frontend-2/layouts/viewer.vue
@@ -16,14 +16,12 @@
       <!-- <span>{{ tourState }}</span> -->
     </div>
 
-    <ClientOnly>
-      <Transition
-        enter-from-class="opacity-0"
-        enter-active-class="transition duration-1000"
-      >
-        <HeaderNavBar v-show="showNavbar" class="relative z-20 mb-6" />
-      </Transition>
-    </ClientOnly>
+    <Transition
+      enter-from-class="opacity-0"
+      enter-active-class="transition duration-1000"
+    >
+      <HeaderNavBar v-show="showNavbar" class="relative z-20 mb-6" />
+    </Transition>
     <main class="absolute top-0 left-0 z-10 h-[100dvh] w-screen">
       <slot />
     </main>

--- a/packages/frontend-2/lib/core/helpers/apolloSetup.ts
+++ b/packages/frontend-2/lib/core/helpers/apolloSetup.ts
@@ -92,6 +92,7 @@ export function buildAbstractCollectionMergeFunction<T extends string>(
     }
 
     return {
+      ...(incoming || {}),
       __typename: incoming?.__typename || existing?.__typename || typeName,
       totalCount: incoming.totalCount || 0,
       cursor: incoming.cursor || null,

--- a/packages/frontend-2/lib/viewer/composables/setup.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup.ts
@@ -66,6 +66,7 @@ import {
   useSetupViewerScope
 } from '~/lib/viewer/composables/setup/core'
 import { useSynchronizedCookie } from '~~/lib/common/composables/reactiveCookie'
+import { buildManualPromise } from '@speckle/ui-components'
 
 export type LoadedModel = NonNullable<
   Get<ViewerLoadedResourcesQuery, 'project.models.items[0]'>
@@ -164,6 +165,14 @@ export type InjectableViewerState = Readonly<{
       resourceItemsQueryVariables: ComputedRef<
         Optional<ProjectViewerResourcesQueryVariables>
       >
+      /**
+       * Whether or not the initial resource items load has happened (useful in SSR)
+       */
+      resourceItemsLoaded: ComputedRef<boolean>
+      /**
+       * Whether or not the initial resources (models, objects etc.) have been loaded (useful in SSR)
+       */
+      resourcesLoaded: ComputedRef<boolean>
       /**
        * Model GQL objects paired with their loaded version IDs
        */
@@ -391,7 +400,20 @@ function setupInitialState(params: UseSetupViewerParams): InitialSetupState {
     projectId,
     sessionId,
     viewer: process.server
-      ? (undefined as unknown as InitialSetupState['viewer'])
+      ? ({
+          instance: undefined,
+          container: undefined,
+          init: {
+            promise: new Promise(() => {}),
+            ref: computed(() => false)
+          },
+          metadata: {
+            worldTree: computed(() => undefined),
+            availableFilters: computed(() => undefined),
+            views: computed(() => []),
+            filteringState: computed(() => undefined)
+          }
+        } as unknown as InitialSetupState['viewer'])
       : {
           instance,
           container,
@@ -504,7 +526,7 @@ function setupResponseResourceItems(
   state: InitialStateWithRequest
 ): Pick<
   InjectableViewerState['resources']['response'],
-  'resourceItems' | 'resourceItemsQueryVariables'
+  'resourceItems' | 'resourceItemsQueryVariables' | 'resourceItemsLoaded'
 > {
   const globalError = useError()
   const {
@@ -514,10 +536,12 @@ function setupResponseResourceItems(
     }
   } = state
 
+  const initLoadDone = ref(process.server ? false : true)
   const {
     result: resolvedResourcesResult,
     variables: resourceItemsQueryVariables,
-    onError
+    onError,
+    onResult
   } = useQuery(
     projectViewerResourcesQuery,
     () => ({
@@ -532,6 +556,11 @@ function setupResponseResourceItems(
       statusCode: 500,
       message: `Viewer resource resolution failed: ${err}`
     })
+    initLoadDone.value = true
+  })
+
+  onResult(() => {
+    initLoadDone.value = true
   })
 
   const resolvedResourceGroups = computed(
@@ -599,9 +628,12 @@ function setupResponseResourceItems(
     return finalItems
   })
 
+  const resourceItemsLoaded = computed(() => initLoadDone.value)
+
   return {
     resourceItems,
-    resourceItemsQueryVariables: computed(() => resourceItemsQueryVariables.value)
+    resourceItemsQueryVariables: computed(() => resourceItemsQueryVariables.value),
+    resourceItemsLoaded
   }
 }
 
@@ -610,7 +642,7 @@ function setupResponseResourceData(
   resourceItemsData: ReturnType<typeof setupResponseResourceItems>
 ): Omit<
   InjectableViewerState['resources']['response'],
-  'resourceItems' | 'resourceItemsQueryVariables'
+  'resourceItems' | 'resourceItemsQueryVariables' | 'resourceItemsLoaded'
 > {
   const apollo = useApolloClient().client
   const globalError = useError()
@@ -624,8 +656,9 @@ function setupResponseResourceData(
     },
     urlHashState: { diff }
   } = state
-  const { resourceItems } = resourceItemsData
+  const { resourceItems, resourceItemsLoaded } = resourceItemsData
 
+  const initLoadDone = ref(process.server ? false : true)
   const objects = computed(() =>
     resourceItems.value.filter((i) => !i.modelId && !i.versionId)
   )
@@ -667,10 +700,29 @@ function setupResponseResourceData(
     result: viewerLoadedResourcesResult,
     variables: viewerLoadedResourcesVariables,
     onError: onViewerLoadedResourcesError,
-    onResult: onViewerLoadedResourcesResult
+    onResult: onViewerLoadedResourcesResult,
+    refetch
   } = useQuery(viewerLoadedResourcesQuery, viewerLoadedResourcesVariablesFunc, {
     keepPreviousResult: true
   })
+
+  const serverResourcesLoadedPromise = buildManualPromise<void>()
+  if (process.server) {
+    watch(
+      () => resourceItemsLoaded.value,
+      async (newVal, oldVal) => {
+        if (!newVal || oldVal) return
+
+        // Reload query once previous query has loaded - unfortunately I can't get this to work without weird promise hacks,
+        // for some reason the query doesn't update if I just update the variables/options
+        await refetch(viewerLoadedResourcesVariablesFunc())
+        serverResourcesLoadedPromise.resolve()
+      },
+      { flush: 'sync' }
+    )
+  } else {
+    serverResourcesLoadedPromise.resolve()
+  }
 
   const project = computed(() => viewerLoadedResourcesResult.value?.project)
   const models = computed(() => project.value?.models?.items || [])
@@ -707,10 +759,12 @@ function setupResponseResourceData(
       statusCode: 500,
       message: `Viewer loaded resource resolution failed: ${err}`
     })
+    initLoadDone.value = true
   })
 
   // Load initial batch of cursors for each model
   onViewerLoadedResourcesResult((res) => {
+    initLoadDone.value = true
     if (!res.data?.project?.models) return
 
     for (const model of res.data.project.models.items) {
@@ -757,6 +811,7 @@ function setupResponseResourceData(
   const {
     result: viewerLoadedThreadsResult,
     onError: onViewerLoadedThreadsError,
+    onResult: onViewerLoadadThredsResult,
     variables: threadsQueryVariables
   } = useQuery(
     viewerLoadedThreadsQuery,
@@ -784,6 +839,22 @@ function setupResponseResourceData(
     logger.error(err)
   })
 
+  const threadsLoadedPromise = buildManualPromise<void>()
+  if (process.server) {
+    onViewerLoadadThredsResult(() => {
+      threadsLoadedPromise.resolve()
+    })
+  } else {
+    threadsLoadedPromise.resolve()
+  }
+
+  onServerPrefetch(async () => {
+    await Promise.all([
+      threadsLoadedPromise.promise,
+      serverResourcesLoadedPromise.promise
+    ])
+  })
+
   return {
     objects,
     commentThreads,
@@ -793,7 +864,8 @@ function setupResponseResourceData(
     project,
     resourceQueryVariables: computed(() => viewerLoadedResourcesVariables.value),
     threadsQueryVariables: computed(() => threadsQueryVariables.value),
-    loadMoreVersions
+    loadMoreVersions,
+    resourcesLoaded: computed(() => initLoadDone.value)
   }
 }
 

--- a/packages/frontend-2/package.json
+++ b/packages/frontend-2/package.json
@@ -20,7 +20,7 @@
     "gqlgen:watch": "graphql-codegen --watch"
   },
   "dependencies": {
-    "@apollo/client": "^3.8.4",
+    "@apollo/client": "^3.9.6",
     "@artmizu/nuxt-prometheus": "^2.2.1",
     "@headlessui/vue": "^1.7.13",
     "@heroicons/vue": "^2.0.12",
@@ -44,8 +44,8 @@
     "@tiptap/pm": "2.0.0-beta.220",
     "@tiptap/suggestion": "2.0.0-beta.220",
     "@tiptap/vue-3": "2.0.0-beta.220",
-    "@vue/apollo-composable": "4.0.0-beta.11",
-    "@vue/apollo-ssr": "4.0.0-beta.9",
+    "@vue/apollo-composable": "4.0.2",
+    "@vue/apollo-ssr": "4.0.0",
     "@vueuse/core": "^9.13.0",
     "apollo-upload-client": "^17.0.0",
     "dayjs": "^1.11.7",

--- a/packages/ui-components/src/composables/common/async.ts
+++ b/packages/ui-components/src/composables/common/async.ts
@@ -65,3 +65,20 @@ export function writableAsyncComputed<T>(
 
   return getter
 }
+
+/**
+ * Build promise that can be resolved/rejected manually outside of the promise's execution scope
+ */
+export const buildManualPromise = <T>() => {
+  let resolve: (value: T) => void
+  let reject: (reason?: any) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  const resolveWrapper: typeof resolve = (...args) => resolve(...args)
+  const rejectWrapper: typeof reject = (...args) => reject(...args)
+
+  return { promise, resolve: resolveWrapper, reject: rejectWrapper }
+}

--- a/packages/ui-components/src/lib.ts
+++ b/packages/ui-components/src/lib.ts
@@ -59,7 +59,10 @@ import InfiniteLoading from '~~/src/components/InfiniteLoading.vue'
 import type { InfiniteLoaderState } from '~~/src/helpers/global/components'
 import LayoutPanel from '~~/src/components/layout/Panel.vue'
 import CommonAlert from '~~/src/components/common/Alert.vue'
-import { writableAsyncComputed } from '~~/src/composables/common/async'
+import {
+  writableAsyncComputed,
+  buildManualPromise
+} from '~~/src/composables/common/async'
 import type {
   AsyncWritableComputedOptions,
   AsyncWritableComputedRef
@@ -138,7 +141,8 @@ export {
   writableAsyncComputed,
   useFormCheckboxModel,
   FormTags,
-  keyboardClick
+  keyboardClick,
+  buildManualPromise
 }
 export type {
   ToastNotification,

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,7 +53,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:^3.6.6, @apollo/client@npm:^3.7.0, @apollo/client@npm:^3.7.14, @apollo/client@npm:^3.8.4":
+"@apollo/client@npm:^3.6.6, @apollo/client@npm:^3.7.0, @apollo/client@npm:^3.7.14":
   version: 3.8.4
   resolution: "@apollo/client@npm:3.8.4"
   dependencies:
@@ -86,6 +86,43 @@ __metadata:
     subscriptions-transport-ws:
       optional: true
   checksum: 509e37cdce7462cacda0a86c413ce471cd8f618625fb8ac3a60d6347d12f37a4fc60e12fc3fc1a375799caa21e56ff58d709e13ef5e13ab15e4dfc828a527848
+  languageName: node
+  linkType: hard
+
+"@apollo/client@npm:^3.9.6":
+  version: 3.9.6
+  resolution: "@apollo/client@npm:3.9.6"
+  dependencies:
+    "@graphql-typed-document-node/core": ^3.1.1
+    "@wry/caches": ^1.0.0
+    "@wry/equality": ^0.5.6
+    "@wry/trie": ^0.5.0
+    graphql-tag: ^2.12.6
+    hoist-non-react-statics: ^3.3.2
+    optimism: ^0.18.0
+    prop-types: ^15.7.2
+    rehackt: 0.0.6
+    response-iterator: ^0.2.6
+    symbol-observable: ^4.0.0
+    ts-invariant: ^0.10.3
+    tslib: ^2.3.0
+    zen-observable-ts: ^1.2.5
+  peerDependencies:
+    graphql: ^15.0.0 || ^16.0.0
+    graphql-ws: ^5.5.5
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+  peerDependenciesMeta:
+    graphql-ws:
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+    subscriptions-transport-ws:
+      optional: true
+  checksum: d862719bbc0879218c6bbcddbf1934ffab91daa38e4ebe7658a2bae8258f69343c9de93960114f78f67bdafcabbfd327416c8f24d9a0c2b90813e4ffa25ae45c
   languageName: node
   linkType: hard
 
@@ -13805,7 +13842,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@speckle/frontend-2@workspace:packages/frontend-2"
   dependencies:
-    "@apollo/client": ^3.8.4
+    "@apollo/client": ^3.9.6
     "@artmizu/nuxt-prometheus": ^2.2.1
     "@babel/core": ^7.19.6
     "@babel/preset-env": ^7.19.4
@@ -13852,8 +13889,8 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.38.1
     "@typescript-eslint/parser": ^5.38.1
     "@vitejs/plugin-legacy": ^4.0.3
-    "@vue/apollo-composable": 4.0.0-beta.11
-    "@vue/apollo-ssr": 4.0.0-beta.9
+    "@vue/apollo-composable": 4.0.2
+    "@vue/apollo-ssr": 4.0.0
     "@vueuse/core": ^9.13.0
     apollo-upload-client: ^17.0.0
     autoprefixer: ^10.4.14
@@ -18689,9 +18726,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/apollo-composable@npm:4.0.0-beta.11":
-  version: 4.0.0-beta.11
-  resolution: "@vue/apollo-composable@npm:4.0.0-beta.11"
+"@vue/apollo-composable@npm:4.0.2":
+  version: 4.0.2
+  resolution: "@vue/apollo-composable@npm:4.0.2"
   dependencies:
     throttle-debounce: ^5.0.0
     ts-essentials: ^9.4.0
@@ -18704,7 +18741,7 @@ __metadata:
   peerDependenciesMeta:
     "@vue/composition-api":
       optional: true
-  checksum: c68771158d1362804c14ad872943b4f549b3f3842de7b9ba2ef21a11e012c7dd71ce7bbc8bed5fbd79ee26a402efee2263e9985b1cac9da0a0a1a8ec3ef66a6c
+  checksum: cb66ba92f179dd81b820c319d22897a1e039922c708ddf66517c67e7c2ed5257bcc5b602ab43b916c5615f50c8e06398851a244eb554ad4c3fb4fb07e81f61ae
   languageName: node
   linkType: hard
 
@@ -18758,12 +18795,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/apollo-ssr@npm:4.0.0-beta.9":
-  version: 4.0.0-beta.9
-  resolution: "@vue/apollo-ssr@npm:4.0.0-beta.9"
+"@vue/apollo-ssr@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@vue/apollo-ssr@npm:4.0.0"
   dependencies:
     serialize-javascript: ^6.0.1
-  checksum: 493a1cae1e900754d3f3117f7a82d17ea0a8c2708923f9264f78f5821ce4380f8893f19a00a257de3f2e50f02ac25a425d57ba8a902767c59c81d975559c4303
+  checksum: e9a82bc27ad5ea464f0b9fb30edc7bae03b399bd3c7c8192652a00df5a0f77bf306a911ccf00e060aa72b7bd395eb5cc5abb35c60132f64387ff5ed5526e47e2
   languageName: node
   linkType: hard
 
@@ -19688,6 +19725,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wry/caches@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@wry/caches@npm:1.0.1"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 9e89aa8e9e08577b2e4acbe805f406b141ae49c2ac4a2e22acf21fbee68339fa0550e0dee28cf2158799f35bb812326e80212e49e2afd169f39f02ad56ae4ef4
+  languageName: node
+  linkType: hard
+
 "@wry/context@npm:^0.7.0":
   version: 0.7.0
   resolution: "@wry/context@npm:0.7.0"
@@ -19721,6 +19767,15 @@ __metadata:
   dependencies:
     tslib: ^2.3.0
   checksum: 106e021125cfafd22250a6631a0438a6a3debae7bd73f6db87fe42aa0757fe67693db0dfbe200ae1f60ba608c3e09ddb8a4e2b3527d56ed0a7e02aa0ee4c94e1
+  languageName: node
+  linkType: hard
+
+"@wry/trie@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@wry/trie@npm:0.5.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 92aeea34152bd8485184236fe328d3d05fc98ee3b431d82ee60cf3584dbf68155419c3d65d0ff3731b204ee79c149440a9b7672784a545afddc8d4342fbf21c9
   languageName: node
   linkType: hard
 
@@ -37056,6 +37111,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"optimism@npm:^0.18.0":
+  version: 0.18.0
+  resolution: "optimism@npm:0.18.0"
+  dependencies:
+    "@wry/caches": ^1.0.0
+    "@wry/context": ^0.7.0
+    "@wry/trie": ^0.4.3
+    tslib: ^2.3.0
+  checksum: d6ed6a90b05ee886dadfe556c7a30227c66843f51278e51eb843977a6a9368b6c50297fcc63fa514f53d8a5a58f8ddc8049c2356bd4ffac32f8961bcb806254d
+  languageName: node
+  linkType: hard
+
 "optionator@npm:^0.8.1":
   version: 0.8.3
   resolution: "optionator@npm:0.8.3"
@@ -40693,6 +40760,21 @@ __metadata:
   bin:
     regjsparser: bin/parser
   checksum: 5e1b76afe8f1d03c3beaf9e0d935dd467589c3625f6d65fb8ffa14f224d783a0fed4bf49c2c1b8211043ef92b6117313419edf055a098ed8342e340586741afc
+  languageName: node
+  linkType: hard
+
+"rehackt@npm:0.0.6":
+  version: 0.0.6
+  resolution: "rehackt@npm:0.0.6"
+  peerDependencies:
+    "@types/react": "*"
+    react: "*"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+  checksum: 25df31d4fc1198b5beba68ec3c960119f120aeba4f7a6f686b087ddbfdd45753ea74b6daf66523c8b6db844429eaed516e0f6f37f657fdcc96334e5ae9efee98
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. Removed unnecessary ClientOnly templates that prevented SSR from being able to pre-render the page and causing a bigger LCP
2. Fixed issues with GQL queries loaded during SSR that previously caused the same queries to be pulled again during CSR, causing longer loading and a bigger CSR