### PR TITLE
Chore (dui3): remove double call on refresh account

### DIFF
--- a/packages/dui3/store/accounts.ts
+++ b/packages/dui3/store/accounts.ts
@@ -61,6 +61,8 @@ export const useAccountStore = defineStore('accountStore', () => {
   }
 
   const refreshAccounts = async () => {
+    console.log('account refresh called')
+
     isLoading.value = true
     const accs = await $accountBinding.getAccounts()
     const newAccs: DUIAccount[] = []
@@ -97,7 +99,7 @@ export const useAccountStore = defineStore('accountStore', () => {
     void testAccounts()
   })
 
-  void refreshAccounts()
+  // void refreshAccounts()
 
   app.vueApp.provide(ApolloClients, apolloClients)
   return {

--- a/packages/dui3/store/accounts.ts
+++ b/packages/dui3/store/accounts.ts
@@ -61,8 +61,6 @@ export const useAccountStore = defineStore('accountStore', () => {
   }
 
   const refreshAccounts = async () => {
-    console.log('account refresh called')
-
     isLoading.value = true
     const accs = await $accountBinding.getAccounts()
     const newAccs: DUIAccount[] = []

--- a/packages/dui3/store/accounts.ts
+++ b/packages/dui3/store/accounts.ts
@@ -99,8 +99,6 @@ export const useAccountStore = defineStore('accountStore', () => {
     void testAccounts()
   })
 
-  // void refreshAccounts()
-
   app.vueApp.provide(ApolloClients, apolloClients)
   return {
     isLoading,


### PR DESCRIPTION
@didimitrie, we were calling it already in index.vue and await it. We do not necessarily call it in store. It caused some errors on Autocad that sqlite connection was trying to do it twice and they were borking each other. Removing this line seems like harmless, tested in Autocad and Sketchup.