### PR TITLE
fix(fe2): hide switch label in webhooks

### DIFF
--- a/packages/frontend-2/components/project/page/settings/webhooks/Webhooks.vue
+++ b/packages/frontend-2/components/project/page/settings/webhooks/Webhooks.vue
@@ -52,6 +52,7 @@
             :model-value="!!item.enabled"
             icons
             :name="'switch-' + item.id"
+            :show-label="false"
             class="scale-90"
             @update:model-value="(newValue) => onEnabledChange(item, newValue)"
           />


### PR DESCRIPTION
## Description & motivation
A label has appeared in the Webhooks table, showing the Switch name. It has now been turned off. 

![image](https://github.com/specklesystems/speckle-server/assets/139135120/b30ce906-b1b0-4c70-bc66-0d40468b43d2)
