### PR TITLE
bugfix(fe2): Fix conditioning around posting comments in viewer

### DIFF
--- a/packages/frontend-2/components/auth/LoginPanel.vue
+++ b/packages/frontend-2/components/auth/LoginPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <Component
     :is="concreteComponent"
+    v-if="!isLoggedIn"
     fancy-glow
     no-shadow
     class="max-w-lg mx-auto w-full"
@@ -43,6 +44,7 @@
       </div>
     </div>
   </Component>
+  <div v-else />
 </template>
 <script setup lang="ts">
 import { useQuery } from '@vue/apollo-composable'
@@ -67,6 +69,7 @@ const props = withDefaults(
   }
 )
 
+const { isLoggedIn } = useActiveUser()
 const { inviteToken } = useAuthManager()
 const router = useRouter()
 

--- a/packages/frontend-2/components/project/page/latest-items/comments/EmptyState.vue
+++ b/packages/frontend-2/components/project/page/latest-items/comments/EmptyState.vue
@@ -35,7 +35,7 @@
       </svg>
     </template>
     <template #cta>
-      <div v-if="small" class="mt-3">
+      <div v-if="small && canPostComment" class="mt-3">
         <FormButton
           size="sm"
           :icon-left="PlusIcon"
@@ -49,6 +49,7 @@
 </template>
 <script setup lang="ts">
 import { PlusIcon } from '@heroicons/vue/24/solid'
+import { useCheckViewerCommentingAccess } from '~/lib/viewer/composables/commentManagement'
 
 defineEmits<{
   (e: 'new-discussion'): void
@@ -57,4 +58,6 @@ defineEmits<{
 defineProps<{
   small?: boolean
 }>()
+
+const canPostComment = useCheckViewerCommentingAccess()
 </script>

--- a/packages/frontend-2/components/project/page/latest-items/comments/EmptyState.vue
+++ b/packages/frontend-2/components/project/page/latest-items/comments/EmptyState.vue
@@ -35,7 +35,7 @@
       </svg>
     </template>
     <template #cta>
-      <div v-if="small && canPostComment" class="mt-3">
+      <div v-if="small && canPostComment && isLoggedIn" class="mt-3">
         <FormButton
           size="sm"
           :icon-left="PlusIcon"
@@ -60,4 +60,5 @@ defineProps<{
 }>()
 
 const canPostComment = useCheckViewerCommentingAccess()
+const { isLoggedIn } = useActiveUser()
 </script>

--- a/packages/frontend-2/components/project/page/latest-items/comments/EmptyState.vue
+++ b/packages/frontend-2/components/project/page/latest-items/comments/EmptyState.vue
@@ -35,7 +35,7 @@
       </svg>
     </template>
     <template #cta>
-      <div v-if="small && canPostComment && isLoggedIn" class="mt-3">
+      <div v-if="small && canPostComment" class="mt-3">
         <FormButton
           size="sm"
           :icon-left="PlusIcon"
@@ -60,5 +60,4 @@ defineProps<{
 }>()
 
 const canPostComment = useCheckViewerCommentingAccess()
-const { isLoggedIn } = useActiveUser()
 </script>

--- a/packages/frontend-2/components/viewer/AnchoredPoints.vue
+++ b/packages/frontend-2/components/viewer/AnchoredPoints.vue
@@ -212,7 +212,8 @@ const onThreadExpandedChange = (isExpanded: boolean) => {
 }
 
 const shouldShowNewThread = computed(
-  () => !isEmbedEnabled.value && !state.ui.measurement.enabled.value
+  () =>
+    !isEmbedEnabled.value && !state.ui.measurement.enabled.value && canPostComment.value
 )
 
 const allThreadsChronologicalOrder = computed(() => {

--- a/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
@@ -120,12 +120,21 @@ const { isLoggedIn } = useActiveUser()
 
 const onThreadClick = () => {
   const newIsExpanded = !props.modelValue.isExpanded
+  // eslint-disable-next-line no-console
+  console.log('logged in:', isLoggedIn.value)
+  // eslint-disable-next-line no-console
+  console.log('canpostcomment:', props.canPostComment)
+
+  if (!isLoggedIn.value) {
+    // eslint-disable-next-line no-console
+    console.log('emit login')
+    emit('login')
+    return
+  }
 
   if (!props.canPostComment) {
-    if (!isLoggedIn.value) {
-      emit('login')
-      return
-    }
+    // eslint-disable-next-line no-console
+    console.log('canpostcomment false')
   }
 
   if (!newIsExpanded) {

--- a/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
@@ -116,13 +116,16 @@ const isPostingNewThread = ref(false)
 //   width: 320
 // })
 const createThread = useSubmitComment()
+const { isLoggedIn } = useActiveUser()
 
 const onThreadClick = () => {
   const newIsExpanded = !props.modelValue.isExpanded
 
   if (!props.canPostComment) {
-    emit('login')
-    return
+    if (!isLoggedIn.value) {
+      emit('login')
+      return
+    }
   }
 
   if (!newIsExpanded) {

--- a/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
@@ -120,21 +120,10 @@ const { isLoggedIn } = useActiveUser()
 
 const onThreadClick = () => {
   const newIsExpanded = !props.modelValue.isExpanded
-  // eslint-disable-next-line no-console
-  console.log('logged in:', isLoggedIn.value)
-  // eslint-disable-next-line no-console
-  console.log('canpostcomment:', props.canPostComment)
 
   if (!isLoggedIn.value) {
-    // eslint-disable-next-line no-console
-    console.log('emit login')
     emit('login')
     return
-  }
-
-  if (!props.canPostComment) {
-    // eslint-disable-next-line no-console
-    console.log('canpostcomment false')
   }
 
   if (!newIsExpanded) {

--- a/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
@@ -121,8 +121,10 @@ const { isLoggedIn } = useActiveUser()
 const onThreadClick = () => {
   const newIsExpanded = !props.modelValue.isExpanded
 
-  if (!isLoggedIn.value) {
-    emit('login')
+  if (!isLoggedIn.value || !props.canPostComment) {
+    if (!isLoggedIn.value) {
+      emit('login')
+    }
     return
   }
 

--- a/packages/frontend-2/components/viewer/anchored-point/Thread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/Thread.vue
@@ -162,7 +162,7 @@
               </FormButton>
             </div>
             <div
-              v-if="!canReply && !isEmbedEnabled"
+              v-if="!canReply && !isEmbedEnabled && !isLoggedIn"
               class="p-3 flex flex-col items-center justify-center bg-foundation-2"
             >
               <FormButton full-width @click="$emit('login')">Reply</FormButton>
@@ -229,7 +229,7 @@ const { isEmbedEnabled } = useEmbed()
 
 const threadId = computed(() => props.modelValue.id)
 const { copy } = useClipboard()
-const { activeUser } = useActiveUser()
+const { activeUser, isLoggedIn } = useActiveUser()
 const { isSmallerOrEqualSm } = useIsSmallerOrEqualThanBreakpoint()
 
 const archiveComment = useArchiveComment()

--- a/packages/frontend-2/lib/viewer/composables/commentManagement.ts
+++ b/packages/frontend-2/lib/viewer/composables/commentManagement.ts
@@ -222,10 +222,7 @@ export function useCheckViewerCommentingAccess() {
       response: { project }
     }
   } = useInjectedViewerState()
-  const { activeUser } = useActiveUser()
   return computed(() => {
-    if (!activeUser.value) return false
-
     const hasRole = !!project.value?.role
     const allowPublicComments = !!project.value?.allowPublicComments
 

--- a/packages/frontend-2/lib/viewer/composables/commentManagement.ts
+++ b/packages/frontend-2/lib/viewer/composables/commentManagement.ts
@@ -222,7 +222,11 @@ export function useCheckViewerCommentingAccess() {
       response: { project }
     }
   } = useInjectedViewerState()
+  const { activeUser } = useActiveUser()
+
   return computed(() => {
+    if (!activeUser.value) return false
+
     const hasRole = !!project.value?.role
     const allowPublicComments = !!project.value?.allowPublicComments
 


### PR DESCRIPTION
## Description & motivation
There was a bug in the viewer where a user who was logged in, was still presented the login screen when trying to post a comment. This occurred when the user was on a public project, that they were not a collaborator in. 

I adjusted the conditions around canPostComment, so it fits better in every scenario. I also hid the 2 "New Comment" buttons when commenting was not possible, but the user was logged in. 