### PR TITLE
WEB-1028 `AutomationRecord` type changes for test automations

### DIFF
--- a/packages/server/modules/automate/helpers/types.ts
+++ b/packages/server/modules/automate/helpers/types.ts
@@ -8,7 +8,23 @@ export type AutomationRecord = {
   enabled: boolean
   createdAt: Date
   updatedAt: Date
-  executionEngineAutomationId: string
+} & (
+  | {
+      executionEngineAutomationId: string
+      isTestAutomation: false
+    }
+  | {
+      executionEngineAutomationId: null
+      isTestAutomation: true
+    }
+)
+
+export type TestAutomation<R extends AutomationRecord> = R & {
+  isTestAutomation: true
+}
+
+export type LiveAutomation<R extends AutomationRecord> = R & {
+  isTestAutomation: false
 }
 
 export type AutomationRevisionRecord = {

--- a/packages/server/modules/automate/index.ts
+++ b/packages/server/modules/automate/index.ts
@@ -8,6 +8,8 @@ import {
 import { Environment } from '@speckle/shared'
 import {
   getActiveTriggerDefinitions,
+  getAutomation,
+  getAutomationRevision,
   getAutomationRunFullTriggers
 } from '@/modules/automate/repositories/automations'
 import { ScopeRecord } from '@/modules/auth/helpers/types'
@@ -70,6 +72,8 @@ const initializeEventListeners = () => {
       VersionEvents.Created,
       async ({ modelId, version, projectId }) => {
         await onModelVersionCreate({
+          getAutomation,
+          getAutomationRevision,
           getTriggers: getActiveTriggerDefinitions,
           triggerFunction: triggerFn
         })({ modelId, versionId: version.id, projectId })

--- a/packages/server/modules/automate/migrations/20240523192300_add_is_test_automation_column.ts
+++ b/packages/server/modules/automate/migrations/20240523192300_add_is_test_automation_column.ts
@@ -1,0 +1,32 @@
+import { Knex } from 'knex'
+
+const AUTOMATIONS_TABLE = 'automations'
+const PLACEHOLDER_NULL_ID = 'null-execution-engine-automation-id'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(AUTOMATIONS_TABLE, (table) => {
+    table.boolean('isTestAutomation').notNullable().defaultTo(false)
+  })
+
+  await knex.schema.alterTable(AUTOMATIONS_TABLE, (table) => {
+    table.setNullable('executionEngineAutomationId')
+  })
+
+  await knex(AUTOMATIONS_TABLE)
+    .where('executionEngineAutomationId', PLACEHOLDER_NULL_ID)
+    .update({ executionEngineAutomationId: null })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(AUTOMATIONS_TABLE, (table) => {
+    table.dropColumn('isTestAutomation')
+  })
+
+  await knex(AUTOMATIONS_TABLE)
+    .whereNull('executionEngineAutomationId')
+    .update({ executionEngineAutomationId: PLACEHOLDER_NULL_ID })
+
+  await knex.schema.alterTable(AUTOMATIONS_TABLE, (table) => {
+    table.string('executionEngineAutomationId').notNullable().alter()
+  })
+}

--- a/packages/server/modules/automate/migrations/20240523192300_add_is_test_automation_column.ts
+++ b/packages/server/modules/automate/migrations/20240523192300_add_is_test_automation_column.ts
@@ -1,7 +1,6 @@
 import { Knex } from 'knex'
 
 const AUTOMATIONS_TABLE = 'automations'
-const PLACEHOLDER_NULL_ID = 'null-execution-engine-automation-id'
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable(AUTOMATIONS_TABLE, (table) => {
@@ -11,20 +10,14 @@ export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable(AUTOMATIONS_TABLE, (table) => {
     table.setNullable('executionEngineAutomationId')
   })
-
-  await knex(AUTOMATIONS_TABLE)
-    .where('executionEngineAutomationId', PLACEHOLDER_NULL_ID)
-    .update({ executionEngineAutomationId: null })
 }
 
 export async function down(knex: Knex): Promise<void> {
+  await knex(AUTOMATIONS_TABLE).where('isTestAutomation', true).delete()
+
   await knex.schema.alterTable(AUTOMATIONS_TABLE, (table) => {
     table.dropColumn('isTestAutomation')
   })
-
-  await knex(AUTOMATIONS_TABLE)
-    .whereNull('executionEngineAutomationId')
-    .update({ executionEngineAutomationId: PLACEHOLDER_NULL_ID })
 
   await knex.schema.alterTable(AUTOMATIONS_TABLE, (table) => {
     table.string('executionEngineAutomationId').notNullable().alter()

--- a/packages/server/modules/automate/services/automationManagement.ts
+++ b/packages/server/modules/automate/services/automationManagement.ts
@@ -103,7 +103,8 @@ export const createAutomation =
         updatedAt: new Date(),
         enabled,
         projectId,
-        executionEngineAutomationId
+        executionEngineAutomationId,
+        isTestAutomation: false
       },
       {
         automationId,

--- a/packages/server/modules/automate/services/trigger.ts
+++ b/packages/server/modules/automate/services/trigger.ts
@@ -14,7 +14,8 @@ import {
   VersionCreatedTriggerManifest,
   VersionCreationTriggerType,
   BaseTriggerManifest,
-  isVersionCreatedTriggerManifest
+  isVersionCreatedTriggerManifest,
+  LiveAutomation
 } from '@/modules/automate/helpers/types'
 import { getBranchLatestCommits } from '@/modules/core/repositories/branches'
 import { getCommit } from '@/modules/core/repositories/commits'
@@ -288,7 +289,9 @@ export const ensureRunConditions =
     revisionId: string
     manifest: M
   }): Promise<{
-    automationWithRevision: AutomationWithRevision<AutomationRevisionWithTriggersFunctions>
+    automationWithRevision: LiveAutomation<
+      AutomationWithRevision<AutomationRevisionWithTriggersFunctions>
+    >
     userId: string
     automateToken: string
   }> => {
@@ -299,6 +302,13 @@ export const ensureRunConditions =
       throw new AutomateInvalidTriggerError(
         "Cannot trigger the given revision, it doesn't exist"
       )
+
+    // if the automation is a test automation, do not trigger
+    if (automationWithRevision.isTestAutomation) {
+      throw new AutomateInvalidTriggerError(
+        'This is a test automation and cannot be triggered outside of local testing'
+      )
+    }
 
     // if the automation is not active, do not trigger
     if (!automationWithRevision.enabled)

--- a/packages/server/modules/automate/tests/trigger.spec.ts
+++ b/packages/server/modules/automate/tests/trigger.spec.ts
@@ -10,10 +10,12 @@ import {
   triggerAutomationRevisionRun
 } from '@/modules/automate/services/trigger'
 import {
+  AutomationRecord,
   AutomationRunStatuses,
   AutomationTriggerDefinitionRecord,
   AutomationTriggerType,
   BaseTriggerManifest,
+  LiveAutomation,
   VersionCreatedTriggerManifest,
   VersionCreationTriggerType,
   isVersionCreatedTriggerManifest
@@ -297,7 +299,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
         // @ts-expect-error force setting the objectId to null
         await createTestCommit(version)
         // create automation,
-        const automation = {
+        const automation: LiveAutomation<AutomationRecord> = {
           id: cryptoRandomString({ length: 10 }),
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -305,6 +307,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
           enabled: true,
           projectId: project.id,
           executionEngineAutomationId: cryptoRandomString({ length: 10 }),
+          isTestAutomation: false,
           userId
         }
         const automationToken = {
@@ -385,7 +388,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
         // @ts-expect-error force setting the objectId to null
         await createTestCommit(version)
         // create automation,
-        const automation = {
+        const automation: LiveAutomation<AutomationRecord> = {
           id: cryptoRandomString({ length: 10 }),
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -393,6 +396,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
           enabled: true,
           projectId: project.id,
           executionEngineAutomationId: cryptoRandomString({ length: 10 }),
+          isTestAutomation: false,
           userId
         }
         const automationToken = {
@@ -487,6 +491,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
               updatedAt: new Date(),
               executionEngineAutomationId: cryptoRandomString({ length: 10 }),
               userId: cryptoRandomString({ length: 10 }),
+              isTestAutomation: false,
               revision: {
                 id: cryptoRandomString({ length: 10 }),
                 createdAt: new Date(),
@@ -529,6 +534,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
               updatedAt: new Date(),
               executionEngineAutomationId: cryptoRandomString({ length: 10 }),
               userId: cryptoRandomString({ length: 10 }),
+              isTestAutomation: false,
               revision: {
                 publicKey,
                 active: false,
@@ -571,6 +577,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
               projectId: cryptoRandomString({ length: 10 }),
               enabled: true,
               executionEngineAutomationId: cryptoRandomString({ length: 10 }),
+              isTestAutomation: false,
               revision: {
                 publicKey,
                 id: cryptoRandomString({ length: 10 }),
@@ -620,6 +627,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
               updatedAt: new Date(),
               executionEngineAutomationId: cryptoRandomString({ length: 10 }),
               userId: cryptoRandomString({ length: 10 }),
+              isTestAutomation: false,
               revision: {
                 publicKey,
                 id: cryptoRandomString({ length: 10 }),
@@ -668,6 +676,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
               updatedAt: new Date(),
               executionEngineAutomationId: cryptoRandomString({ length: 10 }),
               userId: cryptoRandomString({ length: 10 }),
+              isTestAutomation: false,
               revision: {
                 id: cryptoRandomString({ length: 10 }),
                 createdAt: new Date(),
@@ -717,6 +726,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
               enabled: true,
               executionEngineAutomationId: cryptoRandomString({ length: 10 }),
               userId: cryptoRandomString({ length: 10 }),
+              isTestAutomation: false,
               revision: {
                 id: cryptoRandomString({ length: 10 }),
                 userId: cryptoRandomString({ length: 10 }),
@@ -779,6 +789,7 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
               updatedAt: new Date(),
               executionEngineAutomationId: cryptoRandomString({ length: 10 }),
               userId: cryptoRandomString({ length: 10 }),
+              isTestAutomation: false,
               revision: {
                 id: cryptoRandomString({ length: 10 }),
                 userId: cryptoRandomString({ length: 10 }),
@@ -819,6 +830,67 @@ const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
         } catch (error) {
           if (!(error instanceof Error)) throw error
           expect(error.message).contains('Cannot find a token for the automation')
+        }
+      })
+      it('the automation is a test automation', async () => {
+        const manifest: VersionCreatedTriggerManifest = {
+          triggerType: VersionCreationTriggerType,
+          modelId: cryptoRandomString({ length: 10 }),
+          versionId: cryptoRandomString({ length: 10 }),
+          projectId: cryptoRandomString({ length: 10 })
+        }
+        try {
+          await ensureRunConditions({
+            revisionGetter: async () => ({
+              id: cryptoRandomString({ length: 10 }),
+              name: cryptoRandomString({ length: 10 }),
+              projectId: cryptoRandomString({ length: 10 }),
+              enabled: true,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              executionEngineAutomationId: null,
+              userId: cryptoRandomString({ length: 10 }),
+              isTestAutomation: true,
+              revision: {
+                id: cryptoRandomString({ length: 10 }),
+                userId: cryptoRandomString({ length: 10 }),
+                createdAt: new Date(),
+                active: true,
+                publicKey,
+                triggers: [
+                  {
+                    triggeringId: manifest.modelId,
+                    triggerType: manifest.triggerType,
+                    automationRevisionId: cryptoRandomString({ length: 10 })
+                  }
+                ],
+                functions: [],
+                automationId: cryptoRandomString({ length: 10 }),
+                automationToken: cryptoRandomString({ length: 15 })
+              }
+            }),
+            versionGetter: async () => ({
+              author: cryptoRandomString({ length: 10 }),
+              id: cryptoRandomString({ length: 10 }),
+              createdAt: new Date(),
+              message: 'foobar',
+              parents: [],
+              referencedObject: cryptoRandomString({ length: 10 }),
+              totalChildrenCount: null,
+              sourceApplication: 'test suite',
+              streamId: cryptoRandomString({ length: 10 }),
+              branchId: cryptoRandomString({ length: 10 }),
+              branchName: cryptoRandomString({ length: 10 })
+            }),
+            automationTokenGetter: async () => null
+          })({
+            revisionId: cryptoRandomString({ length: 10 }),
+            manifest
+          })
+          throw 'this should have thrown'
+        } catch (error) {
+          if (!(error instanceof Error)) throw error
+          expect(error.message).contains('This is a test automation')
         }
       })
     })

--- a/packages/server/modules/core/dbSchema.ts
+++ b/packages/server/modules/core/dbSchema.ts
@@ -629,7 +629,8 @@ export const Automations = buildTableHelper('automations', [
   'createdAt',
   'updatedAt',
   'userId',
-  'executionEngineAutomationId'
+  'executionEngineAutomationId',
+  'isTestAutomation'
 ])
 
 export { knex }


### PR DESCRIPTION
## Description & motivation

We are introducing the concept of a "test automation" and are using an `isTestAutomation` boolean as a flag to differentiate them from non-test automations. I'm making a few types of changes for the first time and would like to use this PR to make sure things are in order before doing the "real work" of adding/modifying the endpoints used to make test automations.

## Changes:

- Modify automations table schema:
  - Add boolean `isTestAutomation` column
  - Make `executionEngineAutomationId` nullable
- Adds migration for this
- Changes `AutomationRecord` typescript type. Union branches existence of `executionEngineAutomationId` on value of `isTestAutomation`
- Makes changes in code in response to this type

Next we actually use the new type in new endpoints.
