### PR TITLE
bugfix(fe2): remove custom cookie expiration date

### DIFF
--- a/packages/frontend-2/components/projects/Dashboard.vue
+++ b/packages/frontend-2/components/projects/Dashboard.vue
@@ -93,7 +93,6 @@ import { useActiveUser } from '~~/lib/auth/composables/activeUser'
 import type { InfiniteLoaderState } from '~~/lib/global/helpers/components'
 import type { Nullable, Optional, StreamRoles } from '@speckle/shared'
 import { useSynchronizedCookie } from '~~/lib/common/composables/reactiveCookie'
-import dayjs from 'dayjs'
 
 const onUserProjectsUpdateSubscription = graphql(`
   subscription OnUserProjectsUpdate {
@@ -265,15 +264,10 @@ watch(search, (newVal) => {
 
 watch(areQueriesLoading, (newVal) => (showLoadingBar.value = newVal))
 
-function getFutureDateByDays(daysToAdd: number) {
-  return dayjs().add(daysToAdd, 'day').toDate()
-}
-
 const hasCompletedChecklistV1 = useSynchronizedCookie<boolean>(
   `hasCompletedChecklistV1`,
   {
-    default: () => false,
-    expires: getFutureDateByDays(999)
+    default: () => false
   }
 )
 
@@ -285,8 +279,7 @@ const hasDismissedChecklistTime = useSynchronizedCookie<string | undefined>(
 const hasDismissedChecklistForever = useSynchronizedCookie<boolean | undefined>(
   `hasDismissedChecklistForever`,
   {
-    default: () => false,
-    expires: getFutureDateByDays(999)
+    default: () => false
   }
 )
 
@@ -299,7 +292,7 @@ const hasDismissedChecklistTimeAgo = computed(() => {
 
 const hasDismissedNewSpeckleBanner = useSynchronizedCookie<boolean | undefined>(
   `hasDismissedNewSpeckleBanner`,
-  { default: () => false, expires: getFutureDateByDays(999) }
+  { default: () => false }
 )
 
 const showChecklist = computed(() => {

--- a/packages/frontend-2/plugins/survicate.client.ts
+++ b/packages/frontend-2/plugins/survicate.client.ts
@@ -79,8 +79,7 @@ function useInitMainSurvey() {
   const onboardingOrFeedbackDateString = useSynchronizedCookie<string | undefined>(
     'onboardingOrFeedbackDate',
     {
-      default: () => dayjs().startOf('day').format('YYYY-MM-DD'),
-      expires: dayjs().add(999, 'day').toDate()
+      default: () => dayjs().startOf('day').format('YYYY-MM-DD')
     }
   )
   const { projectVersionCount } = useActiveUser()


### PR DESCRIPTION
It was reported that users keep getting the onboarding checklist. While this is not a sure fix, this could fix the issue. We noticed that browsers only allow 400 day cookie expirations, and we were setting it to 999 days. Our cookie plugin already sets a year expiration when no expiration is defined, so this could potentially fix the issue on some browsers. If not, we are at least setting the cookies with an achievable cookie expiration date. 