### PR TITLE
fix(fe2): Use better input names to avoid triggering autocomplete. Stop "a few seconds ago" from breaking line

### DIFF
--- a/packages/frontend-2/components/automate/function/create-dialog/DetailsStep.vue
+++ b/packages/frontend-2/components/automate/function/create-dialog/DetailsStep.vue
@@ -12,7 +12,7 @@
       <div class="sm:w-7/12">
         <FormTextInput
           size="lg"
-          name="name"
+          name="functionName"
           label="Name"
           placeholder="Function Name"
           help="This will be used as the function's display name and also as the name of the Git repository."

--- a/packages/frontend-2/components/automate/function/create-dialog/DetailsStep.vue
+++ b/packages/frontend-2/components/automate/function/create-dialog/DetailsStep.vue
@@ -12,7 +12,7 @@
       <div class="sm:w-7/12">
         <FormTextInput
           size="lg"
-          name="functionName"
+          name="name"
           label="Name"
           placeholder="Function Name"
           help="This will be used as the function's display name and also as the name of the Git repository."

--- a/packages/frontend-2/components/automate/function/create-dialog/DetailsStep.vue
+++ b/packages/frontend-2/components/automate/function/create-dialog/DetailsStep.vue
@@ -20,6 +20,7 @@
           show-required
           :rules="nameRules"
           validate-on-value-update
+          autocomplete="off"
         />
       </div>
     </div>

--- a/packages/frontend-2/components/project/model-page/dialog/move-to/NewTab.vue
+++ b/packages/frontend-2/components/project/model-page/dialog/move-to/NewTab.vue
@@ -11,7 +11,7 @@
         will be moved to.
       </div>
       <FormTextInput
-        name="modelName"
+        name="name"
         label="Model Name"
         placeholder="model/name/here"
         help="Use forward slashes in the model name to nest it below other models."

--- a/packages/frontend-2/components/project/model-page/dialog/move-to/NewTab.vue
+++ b/packages/frontend-2/components/project/model-page/dialog/move-to/NewTab.vue
@@ -11,7 +11,7 @@
         will be moved to.
       </div>
       <FormTextInput
-        name="name"
+        name="modelName"
         label="Model Name"
         placeholder="model/name/here"
         help="Use forward slashes in the model name to nest it below other models."

--- a/packages/frontend-2/components/project/model-page/dialog/move-to/NewTab.vue
+++ b/packages/frontend-2/components/project/model-page/dialog/move-to/NewTab.vue
@@ -18,6 +18,7 @@
         :custom-icon="CubeIcon"
         :rules="rules"
         :disabled="disabled"
+        autocomplete="off"
       />
       <div class="flex justify-end">
         <FormButton submit :disabled="disabled">Move</FormButton>

--- a/packages/frontend-2/components/project/page/models/NewDialog.vue
+++ b/packages/frontend-2/components/project/page/models/NewDialog.vue
@@ -19,6 +19,7 @@
           :rules="rules"
           :disabled="anyMutationsLoading"
           help="Use forward slashes in the model name to nest it below other models."
+          autocomplete="off"
         />
         <FormTextArea
           v-model="newDescription"

--- a/packages/frontend-2/components/project/page/models/NewDialog.vue
+++ b/packages/frontend-2/components/project/page/models/NewDialog.vue
@@ -11,7 +11,7 @@
         <FormTextInput
           v-model="newModelName"
           color="foundation"
-          name="name"
+          name="modelName"
           label="Model Name"
           show-label
           placeholder="model/name/here"

--- a/packages/frontend-2/components/project/page/models/NewDialog.vue
+++ b/packages/frontend-2/components/project/page/models/NewDialog.vue
@@ -11,7 +11,7 @@
         <FormTextInput
           v-model="newModelName"
           color="foundation"
-          name="modelName"
+          name="name"
           label="Model Name"
           show-label
           placeholder="model/name/here"

--- a/packages/frontend-2/components/project/page/models/NewModelStructureItem.vue
+++ b/packages/frontend-2/components/project/page/models/NewModelStructureItem.vue
@@ -19,7 +19,7 @@
         <div class="flex-grow">
           <FormTextInput
             v-model="name"
-            name="name"
+            name="modelName"
             label="Model name"
             placeholder="name"
             auto-focus

--- a/packages/frontend-2/components/project/page/models/NewModelStructureItem.vue
+++ b/packages/frontend-2/components/project/page/models/NewModelStructureItem.vue
@@ -25,6 +25,7 @@
             auto-focus
             :rules="rules"
             :disabled="anyMutationsLoading"
+            autocomplete="off"
           />
         </div>
         <div class="flex flex-wrap gap-1 sm:gap-2">

--- a/packages/frontend-2/components/project/page/models/NewModelStructureItem.vue
+++ b/packages/frontend-2/components/project/page/models/NewModelStructureItem.vue
@@ -19,7 +19,7 @@
         <div class="flex-grow">
           <FormTextInput
             v-model="name"
-            name="modelName"
+            name="name"
             label="Model name"
             placeholder="name"
             auto-focus

--- a/packages/frontend-2/components/project/page/models/card/EditDialog.vue
+++ b/packages/frontend-2/components/project/page/models/card/EditDialog.vue
@@ -24,7 +24,7 @@
       <div class="flex flex-col gap-6 mb-6">
         <FormTextInput
           v-model="newName"
-          name="modelName"
+          name="name"
           show-label
           label="Model Name"
           placeholder="model/name/here"

--- a/packages/frontend-2/components/project/page/models/card/EditDialog.vue
+++ b/packages/frontend-2/components/project/page/models/card/EditDialog.vue
@@ -24,7 +24,7 @@
       <div class="flex flex-col gap-6 mb-6">
         <FormTextInput
           v-model="newName"
-          name="name"
+          name="modelName"
           show-label
           label="Model Name"
           placeholder="model/name/here"

--- a/packages/frontend-2/components/project/page/models/card/EditDialog.vue
+++ b/packages/frontend-2/components/project/page/models/card/EditDialog.vue
@@ -34,6 +34,7 @@
           auto-focus
           :disabled="loading"
           help="Use forward slashes in the model name to nest it below other models."
+          autocomplete="off"
         />
         <FormTextArea
           v-model="newDescription"

--- a/packages/frontend-2/components/projects/AddDialog.vue
+++ b/packages/frontend-2/components/projects/AddDialog.vue
@@ -4,7 +4,7 @@
     <form class="flex flex-col text-foreground" @submit="onSubmit">
       <div class="flex flex-col space-y-3 mb-6">
         <FormTextInput
-          name="name"
+          name="projectName"
           label="Project name"
           placeholder="Project name"
           :rules="[isRequired, isStringOfLength({ maxLength: 512 })]"

--- a/packages/frontend-2/components/projects/AddDialog.vue
+++ b/packages/frontend-2/components/projects/AddDialog.vue
@@ -4,7 +4,7 @@
     <form class="flex flex-col text-foreground" @submit="onSubmit">
       <div class="flex flex-col space-y-3 mb-6">
         <FormTextInput
-          name="projectName"
+          name="name"
           label="Project name"
           placeholder="Project name"
           :rules="[isRequired, isStringOfLength({ maxLength: 512 })]"

--- a/packages/frontend-2/components/projects/AddDialog.vue
+++ b/packages/frontend-2/components/projects/AddDialog.vue
@@ -10,6 +10,7 @@
           :rules="[isRequired, isStringOfLength({ maxLength: 512 })]"
           show-required
           auto-focus
+          autocomplete="off"
         />
         <FormTextArea
           name="description"

--- a/packages/frontend-2/components/viewer/resources/VersionCard.vue
+++ b/packages/frontend-2/components/viewer/resources/VersionCard.vue
@@ -29,14 +29,14 @@
     >
       <ChevronDownIcon class="h-3 w-3" />
     </div>
-    <div class="flex items-center space-x-2 pl-1">
+    <div class="flex items-center gap-1 pl-1">
       <div class="z-20 -ml-2">
         <UserAvatar :user="author" />
       </div>
       <div
         v-show="showTimeline"
         v-tippy="`${createdAt}`"
-        class="bg-foundation-focus inline-block rounded-full px-2 text-xs font-bold"
+        class="bg-foundation-focus inline-block rounded-full px-2 text-xs font-bold shrink-0"
       >
         <span>{{ isLatest ? 'Latest' : timeAgoCreatedAt }}</span>
       </div>


### PR DESCRIPTION
## Description & motivation
2 Small changes to fe2. 

The first was reported by Matteo in discord. Because we call various inputs "name", autocomplete wrongly thinks these are the user’s name, rather than model/project/function etc. I updated these to be more accurate.

The second is something I noticed when working on another task. If you push a version through a connector, quite often you will see "A few seconds ago" as the time in the viewer. This copy is too long, and breaks onto 2 lines and looks poor. 

## Changes:
- Add "autocomplete='off'" to inputs with their name as name, even though it is not the users name. Autocomplete checks the name attribute, and ours cannot be easily changed without breaking changes. Instead, we will just turn off autocomplete for these inputs. 
- Stop "a few seconds ago" from breaking line