### PR TITLE
Feat(dui3): Enable rendering custom message from DocumentInfo

### DIFF
--- a/packages/dui3/lib/bindings/definitions/IBasicConnectorBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IBasicConnectorBinding.ts
@@ -35,6 +35,7 @@ export type DocumentInfo = {
   location: string
   name: string
   id: string
+  message?: string
 }
 
 export type ToastInfo = {

--- a/packages/dui3/pages/index.vue
+++ b/packages/dui3/pages/index.vue
@@ -42,7 +42,10 @@
           </div>
         </div>
         <div v-else>
-          <div class="text-foreground-2">
+          <div v-if="store.documentInfo?.message" class="text-foreground-2">
+            {{ store.documentInfo?.message }}
+          </div>
+          <div v-else class="text-foreground-2">
             Welcome to Speckle! Please open a file to use this plugin.
           </div>
         </div>


### PR DESCRIPTION
This is needed for revit "Family Environment". We will render custom messages if any that send via connector instead default. If message null we render **"Welcome to Speckle! Please open a file to use this plugin."**

![image](https://github.com/specklesystems/speckle-server/assets/45078678/d0c34288-7d0b-4e6b-ae03-90cc3b6b288e)
