### PR TITLE
Overflow and alignment bugs on automation page

### DIFF
--- a/packages/frontend-2/components/automate/function/Card.vue
+++ b/packages/frontend-2/components/automate/function/Card.vue
@@ -28,7 +28,7 @@
           </div>
         </div>
       </div>
-      <div class="label-light text-foreground-2 line-clamp-3 h-16">
+      <div class="label-light text-foreground-2 line-clamp-3 h-16 whitespace-normal">
         {{ plaintextDescription }}
       </div>
       <div v-if="!noButtons" class="flex flex-col sm:flex-row sm:self-end gap-2">
@@ -115,7 +115,7 @@ const { html: plaintextDescription } = useMarkdown(
 )
 
 const classes = computed(() => {
-  const classParts = ['rounded-lg']
+  const classParts = ['rounded-lg truncate']
 
   if (props.selected) {
     classParts.push('ring-2 ring-primary')

--- a/packages/frontend-2/components/project/page/automation/Functions.vue
+++ b/packages/frontend-2/components/project/page/automation/Functions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col">
+  <div class="col-span-1">
     <h2 class="h6 font-bold mb-6">Function</h2>
     <AutomateFunctionCardView v-if="functions.length" vertical>
       <AutomateFunctionCard

--- a/packages/frontend-2/components/project/page/automation/Models.vue
+++ b/packages/frontend-2/components/project/page/automation/Models.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col items-start w-full">
+  <div class="col-span-1">
     <h2 class="h6 font-bold mb-6">Model</h2>
     <div class="w-full">
       <ProjectModelsBasicCardView

--- a/packages/frontend-2/components/project/page/automation/Runs.vue
+++ b/packages/frontend-2/components/project/page/automation/Runs.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col w-full">
-    <div class="flex items-center justify-between mb-2">
+    <div class="flex items-center justify-between h-6 mb-6">
       <h2 class="h6 font-bold">Runs</h2>
       <FormButton
         :icon-left="ArrowPathIcon"
@@ -11,7 +11,6 @@
       </FormButton>
     </div>
     <AutomateRunsTable
-      class="mt-3"
       :runs="automation.runs.items"
       :project-id="projectId"
       :automation-id="automation.id"

--- a/packages/frontend-2/components/project/page/models/Card.vue
+++ b/packages/frontend-2/components/project/page/models/Card.vue
@@ -173,7 +173,7 @@ const hovered = ref(false)
 
 const containerClasses = computed(() => {
   const classParts = [
-    'group rounded-md bg-foundation shadow transition border-2 border-transparent'
+    'group rounded-md bg-foundation shadow transition border-2 border-transparent truncate'
   ]
 
   if (!isPendingModelFragment(props.model)) {

--- a/packages/frontend-2/pages/projects/[id]/index/automations/[aid].vue
+++ b/packages/frontend-2/pages/projects/[id]/index/automations/[aid].vue
@@ -2,9 +2,9 @@
   <div v-if="automation && project" class="flex flex-col gap-8 items-start">
     <ProjectPageAutomationHeader :automation="automation" :project="project" />
 
-    <div class="lg:grid xl:grid-cols-4 gap-6 w-full">
+    <div class="grid grid-cols-1 xl:grid-cols-4 gap-6 w-full">
       <div
-        class="grid gap-6 mb-6 md:grid-cols-2 lg:grid-cols-3 xl:flex xl:flex-col xl:col-span-1"
+        class="col-span-1 grid gap-6 mb-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-1"
       >
         <ProjectPageAutomationFunctions
           :automation="automation"
@@ -13,7 +13,7 @@
         <ProjectPageAutomationModels :automation="automation" :project="project" />
       </div>
       <ProjectPageAutomationRuns
-        class="xl:col-span-3"
+        class="col-span-1 xl:col-span-3"
         :project-id="projectId"
         :automation="automation"
       />


### PR DESCRIPTION
Fixed two bugs on the automation page:

1. The function and model cards didn't truncate properly
2. The function card didn't align with the run table next to it

### Before
![CleanShot 2024-05-27 at 16 30 35@2x](https://github.com/specklesystems/speckle-server/assets/2694102/fecc0608-2327-41d7-ae96-bad8cd58f92f)

### After
![CleanShot 2024-05-27 at 16 26 34@2x](https://github.com/specklesystems/speckle-server/assets/2694102/5480f91b-4d3f-4b01-bd92-bf1b812a4c38)
