### PR TITLE
bugfix(fe2): Discussion EmptyState causing 500 error

### DIFF
--- a/packages/frontend-2/components/project/page/latest-items/comments/EmptyState.vue
+++ b/packages/frontend-2/components/project/page/latest-items/comments/EmptyState.vue
@@ -35,7 +35,7 @@
       </svg>
     </template>
     <template #cta>
-      <div v-if="small && canPostComment" class="mt-3">
+      <div v-if="showButton" class="mt-3">
         <FormButton
           size="sm"
           :icon-left="PlusIcon"
@@ -49,7 +49,6 @@
 </template>
 <script setup lang="ts">
 import { PlusIcon } from '@heroicons/vue/24/solid'
-import { useCheckViewerCommentingAccess } from '~/lib/viewer/composables/commentManagement'
 
 defineEmits<{
   (e: 'new-discussion'): void
@@ -57,7 +56,6 @@ defineEmits<{
 
 defineProps<{
   small?: boolean
+  showButton?: boolean
 }>()
-
-const canPostComment = useCheckViewerCommentingAccess()
 </script>

--- a/packages/frontend-2/components/viewer/comments/Comments.vue
+++ b/packages/frontend-2/components/viewer/comments/Comments.vue
@@ -61,6 +61,7 @@
       <div v-if="commentThreads.length === 0" class="pb-4">
         <ProjectPageLatestItemsCommentsEmptyState
           small
+          :show-button="canPostComment"
           @new-discussion="onNewDiscussion"
         />
       </div>
@@ -85,6 +86,7 @@ import {
   useInjectedViewerRequestedResources
 } from '~~/lib/viewer/composables/setup'
 import { useMixpanel } from '~~/lib/core/composables/mp'
+import { useCheckViewerCommentingAccess } from '~~/lib/viewer/composables/commentManagement'
 
 defineEmits(['close'])
 
@@ -126,6 +128,7 @@ const {
     openThread: { newThreadEditor }
   }
 } = useInjectedViewerInterfaceState()
+const canPostComment = useCheckViewerCommentingAccess()
 
 const showVisibilityOptions = ref(false)
 


### PR DESCRIPTION
## Description & motivation
There was a bug introduced in our recent changes to useCheckViewerCommentingAccess. 

When no discussions were present on a project, and you navigated to the discussions tab, you got a 500 error. 

## Changes:
- Simplified the Discussions Empty State component