### PR TITLE
fix: extra safety for when automate is disabled

### DIFF
--- a/packages/frontend-2/middleware/requireValidAutomation.ts
+++ b/packages/frontend-2/middleware/requireValidAutomation.ts
@@ -11,6 +11,16 @@ export default defineNuxtRouteMiddleware(async (to) => {
   const projectId = to.params.id as string
   // const automationId = to.params.aid as string
 
+  const isAutomateEnabled = useIsAutomateModuleEnabled()
+  if (!isAutomateEnabled.value) {
+    return abortNavigation(
+      createError({
+        statusCode: 404,
+        message: 'Page not found'
+      })
+    )
+  }
+
   const client = useApolloClientFromNuxt()
 
   const { data, errors } = await client

--- a/packages/frontend-2/middleware/requireValidFunction.ts
+++ b/packages/frontend-2/middleware/requireValidFunction.ts
@@ -8,6 +8,16 @@ import {
 export default defineNuxtRouteMiddleware(async (to) => {
   const functionId = to.params.fid as string
 
+  const isAutomateEnabled = useIsAutomateModuleEnabled()
+  if (!isAutomateEnabled.value) {
+    return abortNavigation(
+      createError({
+        statusCode: 404,
+        message: 'Page not found'
+      })
+    )
+  }
+
   const client = useApolloClientFromNuxt()
 
   const { data, errors } = await client

--- a/packages/frontend-2/pages/functions/index.vue
+++ b/packages/frontend-2/pages/functions/index.vue
@@ -28,6 +28,22 @@ import { graphql } from '~/lib/common/generated/gql'
 
 // TODO: Proper search & pagination
 
+definePageMeta({
+  middleware: [
+    function () {
+      const isAutomateEnabled = useIsAutomateModuleEnabled()
+      if (!isAutomateEnabled.value) {
+        return abortNavigation(
+          createError({
+            statusCode: 404,
+            message: 'Page not found'
+          })
+        )
+      }
+    }
+  ]
+})
+
 const pageQuery = graphql(`
   query AutomateFunctionsPage($search: String) {
     ...AutomateFunctionsPageItems_Query

--- a/packages/server/modules/automate/errors/core.ts
+++ b/packages/server/modules/automate/errors/core.ts
@@ -1,0 +1,6 @@
+import { BaseError } from '@/modules/shared/errors/base'
+
+export class AutomateApiDisabledError extends BaseError {
+  static defaultMessage = 'Automate module is disabled'
+  static code = 'AUTOMATE_API_DISABLED'
+}

--- a/packages/server/modules/automate/graph/resolvers/automate.ts
+++ b/packages/server/modules/automate/graph/resolvers/automate.ts
@@ -47,7 +47,7 @@ import { getGenericRedis } from '@/modules/core/index'
 import { getUser } from '@/modules/core/repositories/users'
 import { createAutomation as clientCreateAutomation } from '@/modules/automate/clients/executionEngine'
 import { validateStreamAccess } from '@/modules/core/services/streams/streamAccessService'
-import { Automate, Roles, isNullOrUndefined } from '@speckle/shared'
+import { Automate, Environment, Roles, isNullOrUndefined } from '@speckle/shared'
 import {
   getBranchLatestCommits,
   getBranchesByIds
@@ -89,6 +89,7 @@ import {
   mapDbStatusToGqlStatus,
   mapGqlStatusToDbStatus
 } from '@/modules/automate/utils/automateFunctionRunStatus'
+import { AutomateApiDisabledError } from '@/modules/automate/errors/core'
 
 /**
  * TODO:
@@ -97,497 +98,586 @@ import {
  *  - Subscriptions & cache updates
  */
 
-export = {
-  AutomationRevisionTriggerDefinition: {
-    __resolveType(parent) {
-      if (
-        dbToGraphqlTriggerTypeMap[parent.triggerType] ===
-        AutomateRunTriggerType.VersionCreated
-      ) {
-        return 'VersionCreatedTriggerDefinition'
-      }
-      return null
-    }
-  },
-  AutomationRunTrigger: {
-    __resolveType(parent) {
-      if (
-        dbToGraphqlTriggerTypeMap[parent.triggerType] ===
-        AutomateRunTriggerType.VersionCreated
-      ) {
-        return 'VersionCreatedTrigger'
-      }
-      return null
-    }
-  },
-  VersionCreatedTriggerDefinition: {
-    type: () => AutomateRunTriggerType.VersionCreated,
-    async model(parent, _args, ctx) {
-      return ctx.loaders.branches.getById.load(parent.triggeringId)
-    }
-  },
-  VersionCreatedTrigger: {
-    type: () => AutomateRunTriggerType.VersionCreated,
-    async version(parent, _args, ctx) {
-      return ctx.loaders.commits.getById.load(parent.triggeringId)
-    },
-    async model(parent, _args, ctx) {
-      return ctx.loaders.commits.getCommitBranch.load(parent.triggeringId)
-    }
-  },
-  ProjectTriggeredAutomationsStatusUpdatedMessage: {
-    async project(parent, _args, ctx) {
-      return ctx.loaders.streams.getStream.load(parent.projectId)
-    },
-    async model(parent, _args, ctx) {
-      return ctx.loaders.branches.getById.load(parent.modelId)
-    },
-    async version(parent, _args, ctx) {
-      return ctx.loaders.commits.getById.load(parent.versionId)
-    }
-  },
-  Project: {
-    async automation(parent, args, ctx) {
-      return ctx.loaders.streams.getAutomation.forStream(parent.id).load(args.id)
-    },
-    async automations(parent, args) {
-      const retrievalArgs: GetProjectAutomationsParams = {
-        projectId: parent.id,
-        args
-      }
+const { FF_AUTOMATE_MODULE_ENABLED } = Environment.getFeatureFlags()
 
-      const [{ items, cursor }, totalCount] = await Promise.all([
-        getProjectAutomationsItems(retrievalArgs),
-        getProjectAutomationsTotalCount(retrievalArgs)
-      ])
-
-      return {
-        items,
-        totalCount,
-        cursor
-      }
-    }
-  },
-  Model: {
-    async automationsStatus(parent, _args, ctx) {
-      const getStatus = getAutomationsStatus({
-        getLatestVersionAutomationRuns
-      })
-
-      const modelId = parent.id
-      const projectId = parent.streamId
-      const latestCommit = await ctx.loaders.branches.getLatestCommit.load(parent.id)
-
-      // if the model has no versions, no automations could have run
-      if (!latestCommit) return null
-
-      return await getStatus({
-        projectId,
-        modelId,
-        versionId: latestCommit.id
-      })
-    }
-  },
-  Version: {
-    async automationsStatus(parent, _args, ctx) {
-      const getStatus = getAutomationsStatus({
-        getLatestVersionAutomationRuns
-      })
-
-      const versionId = parent.id
-      const branch = await ctx.loaders.commits.getCommitBranch.load(versionId)
-      if (!branch) throw Error('Invalid version Id')
-
-      const projectId = branch.streamId
-      const modelId = branch.id
-      return await getStatus({
-        projectId,
-        modelId,
-        versionId
-      })
-    }
-  },
-  Automation: {
-    async currentRevision(parent, _args, ctx) {
-      return ctx.loaders.automations.getLatestAutomationRevision.load(parent.id)
-    },
-    async runs(parent, args) {
-      const retrievalArgs = {
-        automationId: parent.id,
-        ...args
-      }
-
-      const [{ items, cursor }, totalCount] = await Promise.all([
-        getAutomationRunsItems({
-          args: retrievalArgs
-        }),
-        getAutomationRunsTotalCount({
-          args: retrievalArgs
-        })
-      ])
-
-      return {
-        items,
-        totalCount,
-        cursor
-      }
-    },
-    async creationPublicKeys(parent, _args, ctx) {
-      await authorizeResolver(
-        ctx.userId!,
-        parent.projectId,
-        Roles.Stream.Owner,
-        ctx.resourceAccessRules
-      )
-
-      const publicKey = await getEncryptionPublicKey()
-      return [publicKey]
-    }
-  },
-  AutomateRun: {
-    async trigger(parent, _args, ctx) {
-      const triggers =
-        parent.triggers ||
-        (await ctx.loaders.automations.getRunTriggers.load(parent.id))
-
-      const trigger = triggers[0]
-      return trigger
-    },
-    async functionRuns(parent) {
-      return parent.functionRuns
-    },
-    async automation(parent, _args, ctx) {
-      return ctx.loaders.automations.getAutomation.load(parent.automationId)
-    },
-    status: (parent) => mapDbStatusToGqlStatus(parent.status)
-  },
-  TriggeredAutomationsStatus: {
-    status: (parent) => mapDbStatusToGqlStatus(parent.status)
-  },
-  AutomateFunctionRun: {
-    async function(parent, _args, ctx) {
-      const fn = await ctx.loaders.automationsApi.getFunction.load(parent.functionId)
-      if (!fn) {
-        throw new FunctionNotFoundError('Function not found', {
-          info: { id: parent.functionId }
-        })
-      }
-
-      return convertFunctionToGraphQLReturn(fn)
-    },
-    results(parent, _args, ctx) {
-      try {
-        return parent.results
-          ? Automate.AutomateTypes.formatResultsSchema(parent.results)
-          : null
-      } catch (e) {
-        ctx.log.warn('Error formatting results schema', e)
-      }
-    },
-    status: (parent) => mapDbStatusToGqlStatus(parent.status)
-  },
-  AutomationRevision: {
-    async triggerDefinitions(parent, _args, ctx) {
-      const triggers = await ctx.loaders.automations.getRevisionTriggerDefinitions.load(
-        parent.id
-      )
-
-      return triggers
-    },
-    async functions(parent, _args, ctx) {
-      const prepareInputs = getFunctionInputsForFrontend({
-        getEncryptionKeyPairFor,
-        buildDecryptor,
-        redactWriteOnlyInputData
-      })
-
-      const fns = await ctx.loaders.automations.getRevisionFunctions.load(parent.id)
-      const fnsReleases = keyBy(
-        (
-          await ctx.loaders.automationsApi.getFunctionRelease.loadMany(
-            fns.map((fn) => [fn.functionId, fn.functionReleaseId])
-          )
-        ).filter(
-          (r): r is FunctionReleaseSchemaType => r !== null && !(r instanceof Error)
-        ),
-        (r) => r.functionVersionId
-      )
-
-      const fnsForRedaction: AutomationRevisionFunctionForInputRedaction[] = fns.map(
-        (fn) => {
-          const release = fnsReleases[fn.functionReleaseId]
-          if (!release) {
-            throw new AutomateFunctionReleaseNotFoundError(
-              `Could not find function release #${fn.functionReleaseId} for function #${fn.functionId}`,
-              {
-                info: {
-                  functionId: fn.functionId,
-                  functionReleaseId: fn.functionReleaseId
-                }
-              }
-            )
+export = (FF_AUTOMATE_MODULE_ENABLED
+  ? {
+      /**
+       * If automate module is enabled
+       */
+      AutomationRevisionTriggerDefinition: {
+        __resolveType(parent) {
+          if (
+            dbToGraphqlTriggerTypeMap[parent.triggerType] ===
+            AutomateRunTriggerType.VersionCreated
+          ) {
+            return 'VersionCreatedTriggerDefinition'
           }
+          return null
+        }
+      },
+      AutomationRunTrigger: {
+        __resolveType(parent) {
+          if (
+            dbToGraphqlTriggerTypeMap[parent.triggerType] ===
+            AutomateRunTriggerType.VersionCreated
+          ) {
+            return 'VersionCreatedTrigger'
+          }
+          return null
+        }
+      },
+      VersionCreatedTriggerDefinition: {
+        type: () => AutomateRunTriggerType.VersionCreated,
+        async model(parent, _args, ctx) {
+          return ctx.loaders.branches.getById.load(parent.triggeringId)
+        }
+      },
+      VersionCreatedTrigger: {
+        type: () => AutomateRunTriggerType.VersionCreated,
+        async version(parent, _args, ctx) {
+          return ctx.loaders.commits.getById.load(parent.triggeringId)
+        },
+        async model(parent, _args, ctx) {
+          return ctx.loaders.commits.getCommitBranch.load(parent.triggeringId)
+        }
+      },
+      ProjectTriggeredAutomationsStatusUpdatedMessage: {
+        async project(parent, _args, ctx) {
+          return ctx.loaders.streams.getStream.load(parent.projectId)
+        },
+        async model(parent, _args, ctx) {
+          return ctx.loaders.branches.getById.load(parent.modelId)
+        },
+        async version(parent, _args, ctx) {
+          return ctx.loaders.commits.getById.load(parent.versionId)
+        }
+      },
+      Project: {
+        async automation(parent, args, ctx) {
+          return ctx.loaders.streams.getAutomation.forStream(parent.id).load(args.id)
+        },
+        async automations(parent, args) {
+          const retrievalArgs: GetProjectAutomationsParams = {
+            projectId: parent.id,
+            args
+          }
+
+          const [{ items, cursor }, totalCount] = await Promise.all([
+            getProjectAutomationsItems(retrievalArgs),
+            getProjectAutomationsTotalCount(retrievalArgs)
+          ])
 
           return {
-            ...fn,
-            release
+            items,
+            totalCount,
+            cursor
           }
         }
-      )
+      },
+      Model: {
+        async automationsStatus(parent, _args, ctx) {
+          const getStatus = getAutomationsStatus({
+            getLatestVersionAutomationRuns
+          })
 
-      return prepareInputs({ fns: fnsForRedaction, publicKey: parent.publicKey })
-    }
-  },
-  AutomationRevisionFunction: {
-    async parameters(parent) {
-      return parent.functionInputs
-    }
-  },
-  AutomateFunction: {
-    async automationCount(parent, _args, ctx) {
-      return ctx.loaders.automations.getFunctionAutomationCount.load(parent.id)
-    },
-    async releases(parent, args) {
-      // TODO: Replace w/ dataloader batch call, when/if possible
-      const fn = await getFunction({
-        functionId: parent.id,
-        releases:
-          args?.cursor || args?.filter?.search || args?.limit
-            ? {
-                cursor: args.cursor || undefined,
-                search: args.filter?.search || undefined,
-                limit: args.limit || undefined
+          const modelId = parent.id
+          const projectId = parent.streamId
+          const latestCommit = await ctx.loaders.branches.getLatestCommit.load(
+            parent.id
+          )
+
+          // if the model has no versions, no automations could have run
+          if (!latestCommit) return null
+
+          return await getStatus({
+            projectId,
+            modelId,
+            versionId: latestCommit.id
+          })
+        }
+      },
+      Version: {
+        async automationsStatus(parent, _args, ctx) {
+          const getStatus = getAutomationsStatus({
+            getLatestVersionAutomationRuns
+          })
+
+          const versionId = parent.id
+          const branch = await ctx.loaders.commits.getCommitBranch.load(versionId)
+          if (!branch) throw Error('Invalid version Id')
+
+          const projectId = branch.streamId
+          const modelId = branch.id
+          return await getStatus({
+            projectId,
+            modelId,
+            versionId
+          })
+        }
+      },
+      Automation: {
+        async currentRevision(parent, _args, ctx) {
+          return ctx.loaders.automations.getLatestAutomationRevision.load(parent.id)
+        },
+        async runs(parent, args) {
+          const retrievalArgs = {
+            automationId: parent.id,
+            ...args
+          }
+
+          const [{ items, cursor }, totalCount] = await Promise.all([
+            getAutomationRunsItems({
+              args: retrievalArgs
+            }),
+            getAutomationRunsTotalCount({
+              args: retrievalArgs
+            })
+          ])
+
+          return {
+            items,
+            totalCount,
+            cursor
+          }
+        },
+        async creationPublicKeys(parent, _args, ctx) {
+          await authorizeResolver(
+            ctx.userId!,
+            parent.projectId,
+            Roles.Stream.Owner,
+            ctx.resourceAccessRules
+          )
+
+          const publicKey = await getEncryptionPublicKey()
+          return [publicKey]
+        }
+      },
+      AutomateRun: {
+        async trigger(parent, _args, ctx) {
+          const triggers =
+            parent.triggers ||
+            (await ctx.loaders.automations.getRunTriggers.load(parent.id))
+
+          const trigger = triggers[0]
+          return trigger
+        },
+        async functionRuns(parent) {
+          return parent.functionRuns
+        },
+        async automation(parent, _args, ctx) {
+          return ctx.loaders.automations.getAutomation.load(parent.automationId)
+        },
+        status: (parent) => mapDbStatusToGqlStatus(parent.status)
+      },
+      TriggeredAutomationsStatus: {
+        status: (parent) => mapDbStatusToGqlStatus(parent.status)
+      },
+      AutomateFunctionRun: {
+        async function(parent, _args, ctx) {
+          const fn = await ctx.loaders.automationsApi.getFunction.load(
+            parent.functionId
+          )
+          if (!fn) {
+            throw new FunctionNotFoundError('Function not found', {
+              info: { id: parent.functionId }
+            })
+          }
+
+          return convertFunctionToGraphQLReturn(fn)
+        },
+        results(parent, _args, ctx) {
+          try {
+            return parent.results
+              ? Automate.AutomateTypes.formatResultsSchema(parent.results)
+              : null
+          } catch (e) {
+            ctx.log.warn('Error formatting results schema', e)
+          }
+        },
+        status: (parent) => mapDbStatusToGqlStatus(parent.status)
+      },
+      AutomationRevision: {
+        async triggerDefinitions(parent, _args, ctx) {
+          const triggers =
+            await ctx.loaders.automations.getRevisionTriggerDefinitions.load(parent.id)
+
+          return triggers
+        },
+        async functions(parent, _args, ctx) {
+          const prepareInputs = getFunctionInputsForFrontend({
+            getEncryptionKeyPairFor,
+            buildDecryptor,
+            redactWriteOnlyInputData
+          })
+
+          const fns = await ctx.loaders.automations.getRevisionFunctions.load(parent.id)
+          const fnsReleases = keyBy(
+            (
+              await ctx.loaders.automationsApi.getFunctionRelease.loadMany(
+                fns.map((fn) => [fn.functionId, fn.functionReleaseId])
+              )
+            ).filter(
+              (r): r is FunctionReleaseSchemaType => r !== null && !(r instanceof Error)
+            ),
+            (r) => r.functionVersionId
+          )
+
+          const fnsForRedaction: AutomationRevisionFunctionForInputRedaction[] =
+            fns.map((fn) => {
+              const release = fnsReleases[fn.functionReleaseId]
+              if (!release) {
+                throw new AutomateFunctionReleaseNotFoundError(
+                  `Could not find function release #${fn.functionReleaseId} for function #${fn.functionId}`,
+                  {
+                    info: {
+                      functionId: fn.functionId,
+                      functionReleaseId: fn.functionReleaseId
+                    }
+                  }
+                )
               }
-            : {}
-      })
 
-      return {
-        cursor: fn.versionCursor,
-        totalCount: fn.versionCount,
-        items: fn.functionVersions.map((r) =>
-          convertFunctionReleaseToGraphQLReturn({ ...r, functionId: parent.id })
-        )
-      }
-    }
-  },
-  AutomateFunctionRelease: {
-    async function(parent, _args, ctx) {
-      const fn = await ctx.loaders.automationsApi.getFunction.load(parent.functionId)
-      if (!fn) {
-        throw new FunctionNotFoundError('Function not found', {
-          info: { id: parent.functionId }
-        })
-      }
+              return {
+                ...fn,
+                release
+              }
+            })
 
-      return convertFunctionToGraphQLReturn(fn)
-    }
-  },
-  AutomateMutations: {
-    async createFunction(_parent, args, ctx) {
-      const create = createFunctionFromTemplate({
-        createExecutionEngineFn: createFunction,
-        getUser
-      })
-
-      return (await create({ input: args.input, userId: ctx.userId! })).graphqlReturn
-    },
-    async updateFunction(_parent, args, ctx) {
-      const update = updateFunction({
-        updateFunction: execEngineUpdateFunction,
-        getFunction
-      })
-      return await update({ input: args.input, userId: ctx.userId! })
-    }
-  },
-  ProjectAutomationMutations: {
-    async create(parent, { input }, ctx) {
-      const testAutomateAuthCode = process.env['TEST_AUTOMATE_AUTHENTICATION_CODE']
-      const create = createAutomation({
-        createAuthCode: testAutomateAuthCode
-          ? async () => testAutomateAuthCode
-          : createStoredAuthCode({ redis: getGenericRedis() }),
-        automateCreateAutomation: clientCreateAutomation,
-        storeAutomation
-      })
-
-      return (
-        await create({
-          input,
-          userId: ctx.userId!,
-          projectId: parent.projectId,
-          userResourceAccessRules: ctx.resourceAccessRules
-        })
-      ).automation
-    },
-    async update(parent, { input }, ctx) {
-      const update = updateAutomation({
-        getAutomation,
-        updateAutomation: updateDbAutomation
-      })
-
-      return await update({
-        input,
-        userId: ctx.userId!,
-        projectId: parent.projectId,
-        userResourceAccessRules: ctx.resourceAccessRules
-      })
-    },
-    async createRevision(parent, { input }, ctx) {
-      const create = createAutomationRevision({
-        getAutomation,
-        storeAutomationRevision,
-        getBranchesByIds,
-        getFunctionRelease,
-        getEncryptionKeyPair,
-        getFunctionInputDecryptor: getFunctionInputDecryptor({ buildDecryptor }),
-        getFunctionReleases
-      })
-
-      return await create({
-        input,
-        projectId: parent.projectId,
-        userId: ctx.userId!,
-        userResourceAccessRules: ctx.resourceAccessRules
-      })
-    },
-    async trigger(parent, { automationId }, ctx) {
-      const trigger = manuallyTriggerAutomation({
-        getAutomationTriggerDefinitions,
-        getAutomation,
-        getBranchLatestCommits,
-        triggerFunction: triggerAutomationRevisionRun({
-          automateRunTrigger: triggerAutomationRun,
-          getEncryptionKeyPairFor,
-          getFunctionInputDecryptor: getFunctionInputDecryptor({ buildDecryptor })
-        })
-      })
-
-      await trigger({
-        automationId,
-        userId: ctx.userId!,
-        userResourceAccessRules: ctx.resourceAccessRules,
-        projectId: parent.projectId
-      })
-
-      return true
-    }
-  },
-  Query: {
-    async automateValidateAuthCode(_parent, { code }) {
-      const validate = validateStoredAuthCode({
-        redis: getGenericRedis()
-      })
-      return await validate(code)
-    },
-    async automateFunction(_parent, { id }, ctx) {
-      const fn = await ctx.loaders.automationsApi.getFunction.load(id)
-      if (!fn) {
-        throw new FunctionNotFoundError('Function not found', {
-          info: { id }
-        })
-      }
-
-      return convertFunctionToGraphQLReturn(fn)
-    },
-    async automateFunctions(_parent, args) {
-      const res = await getFunctions({
-        query: {
-          query: args.filter?.search || undefined,
-          cursor: args.cursor || undefined,
-          limit: isNullOrUndefined(args.limit) ? undefined : args.limit,
-          functionsWithoutVersions: args.filter?.functionsWithoutReleases || undefined,
-          featuredFunctionsOnly: args.filter?.featuredFunctionsOnly || undefined
+          return prepareInputs({ fns: fnsForRedaction, publicKey: parent.publicKey })
         }
-      })
+      },
+      AutomationRevisionFunction: {
+        async parameters(parent) {
+          return parent.functionInputs
+        }
+      },
+      AutomateFunction: {
+        async automationCount(parent, _args, ctx) {
+          return ctx.loaders.automations.getFunctionAutomationCount.load(parent.id)
+        },
+        async releases(parent, args) {
+          // TODO: Replace w/ dataloader batch call, when/if possible
+          const fn = await getFunction({
+            functionId: parent.id,
+            releases:
+              args?.cursor || args?.filter?.search || args?.limit
+                ? {
+                    cursor: args.cursor || undefined,
+                    search: args.filter?.search || undefined,
+                    limit: args.limit || undefined
+                  }
+                : {}
+          })
 
-      const items = res.items.map(convertFunctionToGraphQLReturn)
+          return {
+            cursor: fn.versionCursor,
+            totalCount: fn.versionCount,
+            items: fn.functionVersions.map((r) =>
+              convertFunctionReleaseToGraphQLReturn({ ...r, functionId: parent.id })
+            )
+          }
+        }
+      },
+      AutomateFunctionRelease: {
+        async function(parent, _args, ctx) {
+          const fn = await ctx.loaders.automationsApi.getFunction.load(
+            parent.functionId
+          )
+          if (!fn) {
+            throw new FunctionNotFoundError('Function not found', {
+              info: { id: parent.functionId }
+            })
+          }
 
-      return {
-        cursor: res.cursor,
-        totalCount: res.totalCount,
-        items
-      }
-    }
-  },
-  User: {
-    // TODO: Needs proper integration w/ Execution engine
-    automateInfo: () => ({
-      hasAutomateGithubApp: false,
-      availableGithubOrgs: []
-    })
-  },
-  ServerInfo: {
-    // TODO: Needs proper integration w/ Execution engine
-    automate: () => ({
-      availableFunctionTemplates: functionTemplateRepos.slice()
-    })
-  },
-  ProjectMutations: {
-    async automationMutations(_parent, { projectId }, ctx) {
-      await validateStreamAccess(
-        ctx.userId!,
-        projectId,
-        Roles.Stream.Owner,
-        ctx.resourceAccessRules
-      )
-      return { projectId }
-    }
-  },
-  Mutation: {
-    async automateFunctionRunStatusReport(_parent, { input }) {
-      const deps: ReportFunctionRunStatusDeps = {
-        getAutomationFunctionRunRecord: getFunctionRun,
-        upsertAutomationFunctionRunRecord: upsertAutomationFunctionRun,
-        automationRunUpdater: updateAutomationRun
-      }
+          return convertFunctionToGraphQLReturn(fn)
+        }
+      },
+      AutomateMutations: {
+        async createFunction(_parent, args, ctx) {
+          const create = createFunctionFromTemplate({
+            createExecutionEngineFn: createFunction,
+            getUser
+          })
 
-      const payload = {
-        ...input,
-        contextView: input.contextView ?? null,
-        results: (input.results as Automate.AutomateTypes.ResultsSchema) ?? null,
-        runId: input.functionRunId,
-        status: mapGqlStatusToDbStatus(input.status),
-        statusMessage: input.statusMessage ?? null
-      }
+          return (await create({ input: args.input, userId: ctx.userId! }))
+            .graphqlReturn
+        },
+        async updateFunction(_parent, args, ctx) {
+          const update = updateFunction({
+            updateFunction: execEngineUpdateFunction,
+            getFunction
+          })
+          return await update({ input: args.input, userId: ctx.userId! })
+        }
+      },
+      ProjectAutomationMutations: {
+        async create(parent, { input }, ctx) {
+          const testAutomateAuthCode = process.env['TEST_AUTOMATE_AUTHENTICATION_CODE']
+          const create = createAutomation({
+            createAuthCode: testAutomateAuthCode
+              ? async () => testAutomateAuthCode
+              : createStoredAuthCode({ redis: getGenericRedis() }),
+            automateCreateAutomation: clientCreateAutomation,
+            storeAutomation
+          })
 
-      const result = await reportFunctionRunStatus(deps)(payload)
+          return (
+            await create({
+              input,
+              userId: ctx.userId!,
+              projectId: parent.projectId,
+              userResourceAccessRules: ctx.resourceAccessRules
+            })
+          ).automation
+        },
+        async update(parent, { input }, ctx) {
+          const update = updateAutomation({
+            getAutomation,
+            updateAutomation: updateDbAutomation
+          })
 
-      return result
-    },
-    automateMutations: () => ({})
-  },
-  Subscription: {
-    projectTriggeredAutomationsStatusUpdated: {
-      subscribe: filteredSubscribe(
-        ProjectSubscriptions.ProjectTriggeredAutomationsStatusUpdated,
-        async (payload, args, ctx) => {
-          if (payload.projectId !== args.projectId) return false
+          return await update({
+            input,
+            userId: ctx.userId!,
+            projectId: parent.projectId,
+            userResourceAccessRules: ctx.resourceAccessRules
+          })
+        },
+        async createRevision(parent, { input }, ctx) {
+          const create = createAutomationRevision({
+            getAutomation,
+            storeAutomationRevision,
+            getBranchesByIds,
+            getFunctionRelease,
+            getEncryptionKeyPair,
+            getFunctionInputDecryptor: getFunctionInputDecryptor({ buildDecryptor }),
+            getFunctionReleases
+          })
 
-          await authorizeResolver(
-            ctx.userId,
-            payload.projectId,
+          return await create({
+            input,
+            projectId: parent.projectId,
+            userId: ctx.userId!,
+            userResourceAccessRules: ctx.resourceAccessRules
+          })
+        },
+        async trigger(parent, { automationId }, ctx) {
+          const trigger = manuallyTriggerAutomation({
+            getAutomationTriggerDefinitions,
+            getAutomation,
+            getBranchLatestCommits,
+            triggerFunction: triggerAutomationRevisionRun({
+              automateRunTrigger: triggerAutomationRun,
+              getEncryptionKeyPairFor,
+              getFunctionInputDecryptor: getFunctionInputDecryptor({ buildDecryptor })
+            })
+          })
+
+          await trigger({
+            automationId,
+            userId: ctx.userId!,
+            userResourceAccessRules: ctx.resourceAccessRules,
+            projectId: parent.projectId
+          })
+
+          return true
+        }
+      },
+      Query: {
+        async automateValidateAuthCode(_parent, { code }) {
+          const validate = validateStoredAuthCode({
+            redis: getGenericRedis()
+          })
+          return await validate(code)
+        },
+        async automateFunction(_parent, { id }, ctx) {
+          const fn = await ctx.loaders.automationsApi.getFunction.load(id)
+          if (!fn) {
+            throw new FunctionNotFoundError('Function not found', {
+              info: { id }
+            })
+          }
+
+          return convertFunctionToGraphQLReturn(fn)
+        },
+        async automateFunctions(_parent, args) {
+          const res = await getFunctions({
+            query: {
+              query: args.filter?.search || undefined,
+              cursor: args.cursor || undefined,
+              limit: isNullOrUndefined(args.limit) ? undefined : args.limit,
+              functionsWithoutVersions:
+                args.filter?.functionsWithoutReleases || undefined,
+              featuredFunctionsOnly: args.filter?.featuredFunctionsOnly || undefined
+            }
+          })
+
+          const items = res.items.map(convertFunctionToGraphQLReturn)
+
+          return {
+            cursor: res.cursor,
+            totalCount: res.totalCount,
+            items
+          }
+        }
+      },
+      User: {
+        // TODO: Needs proper integration w/ Execution engine
+        automateInfo: () => ({
+          hasAutomateGithubApp: false,
+          availableGithubOrgs: []
+        })
+      },
+      ServerInfo: {
+        // TODO: Needs proper integration w/ Execution engine
+        automate: () => ({
+          availableFunctionTemplates: functionTemplateRepos.slice()
+        })
+      },
+      ProjectMutations: {
+        async automationMutations(_parent, { projectId }, ctx) {
+          await validateStreamAccess(
+            ctx.userId!,
+            projectId,
             Roles.Stream.Owner,
             ctx.resourceAccessRules
           )
-          return true
+          return { projectId }
         }
-      )
-    },
-    projectAutomationsUpdated: {
-      subscribe: filteredSubscribe(
-        ProjectSubscriptions.ProjectAutomationsUpdated,
-        async (payload, args, ctx) => {
-          if (payload.projectId !== args.projectId) return false
+      },
+      Mutation: {
+        async automateFunctionRunStatusReport(_parent, { input }) {
+          const deps: ReportFunctionRunStatusDeps = {
+            getAutomationFunctionRunRecord: getFunctionRun,
+            upsertAutomationFunctionRunRecord: upsertAutomationFunctionRun,
+            automationRunUpdater: updateAutomationRun
+          }
 
-          await authorizeResolver(
-            ctx.userId,
-            payload.projectId,
-            Roles.Stream.Owner,
-            ctx.resourceAccessRules
+          const payload = {
+            ...input,
+            contextView: input.contextView ?? null,
+            results: (input.results as Automate.AutomateTypes.ResultsSchema) ?? null,
+            runId: input.functionRunId,
+            status: mapGqlStatusToDbStatus(input.status),
+            statusMessage: input.statusMessage ?? null
+          }
+
+          const result = await reportFunctionRunStatus(deps)(payload)
+
+          return result
+        },
+        automateMutations: () => ({})
+      },
+      Subscription: {
+        projectTriggeredAutomationsStatusUpdated: {
+          subscribe: filteredSubscribe(
+            ProjectSubscriptions.ProjectTriggeredAutomationsStatusUpdated,
+            async (payload, args, ctx) => {
+              if (payload.projectId !== args.projectId) return false
+
+              await authorizeResolver(
+                ctx.userId,
+                payload.projectId,
+                Roles.Stream.Owner,
+                ctx.resourceAccessRules
+              )
+              return true
+            }
           )
-          return true
+        },
+        projectAutomationsUpdated: {
+          subscribe: filteredSubscribe(
+            ProjectSubscriptions.ProjectAutomationsUpdated,
+            async (payload, args, ctx) => {
+              if (payload.projectId !== args.projectId) return false
+
+              await authorizeResolver(
+                ctx.userId,
+                payload.projectId,
+                Roles.Stream.Owner,
+                ctx.resourceAccessRules
+              )
+              return true
+            }
+          )
         }
-      )
+      }
     }
-  }
-} as Resolvers
+  : {
+      /**
+       * If automate module is disabled
+       */
+      Project: {
+        automation: () => {
+          throw new AutomateApiDisabledError()
+        },
+        automations: () => {
+          throw new AutomateApiDisabledError()
+        }
+      },
+      AutomateMutations: {
+        createFunction: () => {
+          throw new AutomateApiDisabledError()
+        },
+        updateFunction: () => {
+          throw new AutomateApiDisabledError()
+        }
+      },
+      ProjectAutomationMutations: {
+        create: () => {
+          throw new AutomateApiDisabledError()
+        },
+        update: () => {
+          throw new AutomateApiDisabledError()
+        },
+        createRevision: () => {
+          throw new AutomateApiDisabledError()
+        },
+        trigger: () => {
+          throw new AutomateApiDisabledError()
+        }
+      },
+      Query: {
+        automateValidateAuthCode: () => {
+          throw new AutomateApiDisabledError()
+        },
+        automateFunction: () => {
+          throw new AutomateApiDisabledError()
+        },
+        automateFunctions: () => {
+          throw new AutomateApiDisabledError()
+        }
+      },
+      User: {
+        automateInfo: () => ({
+          hasAutomateGithubApp: false,
+          availableGithubOrgs: []
+        })
+      },
+      ServerInfo: {
+        automate: () => ({
+          availableFunctionTemplates: []
+        })
+      },
+      Mutation: {
+        automateFunctionRunStatusReport: () => {
+          throw new AutomateApiDisabledError()
+        },
+        automateMutations: () => ({})
+      },
+      Subscription: {
+        projectTriggeredAutomationsStatusUpdated: {
+          subscribe: filteredSubscribe(
+            ProjectSubscriptions.ProjectTriggeredAutomationsStatusUpdated,
+            () => false
+          )
+        },
+        projectAutomationsUpdated: {
+          subscribe: filteredSubscribe(
+            ProjectSubscriptions.ProjectAutomationsUpdated,
+            () => false
+          )
+        }
+      }
+    }) as Resolvers

--- a/packages/server/modules/index.js
+++ b/packages/server/modules/index.js
@@ -107,6 +107,8 @@ exports.shutdown = async () => {
 }
 
 /**
+ * GQL components will be loaded even from disabled modules to avoid schema complexity, so ensure
+ * that resolvers return valid values even if the module is disabled
  * @returns {Pick<import('apollo-server-express').Config, 'resolvers' | 'typeDefs'> & { directiveBuilders: Record<string, import('@/modules/core/graph/helpers/directiveHelper').GraphqlDirectiveBuilder>}}
  */
 const graphComponents = () => {
@@ -116,13 +118,9 @@ const graphComponents = () => {
   let resolverObjs = []
   let directiveBuilders = {}
 
-  const enabledModules = getEnabledModuleNames()
-
   // load typedefs from /assets
   const assetModuleDirs = fs.readdirSync(`${packageRoot}/assets`)
   assetModuleDirs.forEach((dir) => {
-    // if module is not in the enabled modules list, skip loading the gql schema
-    // if (!enabledModules.includes(dir)) return
     const typeDefDirPath = path.join(`${packageRoot}/assets`, dir, 'typedefs')
     if (fs.existsSync(typeDefDirPath)) {
       const moduleSchemas = fs.readdirSync(typeDefDirPath)
@@ -135,8 +133,6 @@ const graphComponents = () => {
   // load code modules from /modules
   const codeModuleDirs = fs.readdirSync(`${appRoot}/modules`)
   codeModuleDirs.forEach((file) => {
-    // if module is not in the enabled modules list, skip loading the gql resolvers
-    if (!enabledModules.includes(file)) return
     const fullPath = path.join(`${appRoot}/modules`, file)
 
     // first pass load of resolvers


### PR DESCRIPTION
tl;dr; Even if a module is disabled, its GQL components (typedefs, resolvers) will still be loaded to avoid complexity on the client-side. So we must always ensure resolvers can handle the module being disabled.