### PR TITLE
bugfix(fe2): Coloring function disappears if parameter title is too long

### DIFF
--- a/packages/frontend-2/components/viewer/explorer/Filters.vue
+++ b/packages/frontend-2/components/viewer/explorer/Filters.vue
@@ -2,19 +2,19 @@
   <ViewerLayoutPanel class="mt-2" hide-close>
     <template #title>Filtering</template>
     <template #actions>
-      <div class="flex justify-between items-center w-full">
-        <div class="-mt-1">
-          <FormButton
-            v-tippy="'Change Filter'"
-            text
-            size="xs"
-            :icon-right="showAllFilters ? ChevronUpIcon : ChevronDownIcon"
-            class="capitalize"
-            @click="showAllFilters = !showAllFilters"
-          >
+      <div class="flex justify-between items-center w-full gap-2">
+        <FormButton
+          v-tippy="'Change Filter'"
+          text
+          size="xs"
+          :icon-right="showAllFilters ? ChevronUpIcon : ChevronDownIcon"
+          class="capitalize"
+          @click="showAllFilters = !showAllFilters"
+        >
+          <span class="max-w-20 md:max-w-36 truncate">
             {{ title.split('.').reverse()[0] || title || 'No Title' }}
-          </FormButton>
-        </div>
+          </span>
+        </FormButton>
         <div class="flex gap-1 divide-x divide-outline-3">
           <FormButton
             v-if="title !== 'Object Type'"


### PR DESCRIPTION
## Description & motivation
If there was a longer filter name, the colouring function is pushed off the filter menu, and becomes unusable. 

## Changes:
- Remove -mt-1 which wasn't needed
- Add truncate to the button label, and a max width for mobile and desktop