### PR TITLE
feat(fe2): Use shortened header in Scene Explorer

### DIFF
--- a/packages/frontend-2/components/viewer/explorer/TreeItem.vue
+++ b/packages/frontend-2/components/viewer/explorer/TreeItem.vue
@@ -183,8 +183,17 @@ const isAtomic = computed(() => props.treeItem.atomic === true)
 const speckleData = props.treeItem?.raw as SpeckleObject
 const rawSpeckleData = props.treeItem?.raw as SpeckleObject
 
+function getNestedModelHeader(name: string): string {
+  const parts = name.split('/')
+  return parts.length > 1 ? (parts.pop() as string) : name
+}
+
 const headerAndSubheader = computed(() => {
-  return getHeaderAndSubheaderForSpeckleObject(rawSpeckleData)
+  const { header, subheader } = getHeaderAndSubheaderForSpeckleObject(rawSpeckleData)
+  return {
+    header: getNestedModelHeader(header),
+    subheader
+  }
 })
 
 const childrenLength = computed(() => {


### PR DESCRIPTION
## Description & motivation
In scene explorer, we show the full model name, including nestings. This means the actual model name is often cut off. 

We show the shortened model name in the Models panel. We should shorten it in the same was in scene explorer. 

## Changes:
- Add getNestedModelHeader function
- User getNestedModelHeader with result of getHeaderAndSubheaderForSpeckleObject