### PR TITLE
Remove various hover transitions around the viewer

### DIFF
--- a/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
@@ -35,7 +35,7 @@
         <div
           v-if="modelValue.isExpanded && canPostComment"
           ref="threadContainer"
-          class="sm:absolute min-w-[200px] hover:bg-foundation transition bg-white/80 dark:bg-neutral-800/90 dark:hover:bg-neutral-800 backdrop-blur-sm sm:rounded-lg shadow-md"
+          class="sm:absolute min-w-[200px] hover:bg-foundation bg-white/80 dark:bg-neutral-800/90 dark:hover:bg-neutral-800 backdrop-blur-sm sm:rounded-lg shadow-md"
         >
           <div class="relative">
             <ViewerCommentsEditor

--- a/packages/frontend-2/components/viewer/explorer/Filters.vue
+++ b/packages/frontend-2/components/viewer/explorer/Filters.vue
@@ -63,7 +63,7 @@
           class="text-xs"
         >
           <button
-            class="block w-full text-left hover:bg-primary-muted transition truncate rounded-md py-1 px-2 mx-2"
+            class="block w-full text-left hover:bg-primary-muted truncate rounded-md py-1 px-2 mx-2"
             @click="
               ;(showAllFilters = false),
                 setPropertyFilter(filter),

--- a/packages/frontend-2/components/viewer/explorer/StringFilterItem.vue
+++ b/packages/frontend-2/components/viewer/explorer/StringFilterItem.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
     <div
-      :class="`flex group pl-1 justify-between items-center w-full max-w-full overflow-hidden select-none space-x-2 rounded border-l-4 hover:bg-primary-muted hover:shadow-md transition-all text-foreground cursor-pointer ${
+      :class="`flex group pl-1 justify-between items-center w-full max-w-full overflow-hidden select-none space-x-2 rounded border-l-4 hover:bg-primary-muted hover:shadow-md text-foreground cursor-pointer ${
         isSelected ? 'border-primary bg-primary-muted' : 'border-transparent'
       }`"
       @click="setSelection()"

--- a/packages/frontend-2/components/viewer/explorer/TreeItem.vue
+++ b/packages/frontend-2/components/viewer/explorer/TreeItem.vue
@@ -14,7 +14,7 @@
             @click="manualUnfoldToggle()"
           >
             <ChevronDownIcon
-              :class="`h-3 w-3 transition ${!unfold ? '-rotate-90' : 'rotate-0'} ${
+              :class="`h-3 w-3 ${!unfold ? '-rotate-90' : 'rotate-0'} ${
                 isSelected ? 'text-primary' : ''
               }`"
             />
@@ -22,7 +22,7 @@
         </div>
         <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
         <div
-          :class="`hover:bg-primary-muted group flex flex-grow cursor-pointer items-center space-x-1 overflow-hidden rounded border-l-4 pl-2 pr-1 transition hover:shadow-md
+          :class="`hover:bg-primary-muted group flex flex-grow cursor-pointer items-center space-x-1 overflow-hidden rounded border-l-4 pl-2 pr-1 hover:shadow-md
             ${isSelected ? 'border-primary bg-primary-muted' : 'border-transparent'}
           `"
           @click="(e:MouseEvent) => setSelection(e)"
@@ -50,9 +50,9 @@
           <div class="flex-grow"></div>
           <div class="flex flex-shrink-0 items-center space-x-1">
             <!-- <div v-if="!(isSingleCollection || isMultipleCollection)"> -->
-            <div class="flex space-x-2 transition">
+            <div class="flex space-x-2">
               <button
-                :class="`hover:text-primary px-1 py-2 opacity-0 transition group-hover:opacity-100 ${
+                :class="`hover:text-primary px-1 py-2 opacity-0 group-hover:opacity-100 ${
                   isHidden ? 'opacity-100' : ''
                 }`"
                 @click.stop="hideOrShowObject"
@@ -61,7 +61,7 @@
                 <EyeSlashIcon v-else class="h-3 w-3" />
               </button>
               <button
-                :class="`hover:text-primary px-1 py-2 opacity-0 transition group-hover:opacity-100 ${
+                :class="`hover:text-primary px-1 py-2 opacity-0 group-hover:opacity-100 ${
                   isIsolated ? 'opacity-100' : ''
                 }`"
                 @click.stop="isolateOrUnisolateObject"

--- a/packages/frontend-2/components/viewer/resources/ModelCard.vue
+++ b/packages/frontend-2/components/viewer/resources/ModelCard.vue
@@ -2,7 +2,7 @@
   <div class="relative">
     <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
     <div
-      :class="`rounded-md border-l-4 transition  ${
+      :class="`rounded-md border-l-4  ${
         showVersions
           ? 'border-primary max-h-96 shadow-md'
           : 'hover:border-primary border-transparent'
@@ -12,7 +12,7 @@
       <div
         :class="`${
           showVersions ? 'bg-primary' : 'bg-foundation hover:bg-primary-muted'
-        } group sticky cursor-pointer top-0 z-20 flex h-10 sm:h-20 min-w-0 max-w-full items-center justify-between space-x-2 p-2 transition select-none`"
+        } group sticky cursor-pointer top-0 z-20 flex h-10 sm:h-20 min-w-0 max-w-full items-center justify-between space-x-2 p-2 select-none`"
         @click="showVersions = !showVersions"
       >
         <div>

--- a/packages/frontend-2/components/viewer/resources/VersionCard.vue
+++ b/packages/frontend-2/components/viewer/resources/VersionCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="`bg-foundation group relative block w-full space-y-2 rounded-md pb-2 text-left transition ${
+    :class="`bg-foundation group relative block w-full space-y-2 rounded-md pb-2 text-left ${
       clickable
         ? 'hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'
         : ' bg-primary-muted cursor-default'
@@ -17,7 +17,7 @@
         isLoaded
           ? 'border-primary border-r-4 border'
           : 'border-dashed border-outline-3 border-r-2'
-      } group-hover:border-primary left-[7px] z-10 transition-all`"
+      } group-hover:border-primary left-[7px] z-10`"
     ></div>
     <div
       v-if="last"

--- a/packages/frontend-2/components/viewer/views/Menu.vue
+++ b/packages/frontend-2/components/viewer/views/Menu.vue
@@ -18,7 +18,7 @@
         <!-- Canonical views first -->
         <div v-for="view in canonicalViews" :key="view.name">
           <button
-            class="hover:bg-primary-muted text-foreground w-full h-full text-xs sm:text-sm py-2 transition"
+            class="hover:bg-primary-muted text-foreground w-full h-full text-xs sm:text-sm py-2"
             @click="setView(view.name.toLowerCase() as CanonicalView)"
           >
             {{ view.name }}

--- a/packages/frontend-2/lib/viewer/composables/commentBubbles.ts
+++ b/packages/frontend-2/lib/viewer/composables/commentBubbles.ts
@@ -84,8 +84,7 @@ export function useViewerNewThreadBubble(params: {
       state.style = {
         ...state.style,
         ...result.style,
-        opacity: state.isOccluded ? '0.8' : '1.0',
-        transition: 'all 0.1s ease'
+        opacity: state.isOccluded ? '0.8' : '1.0'
       }
     }
   })
@@ -319,7 +318,6 @@ export function useExpandedThreadResponsiveLocation(params: {
         : leftForShowingOnLeftSide,
     transformOrigin: 'center center',
     transform: 'translateY(-50%)',
-    transition: 'all 0.1s ease',
     width: `${width}px`
   }))
 


### PR DESCRIPTION
I've removed various 150ms hover transitions around the viewer so it feels more snappy to navigate. The motivation is PR #2322 which might hurt the performance a bit in some situations when merged, and these hover transitions make that more noticeable. 