### PR TITLE
fix(fe2): set height of selection info header to avoid transparency issue

### DIFF
--- a/packages/frontend-2/components/viewer/Sidebar.vue
+++ b/packages/frontend-2/components/viewer/Sidebar.vue
@@ -37,7 +37,7 @@
       >
         <!-- Header -->
         <div
-          class="h-18 absolute z-10 top-0 w-full left-0 bg-foundation shadow-md sm:rounded-t-md"
+          class="h-[4.5rem] absolute z-10 top-0 w-full left-0 bg-foundation shadow-md sm:rounded-t-md"
         >
           <div
             class="flex items-center justify-between pl-3 pr-2.5 h-10 border-b border-outline-3"
@@ -57,7 +57,7 @@
             </div>
           </div>
         </div>
-        <div class="w-full" :class="$slots.actions ? 'h-16 sm:h-20' : 'h-10'"></div>
+        <div class="w-full" :class="$slots.actions ? 'h-[4.5rem]' : 'h-10'"></div>
         <div
           class="overflow-y-auto simple-scrollbar h-full bg-foundation w-full pt-2 sm:rounded-b-md"
         >


### PR DESCRIPTION
## Description & motivation
![image](https://github.com/specklesystems/speckle-server/assets/139135120/aaa8c79d-ebdc-4342-9af5-617c70d79407)

## Changes:
- Remove `h-18` - this is not a defined Tailwind height
- Match height in header spacer