### PR TITLE
Fix(fe2): Map user_id for Survicate-Mixpanel integration

### DIFF
--- a/packages/frontend-2/plugins/survicate.client.ts
+++ b/packages/frontend-2/plugins/survicate.client.ts
@@ -55,7 +55,8 @@ export default defineNuxtPlugin(async () => {
           (user, { resolveDistinctId }) => {
             const distinctId = resolveDistinctId(user)
             if (distinctId && survicateInstance) {
-              survicateInstance.setVisitorTraits({ distinctId })
+              // eslint-disable-next-line camelcase
+              survicateInstance.setVisitorTraits({ user_id: distinctId })
             }
           },
           { immediate: true }

--- a/packages/frontend-2/plugins/survicate.client.ts
+++ b/packages/frontend-2/plugins/survicate.client.ts
@@ -56,7 +56,7 @@ export default defineNuxtPlugin(async () => {
             const distinctId = resolveDistinctId(user)
             if (distinctId && survicateInstance) {
               // eslint-disable-next-line camelcase
-              survicateInstance.setVisitorTraits({ user_id: distinctId })
+              survicateInstance.setVisitorTraits({ user_id: distinctId, distinctId })
             }
           },
           { immediate: true }


### PR DESCRIPTION
## Description & motivation
Currently, Survicate does not support mapping custom attributes like distinctId to Mixpanel's distinct_id. This change updates the Survicate initialisation to set the user_id attribute, ensuring proper identification in Mixpanel.

## Changes:
- Map user_id to distinctId for Survicate-Mixpanel integration