### PR TITLE
Proper fix of model and function card truncation

### DIFF
--- a/packages/frontend-2/components/automate/function/Card.vue
+++ b/packages/frontend-2/components/automate/function/Card.vue
@@ -115,7 +115,7 @@ const { html: plaintextDescription } = useMarkdown(
 )
 
 const classes = computed(() => {
-  const classParts = ['rounded-lg truncate']
+  const classParts = ['rounded-lg']
 
   if (props.selected) {
     classParts.push('ring-2 ring-primary')

--- a/packages/frontend-2/components/automate/function/CardView.vue
+++ b/packages/frontend-2/components/automate/function/CardView.vue
@@ -12,12 +12,12 @@ const props = defineProps<{
 const classes = computed(() => {
   const classParts = ['grid gap-4 lg:gap-6']
 
-  if (!props.vertical) {
-    classParts.push('sm:grid-cols-2')
-
-    if (!props.smallView) {
-      classParts.push('lg:grid-cols-3')
-    }
+  if (props.vertical) {
+    classParts.push('grid-cols-1')
+  } else if (props.smallView) {
+    classParts.push('grid-cols-1 sm:grid-cols-2')
+  } else {
+    classParts.push('grid-cols-1 sm:grid-cols-2 lg:grid-cols-3')
   }
 
   return classParts.join(' ')

--- a/packages/frontend-2/components/project/models/BasicCardView.vue
+++ b/packages/frontend-2/components/project/models/BasicCardView.vue
@@ -1,11 +1,5 @@
 <template>
-  <div
-    class="relative z-10 grid gap-3"
-    :class="[
-      smallView ? 'grid-cols-2 sm:grid-cols-3 md:grid-cols-4' : '',
-      !vertical ? 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4' : ''
-    ]"
-  >
+  <div :class="classes">
     <!-- Decrementing z-index necessary for the actions menu to render correctly. Each card has its own stacking context because of the scale property -->
     <ProjectPageModelsCard
       v-for="(item, i) in items"
@@ -34,7 +28,7 @@ defineEmits<{
   (e: 'model-clicked', v: { id: string; e: MouseEvent | KeyboardEvent }): void
 }>()
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     project: Optional<ProjectPageModelsCardProjectFragment>
     items: Array<ProjectPageLatestItemsModelItemFragment | PendingFileUploadFragment>
@@ -50,4 +44,18 @@ withDefaults(
     showVersions: true
   }
 )
+
+const classes = computed(() => {
+  const classParts = ['relative z-10 grid gap-3']
+
+  if (props.vertical) {
+    classParts.push('grid-cols-1')
+  } else if (props.smallView) {
+    classParts.push('grid-cols-1 sm:grid-cols-2 lg:grid-cols-3')
+  } else {
+    classParts.push('grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4')
+  }
+
+  return classParts.join(' ')
+})
 </script>

--- a/packages/frontend-2/components/project/page/models/Card.vue
+++ b/packages/frontend-2/components/project/page/models/Card.vue
@@ -173,7 +173,7 @@ const hovered = ref(false)
 
 const containerClasses = computed(() => {
   const classParts = [
-    'group rounded-md bg-foundation shadow transition border-2 border-transparent truncate'
+    'group rounded-md bg-foundation shadow transition border-2 border-transparent'
   ]
 
   if (!isPendingModelFragment(props.model)) {


### PR DESCRIPTION
Follow up to this PR from yesterday: https://github.com/specklesystems/speckle-server/pull/2291

The way I fixed the truncation yesterday meant that the ··· menu on model cards got cut off because of overflow hidden. This PR fixes the truncation properly through better grid classes.

Note that I've also changed a bit how the models are displayed across breakpoints in the different cases. It's better now.