### PR TITLE
fix(dui3/ui-components): optinal css fiddles for ancient chrome versions

### DIFF
--- a/packages/ui-components/src/components/layout/Dialog.vue
+++ b/packages/ui-components/src/components/layout/Dialog.vue
@@ -11,11 +11,11 @@
         leave-to="opacity-0"
       >
         <div
-          class="fixed inset-0 bg-neutral-100/70 dark:bg-neutral-900/70 transition-opacity backdrop-blur-xs"
+          :class="`fixed ${insetClass} bg-neutral-100/70 dark:bg-neutral-900/70 transition-opacity backdrop-blur-xs`"
         />
       </TransitionChild>
 
-      <div class="fixed inset-0 z-10 h-[100dvh] w-screen">
+      <div :class="`fixed ${insetClass} z-10 ${mainHeightClass} w-screen`">
         <div class="flex justify-center items-center h-full w-full p-4 sm:p-0">
           <TransitionChild
             as="template"
@@ -124,6 +124,12 @@ const props = defineProps<{
    * If set, the modal will be wrapped in a form element and the `onSubmit` callback will be invoked when the user submits the form
    */
   onSubmit?: (e: SubmitEvent) => void
+  /**
+   * If set, it will replace inset-0 with top-0, bottom-0, etc. and it will not use dvh units.
+   * This is required as we're using this in DUI3, which needs to work in chromium 65, which does
+   * not support the above. Life is pain.
+   */
+  chromium65Compatibility?: boolean
 }>()
 
 const slots = useSlots()
@@ -138,6 +144,20 @@ const hasTitle = computed(() => props.title || slots.header)
 const open = computed({
   get: () => props.open,
   set: (newVal) => emit('update:open', newVal)
+})
+
+/**
+ * DUI3/Chromium 65 compatibility mode.
+ */
+const insetClass = computed(() => {
+  return props.chromium65Compatibility ? 'inset-0' : 'top-0 bottom-0 right-0 left-0'
+})
+
+/**
+ * DUI3/Chromium 65 compatibility mode.
+ */
+const mainHeightClass = computed(() => {
+  return props.chromium65Compatibility ? 'h-[100vh]' : 'h-[100dvh]'
 })
 
 const maxWidthWeight = computed(() => {


### PR DESCRIPTION
## Description & motivation

DUI3 runs sometimes in an ancient chrome version (65), which does not support the following: 
- `inset` classes
- `dvh` units

This results in unscrollable dialogs in aforementioned ancient chrome version. 

## Changes:

Adds a tiny optional off prop to the layout dialog component, that then does the following: 

- `inset-0` becomes `top-0 bottom-0 right-0 left-0` 
- `dvh` units become `vh` units

cc @andrewwallacespeckle as this is something i'd like to merge in main too! 

