### PR TITLE
FE2 - Give New Speckle Banner priority over Feedback Banner

### DIFF
--- a/packages/frontend-2/components/projects/Dashboard.vue
+++ b/packages/frontend-2/components/projects/Dashboard.vue
@@ -346,6 +346,7 @@ const showFeedbackRequest = computed(() => {
     storedDateString = formattedDate
   }
 
+  if (showNewSpeckleBanner.value) return false
   if (hasDismissedOrOpenedFeedback.value) return false
   if (showChecklist.value) return false
   if (projectsPanelResult?.value?.activeUser?.projectInvites.length) return false
@@ -359,7 +360,6 @@ const showFeedbackRequest = computed(() => {
 const showNewSpeckleBanner = computed(() => {
   if (hasDismissedNewSpeckleBanner.value) return false
   if (projectsPanelResult?.value?.activeUser?.projectInvites.length) return false
-  if (showFeedbackRequest.value) return false
 
   return true
 })


### PR DESCRIPTION
Small change from testing. 

The "New Speckle" banner now has priority over the Feedback banner. Previously, a user who had not dismissed the feedback, would not see the New Speckle banner. 