### PR TITLE
Remove mobile onboarding banners

### DIFF
--- a/packages/frontend-2/components/onboarding/checklist/v1.vue
+++ b/packages/frontend-2/components/onboarding/checklist/v1.vue
@@ -7,19 +7,6 @@
       } ${allCompleted ? 'max-w-lg mx-auto' : ''}`"
     >
       <div>
-        <div class="sm:hidden px-4 pt-2 pb-1">
-          <div
-            class="bg-foundation p-2 rounded-md text-sm flex flex-col text-center gap-2"
-          >
-            <p>
-              There's more to Speckle - be sure to visit on a computer. Since you're on
-              a mobile device, feel free to keep exploring the web app!
-            </p>
-            <FormButton text size="sm" @click="dismissChecklistForever()">
-              Don't show again
-            </FormButton>
-          </div>
-        </div>
         <div
           v-if="!allCompleted"
           :class="`hidden sm:grid gap-2 ${

--- a/packages/frontend-2/components/tour/Onboarding.vue
+++ b/packages/frontend-2/components/tour/Onboarding.vue
@@ -16,13 +16,6 @@
       <div v-if="!isSmallerOrEqualSm" class="relative z-50">
         <OnboardingChecklistV1 show-bottom-escape background @dismiss="step++" />
       </div>
-      <div v-else class="fixed bottom-10 left-0 w-screen z-50 p-10">
-        <div class="bg-foundation p-2 rounded-md text-sm">
-          There's more to Speckle - be sure to visit on a computer. Since you're on a
-          mobile device, feel free to keep exploring the web app!
-          <FormButton class="w-full mt-4" @click="step++">Let's go!</FormButton>
-        </div>
-      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
We're getting rid of these two onboarding messages on mobile. It's not necessary to tell users to check it out again using another device. We can introduce better onboarding on mobile later. 

![image](https://github.com/specklesystems/speckle-server/assets/2694102/927f5445-8ca1-467c-ab1e-aae752dbed20)

![image](https://github.com/specklesystems/speckle-server/assets/2694102/fb3b8e45-26a2-45d9-a613-a284c88d9fe9)
