### PR TITLE
fix(fe2): add bg-foundation to segmentation dialogs

### DIFF
--- a/packages/frontend-2/components/tour/Segmentation.vue
+++ b/packages/frontend-2/components/tour/Segmentation.vue
@@ -38,7 +38,7 @@
       <!-- eslint-disable-next-line vuejs-accessibility/mouse-events-have-key-events -->
       <div
         v-show="step === 1"
-        class="bg-white/60 dark:bg-neutral-900/60 border dark:border-neutral-800 text-foreground backdrop-blur shadow-lg rounded-xl p-4 space-y-4 absolute pointer-events-auto mx-2"
+        class="bg-foundation border dark:border-neutral-800 text-foreground backdrop-blur shadow-lg rounded-xl p-4 space-y-4 absolute pointer-events-auto mx-2"
         @mouseenter="rotateGently(Math.random() * 2)"
         @mouseleave="rotateGently(Math.random() * 2)"
       >

--- a/packages/frontend-2/components/tour/Segmentation.vue
+++ b/packages/frontend-2/components/tour/Segmentation.vue
@@ -7,7 +7,7 @@
       <!-- eslint-disable-next-line vuejs-accessibility/mouse-events-have-key-events -->
       <div
         v-show="step === 0"
-        class="border border-outline text-foreground backdrop-blur shadow-lg rounded-xl p-4 space-y-4 absolute pointer-events-auto mx-2"
+        class="border border-outline bg-foundation text-foreground backdrop-blur shadow-lg rounded-xl p-4 space-y-4 absolute pointer-events-auto mx-2"
         @mouseenter="rotateGently(Math.random() * 2)"
         @mouseleave="rotateGently(Math.random() * 2)"
       >

--- a/packages/frontend-2/plugins/survicate.client.ts
+++ b/packages/frontend-2/plugins/survicate.client.ts
@@ -27,7 +27,6 @@ export default defineNuxtPlugin(async () => {
 
   // Skip initialization if the survicateWorkspaceKey is empty or undefined
   if (!survicateWorkspaceKey?.length) {
-    logger.warn('Survicate workspace key is empty, skipping Survicate initialization.')
     return {
       provide: {
         survicate: survicateInstance


### PR DESCRIPTION
## Description & motivation
Reported by Fabians in Discord, it seems the bg colour was dropped in the segmentation dialogs. I have readded

![image](https://github.com/specklesystems/speckle-server/assets/139135120/b6c68cde-9d5d-4927-adf9-0a431c01f68e)