### PR TITLE
feat(fe2): dont zoom out when quick measuring in perpendicular mode

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/setup/selection.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/selection.ts
@@ -3,7 +3,7 @@
 import type { SpeckleObject } from '~~/lib/common/helpers/sceneExplorer'
 import { useMixpanel } from '~~/lib/core/composables/mp'
 import { useInjectedViewerState } from '~~/lib/viewer/composables/setup'
-import { useCameraUtilities, useSelectionUtilities } from '~~/lib/viewer/composables/ui'
+import { useSelectionUtilities } from '~~/lib/viewer/composables/ui'
 import { useSelectionEvents } from '~~/lib/viewer/composables/viewer'
 
 function useCollectSelection() {
@@ -26,9 +26,7 @@ function useCollectSelection() {
 function useSelectOrZoomOnSelection() {
   const state = useInjectedViewerState()
   const { clearSelection, addToSelection } = useSelectionUtilities()
-  const { zoom } = useCameraUtilities()
   const mp = useMixpanel()
-  const logger = useLogger()
 
   const trackAndClearSelection = () => {
     clearSelection()
@@ -80,29 +78,6 @@ function useSelectOrZoomOnSelection() {
           name: 'selection',
           action: 'select',
           multiple: args.multiple
-        })
-      },
-      doubleClickCallback: (args, { firstVisibleSelectionHit }) => {
-        if (!args) return zoom()
-        if (!args.hits) return zoom()
-        if (args.hits.length === 0) return zoom()
-
-        const firstVisHit = firstVisibleSelectionHit
-        if (!firstVisHit) return clearSelection()
-
-        if (state.ui.filters.selectedObjects.value.length !== 0) {
-          const ids = state.ui.filters.selectedObjects.value.map((o) => o.id as string)
-          zoom(ids)
-        } // else somethingn is weird.
-        else {
-          logger.warn(
-            "Got a double click event but there's no selected object in the state - this should be impossible :)"
-          )
-        }
-        mp.track('Viewer Action', {
-          type: 'action',
-          name: 'zoom',
-          source: 'object-double-click'
         })
       }
     },

--- a/packages/frontend-2/lib/viewer/composables/setup/selection.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/selection.ts
@@ -3,7 +3,7 @@
 import type { SpeckleObject } from '~~/lib/common/helpers/sceneExplorer'
 import { useMixpanel } from '~~/lib/core/composables/mp'
 import { useInjectedViewerState } from '~~/lib/viewer/composables/setup'
-import { useSelectionUtilities } from '~~/lib/viewer/composables/ui'
+import { useCameraUtilities, useSelectionUtilities } from '~~/lib/viewer/composables/ui'
 import { useSelectionEvents } from '~~/lib/viewer/composables/viewer'
 
 function useCollectSelection() {
@@ -27,6 +27,8 @@ function useSelectOrZoomOnSelection() {
   const state = useInjectedViewerState()
   const { clearSelection, addToSelection } = useSelectionUtilities()
   const mp = useMixpanel()
+  const { zoom } = useCameraUtilities()
+  const logger = useLogger()
 
   const trackAndClearSelection = () => {
     clearSelection()
@@ -78,6 +80,33 @@ function useSelectOrZoomOnSelection() {
           name: 'selection',
           action: 'select',
           multiple: args.multiple
+        })
+      },
+      doubleClickCallback: (args, { firstVisibleSelectionHit }) => {
+        const isMeasureMode = state.ui.measurement.enabled.value
+        if (isMeasureMode) {
+          return
+        }
+        if (!args) return zoom()
+        if (!args.hits) return zoom()
+        if (args.hits.length === 0) return zoom()
+
+        const firstVisHit = firstVisibleSelectionHit
+        if (!firstVisHit) return clearSelection()
+
+        if (state.ui.filters.selectedObjects.value.length !== 0) {
+          const ids = state.ui.filters.selectedObjects.value.map((o) => o.id as string)
+          zoom(ids)
+        } // else somethingn is weird.
+        else {
+          logger.warn(
+            "Got a double click event but there's no selected object in the state - this should be impossible :)"
+          )
+        }
+        mp.track('Viewer Action', {
+          type: 'action',
+          name: 'zoom',
+          source: 'object-double-click'
         })
       }
     },

--- a/packages/frontend-2/lib/viewer/composables/setup/selection.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/selection.ts
@@ -26,8 +26,8 @@ function useCollectSelection() {
 function useSelectOrZoomOnSelection() {
   const state = useInjectedViewerState()
   const { clearSelection, addToSelection } = useSelectionUtilities()
-  const mp = useMixpanel()
   const { zoom } = useCameraUtilities()
+  const mp = useMixpanel()
   const logger = useLogger()
 
   const trackAndClearSelection = () => {

--- a/packages/frontend-2/lib/viewer/composables/setup/selection.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/selection.ts
@@ -85,9 +85,9 @@ function useSelectOrZoomOnSelection() {
       },
       doubleClickCallback: (args, { firstVisibleSelectionHit }) => {
         const isMeasureMode = state.ui.measurement.enabled.value
-        const measureMode = state.ui.measurement.options.value.type
+        const measurementType = state.ui.measurement.options.value.type
 
-        if (isMeasureMode && measureMode === MeasurementType.PERPENDICULAR) {
+        if (isMeasureMode && measurementType === MeasurementType.PERPENDICULAR) {
           return
         }
         if (!args) return zoom()

--- a/packages/frontend-2/lib/viewer/composables/setup/selection.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/selection.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
+import { MeasurementType } from '@speckle/viewer'
 import type { SpeckleObject } from '~~/lib/common/helpers/sceneExplorer'
 import { useMixpanel } from '~~/lib/core/composables/mp'
 import { useInjectedViewerState } from '~~/lib/viewer/composables/setup'
@@ -84,7 +85,9 @@ function useSelectOrZoomOnSelection() {
       },
       doubleClickCallback: (args, { firstVisibleSelectionHit }) => {
         const isMeasureMode = state.ui.measurement.enabled.value
-        if (isMeasureMode) {
+        const measureMode = state.ui.measurement.options.value.type
+
+        if (isMeasureMode && measureMode === MeasurementType.PERPENDICULAR) {
           return
         }
         if (!args) return zoom()


### PR DESCRIPTION
## Description & motivation
[JIRA TICKET
](https://spockle.atlassian.net/browse/WBX-434)

When in measure mode, and perpendicular mode, you can double click to quick measure. This also triggers a zoom, which is not wanted. 

## Changes:
- Check measure mode is enabled
- Check Measurement Type is Perpendicular
- Return when both are not true 