### PR TITLE
fix: Remove z-index causing explode menu to be hidden

### DIFF
--- a/packages/frontend-2/components/viewer/Controls.vue
+++ b/packages/frontend-2/components/viewer/Controls.vue
@@ -176,7 +176,7 @@
     </div>
     <div
       ref="scrollableControlsContainer"
-      :class="`simple-scrollbar absolute z-10 ml-12 md:ml-14 mb-4 max-h-[calc(100dvh-4.5rem)] overflow-y-auto px-[2px] py-[2px] transition z-20 ${
+      :class="`simple-scrollbar absolute z-10 ml-12 md:ml-14 mb-4 max-h-[calc(100dvh-4.5rem)] overflow-y-auto px-[2px] py-[2px] transition ${
         activeControl !== 'none'
           ? 'translate-x-0 opacity-100'
           : '-translate-x-[100%] opacity-0'


### PR DESCRIPTION
During the Gendo integration, a z-index was added to the controls sidebar to aid in making it resizeable. This meant the lower control items were not visible. 

This is a quick change to remove this z-index, and fall back to the already declared z-10. 

@didimitrie It may be that this z-20 was needed, but I have done a good bit of testing and everything still seems to work. Maybe you can remember why it was needed?

Before:
<img width="434" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/382600b1-73b6-48b4-856e-209c56d50e6a">

After:
<img width="427" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/4dc2511a-54ce-4744-b7a2-87e6a5df1f8a">
