### PR TITLE
Replace YouTube video with Vimeo 

### DIFF
--- a/packages/frontend-2/components/projects/NewSpeckle/Dialog.vue
+++ b/packages/frontend-2/components/projects/NewSpeckle/Dialog.vue
@@ -4,14 +4,33 @@
       What's New in Speckle?
     </h2>
     <p class="text-foreground-2 text-center mb-6">A new way to collaborate in AEC.</p>
-    <div class="aspect-video w-full">
+    <div class="relative bg-white">
+      <div class="absolute inset-0 flex items-center justify-center" role="status">
+        <svg
+          aria-hidden="true"
+          class="w-6 h-6 text-outline-2 animate-spin fill-primary"
+          viewBox="0 0 100 101"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+            fill="currentColor"
+          />
+          <path
+            d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+            fill="currentFill"
+          />
+        </svg>
+        <span class="sr-only">Loading...</span>
+      </div>
       <iframe
-        class="w-full h-full"
-        src="https://www.youtube.com/embed/QI5pVV1GCNs?si=op1o9Ud4fOKsQlWe"
-        title="YouTube video player"
+        title="What's new in Speckle?"
+        src="https://player.vimeo.com/video/925455838?h=052c422cae&autoplay=1&title=0&byline=0&portrait=0&controls=0&muted=1"
         frameborder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allow="autoplay; fullscreen;"
         allowfullscreen
+        class="aspect-video w-full relative z-10"
       ></iframe>
     </div>
   </LayoutDialog>

--- a/packages/frontend-2/components/projects/NewSpeckle/Dialog.vue
+++ b/packages/frontend-2/components/projects/NewSpeckle/Dialog.vue
@@ -26,7 +26,7 @@
       </div>
       <iframe
         title="What's new in Speckle?"
-        src="https://player.vimeo.com/video/925455838?h=052c422cae&autoplay=1&title=0&byline=0&portrait=0&controls=0&muted=1"
+        src="https://player.vimeo.com/video/925455838?h=052c422cae&autoplay=1&title=0&loop=1&byline=0&portrait=0&controls=0&muted=1"
         frameborder="0"
         allow="autoplay; fullscreen;"
         allowfullscreen

--- a/packages/frontend/src/main/dialogs/NewSpeckle.vue
+++ b/packages/frontend/src/main/dialogs/NewSpeckle.vue
@@ -11,16 +11,17 @@
       </div>
       <v-row no-gutters align="center" justify="space-between" class="pa-6">
         <v-col cols="12" md="7">
-          <iframe
-            style="width: 100%; height: 100%; min-height: 250px"
-            src="https://www.youtube.com/embed/QI5pVV1GCNs?si=op1o9Ud4fOKsQlWe"
-            title="YouTube video player"
-            frameborder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            allowfullscreen
-          ></iframe>
+          <div style="padding: 56.25% 0 0 0; position: relative">
+            <iframe
+              src="https://player.vimeo.com/video/925455838?h=052c422cae&autoplay=1&title=0&loop=1&byline=0&portrait=0&controls=0&muted=1"
+              style="position: absolute; top: 0; left: 0; width: 100%; height: 100%"
+              frameborder="0"
+              allow="autoplay; fullscreen;"
+              allowfullscreen
+            ></iframe>
+          </div>
         </v-col>
-        <v-col cols="12" md="5" class="pt-4 pt-md-0 pb-md-2 pl-8">
+        <v-col cols="12" md="5" class="pt-8 pt-md-0 pb-md-2 pl-md-8">
           <h2>What’s New?</h2>
           <div class="d-flex align-center py-2">
             <svg

--- a/packages/frontend/src/main/dialogs/NewSpeckle.vue
+++ b/packages/frontend/src/main/dialogs/NewSpeckle.vue
@@ -16,7 +16,7 @@
               src="https://player.vimeo.com/video/925455838?h=052c422cae&autoplay=1&title=0&loop=1&byline=0&portrait=0&controls=0&muted=1"
               style="position: absolute; top: 0; left: 0; width: 100%; height: 100%"
               frameborder="0"
-              allow="autoplay; fullscreen;"
+              allow="autoplay"
               allowfullscreen
             ></iframe>
           </div>


### PR DESCRIPTION
## Description & motivation
It was decided that pro Vimeo was worth the cost, as it gave us the option of a much cleaner embedded player. The first video we have moved to Vimeo is the "What's new in Speckle" video. 

## Changes:
- Replace FE1 YouTube link with Vimeo Embed
- Replace FE2YouTube link with Vimeo Embed
- Added a background div with spinner, which will show while the video loads

## Screenshots:
https://github.com/specklesystems/speckle-server/assets/139135120/527485c9-8c88-4abc-86a6-a5f270b0dd85

https://github.com/specklesystems/speckle-server/assets/139135120/c202a647-fffd-4e7f-ba91-40d3a878d461