### PR TITLE
feat(fe2): Collapse all selected properties when new element is selected

### DIFF
--- a/packages/frontend-2/components/viewer/selection/Object.vue
+++ b/packages/frontend-2/components/viewer/selection/Object.vue
@@ -315,4 +315,11 @@ const categorisedValuePairs = computed(() => {
     nulls: keyValuePairs.value.filter((item) => item.value === null)
   }
 })
+
+watch(
+  () => props.unfold,
+  (newVal) => {
+    unfold.value = newVal
+  }
+)
 </script>


### PR DESCRIPTION
## Description & motivation
When a single item is selected, the object appears in the sidebar unfolded. When a new item is selected (using shift - so both items are now selected), the first item remains unfolded, but the second is folder. 

In the scenario, the first and second should be folded. Any time more than 1 item is selected, all items should be folded. 

## Changes:
- Add a watch to ViewerSelectionObject to update the fold state when a change has been made