### PR TITLE
fix(fe2): "Manage" Button causes authentication error for user without edit permissions

### DIFF
--- a/packages/frontend-2/components/project/page/team/Block.vue
+++ b/packages/frontend-2/components/project/page/team/Block.vue
@@ -15,7 +15,7 @@
     <template #bottom>
       <div class="flex items-center justify-between mt-1">
         <UserAvatarGroup :users="teamUsers" class="max-w-[104px]" />
-        <div v-if="activeUser">
+        <div v-if="canEdit">
           <FormButton class="ml-2" :to="projectCollaboratorsRoute(project.id)">
             Manage
           </FormButton>
@@ -25,7 +25,7 @@
   </ProjectPageStatsBlock>
 </template>
 <script setup lang="ts">
-import { useActiveUser } from '~~/lib/auth/composables/activeUser'
+import { canEditProject } from '~~/lib/projects/helpers/permissions'
 import type { ProjectPageTeamInternals_ProjectFragment } from '~~/lib/common/generated/gql/graphql'
 import { projectCollaboratorsRoute } from '~~/lib/common/helpers/route'
 
@@ -33,7 +33,7 @@ const props = defineProps<{
   project: ProjectPageTeamInternals_ProjectFragment
 }>()
 
-const { activeUser } = useActiveUser()
+const canEdit = computed(() => canEditProject(props.project))
 
 const teamUsers = computed(() => props.project.team.map((t) => t.user))
 </script>


### PR DESCRIPTION
## Description & motivation
It was noticed that when a project contributor clicks the "Manage" button in the team block, they are taken to a Contributor page with no contributors, and an authentication error in console. A reload fixed this, suggesting it is not an authentication problem, but more likely to be some race condition. 

I have spent a bit of time troubleshooting this, but have not found the underlying issue. Some input from Fabians would be good here. 

In the meantime, I have changed the conditioning around the manage button, so only users with edit permissions can see the Manage button. Users without this permission can still go to settings>contributors, but they won't see the Manage button from the project page. 

## Changes:
- Change condition on "Manage" button from "activeUser" to "canEditProject".