### PR TITLE
Small fix: test automations are never triggered

### DIFF
--- a/packages/frontend-2/components/project/page/automations/Row.vue
+++ b/packages/frontend-2/components/project/page/automations/Row.vue
@@ -35,7 +35,7 @@
     <div class="flex flex-col mb-6">
       <template v-if="triggerModels.length">
         <div class="flex gap-2">
-          <div class="mt-1">Triggered by</div>
+          <div class="mt-1">{{ triggerLabel }}</div>
           <div v-for="model in triggerModels" :key="model.id" class="truncate">
             <CommonTextLink :icon-left="CubeIcon" :to="finalModelUrl(model.id)">
               {{ model.name }}
@@ -111,6 +111,10 @@ const triggerModels = computed(
       (trigger) => trigger.model
     ) || []
 )
+
+const triggerLabel = computed(() => {
+  return isTestAutomation.value ? 'Connected to' : 'Triggered by'
+})
 
 const finalModelUrl = (modelId: string) =>
   modelUrl({ projectId: props.projectId, modelId })


### PR DESCRIPTION
Caught a small copy error when testing test automations. Currently each entry will say "triggered by [Model]" when this is not true for test automations.

Changed to "connected to" but open to any phrasing:

![Screen Shot 2024-06-03 at 15 15 00](https://github.com/specklesystems/speckle-server/assets/20760128/0301169a-43fb-48f8-8bb4-548b31fabbc1)
