### PR TITLE
feat(fe2): add tooltip to "Open selection in new window"

### DIFF
--- a/packages/frontend-2/components/viewer/selection/Sidebar.vue
+++ b/packages/frontend-2/components/viewer/selection/Sidebar.vue
@@ -31,6 +31,7 @@
         <div class="flex justify-end w-full">
           <div v-tippy="`Open selection in new window`" class="max-w-max">
             <FormButton size="xs" :to="selectionLink" color="secondary" target="_blank">
+              <span class="sr-only">Open selection in new window</span>
               <ArrowTopRightOnSquareIcon class="w-4" />
             </FormButton>
           </div>

--- a/packages/frontend-2/components/viewer/selection/Sidebar.vue
+++ b/packages/frontend-2/components/viewer/selection/Sidebar.vue
@@ -28,16 +28,12 @@
             Isolate
           </div>
         </FormButton>
-        <div class="w-full text-right">
-          <FormButton
-            title="Open selection in new window"
-            size="xs"
-            text
-            :to="selectionLink"
-            target="_blank"
-          >
-            <ArrowTopRightOnSquareIcon class="w-4" />
-          </FormButton>
+        <div class="flex justify-end w-full">
+          <div v-tippy="`Open selection in new window`" class="max-w-max">
+            <FormButton size="xs" :to="selectionLink" color="secondary" target="_blank">
+              <ArrowTopRightOnSquareIcon class="w-4" />
+            </FormButton>
+          </div>
         </div>
       </template>
       <div class="p-1 mb-2 sm:mb-0 sm:py-2">


### PR DESCRIPTION
## Description & motivation
<img width="335" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/93f8b02c-bf18-419b-8822-4be6c4a38b03">

Add a Tooltip to the new "Open selection in new window" button in the selection info panel.

I'm not entirely sure why the tooltip would not work properly when applied to the button, but wrapping the button in a div, and applying v-tippy to this worked fine. 