### PR TITLE
feat(fe2): Allow selection of hidden items from Scene Explorer

### DIFF
--- a/packages/frontend-2/components/viewer/explorer/StringFilterItem.vue
+++ b/packages/frontend-2/components/viewer/explorer/StringFilterItem.vue
@@ -95,8 +95,6 @@ const availableTargetIds = computed(() => {
   if (isolatedObjectIds.value.length)
     targets = props.item.ids.filter((id) => isolatedObjectIds.value.includes(id))
 
-  if (hiddenObjectIds.value.length)
-    targets = props.item.ids.filter((id) => !hiddenObjectIds.value.includes(id))
   return targets
 })
 

--- a/packages/frontend-2/components/viewer/explorer/TreeItem.vue
+++ b/packages/frontend-2/components/viewer/explorer/TreeItem.vue
@@ -316,7 +316,6 @@ const isSelected = computed(() => {
 })
 
 const setSelection = (e: MouseEvent) => {
-  if (isHidden.value) return
   if (isSelected.value && !e.shiftKey) {
     clearSelection()
     return
@@ -352,7 +351,6 @@ const isIsolated = computed(() => {
 const hideOrShowObject = () => {
   const ids = getTargetObjectIds(rawSpeckleData)
   if (!isHidden.value) {
-    removeFromSelection(rawSpeckleData)
     hideObjects(ids)
     return
   }

--- a/packages/frontend-2/components/viewer/selection/Sidebar.vue
+++ b/packages/frontend-2/components/viewer/selection/Sidebar.vue
@@ -9,10 +9,13 @@
           class="opacity-80 hover:opacity-100"
           @click.stop="hideOrShowSelection"
         >
-          <div class="flex items-center gap-1">
-            <EyeIcon v-if="!isHidden" class="h-4 w-4" />
-            <EyeSlashIcon v-else class="h-4 w-4" />
+          <div v-if="!isHidden" class="flex items-center gap-1">
+            <EyeSlashIcon class="h-4 w-4" />
             Hide
+          </div>
+          <div v-else class="flex items-center gap-1">
+            <EyeIcon class="h-4 w-4" />
+            Unhide
           </div>
         </FormButton>
         <FormButton


### PR DESCRIPTION
## Description & motivation
1. Make it possible to select hidden elements from the Scene Explorer and Filters. Behaviour when selecting: Show outline of element, open the selection info panel, but it’s still hidden.

2. Don’t deselect an element if you hide it from the Scene Explorer. Create the same experience as when you hide an element from the Selection Info panel.

## Changes:
- Remove hidden item check from setSelection
- Remove hidden item check from availableTargetIds
- removeFromSelection even if hidden
- Update "Hide/Unhide" sidebar text to make it more clear