### PR TITLE
fix(fe2): fix console improvements around form elements

### DIFF
--- a/packages/frontend-2/components/common/EditableTitleDescription.vue
+++ b/packages/frontend-2/components/common/EditableTitleDescription.vue
@@ -11,6 +11,7 @@
         >
           <textarea
             v-model="title"
+            name="Title"
             maxlength="512"
             :class="titleInputClasses"
             placeholder="Please enter a valid title"
@@ -42,6 +43,7 @@
         >
           <textarea
             v-model="description"
+            name="Description"
             :class="[
               ...descriptionInputClasses,
               description ? 'focus:min-w-0' : 'min-w-[260px]'

--- a/packages/ui-components/src/components/form/select/Base.vue
+++ b/packages/ui-components/src/components/form/select/Base.vue
@@ -13,6 +13,7 @@
         :id="labelId"
         class="block label text-foreground-2 mb-2"
         :class="{ 'sr-only': !showLabel }"
+        :for="buttonId"
       >
         {{ label }}
       </ListboxLabel>


### PR DESCRIPTION
## Description & motivation
Noticed a few minor 'improvements' that were highlighted in console. After Fabs work to remove all warnings and errors, this clears all messages. 

<img width="640" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/96b59839-1b57-4b49-83a0-6143fb04ca2e">


## Changes:
- Update `FormSelect` in `ui-components` to also add a "for" to labels
- Add title to textareas in `EditableTitleDescription"