### PR TITLE
Fix automation creation form

### DIFF
--- a/packages/frontend-2/components/automate/automation/CreateDialog.vue
+++ b/packages/frontend-2/components/automate/automation/CreateDialog.vue
@@ -481,8 +481,8 @@ const onDialogSubmit = async (e: SubmitEvent) => {
   if (enumStep.value === AutomationCreateSteps.AutomationDetails) {
     await onDetailsSubmit(e)
   } else if (enumStep.value === AutomationCreateSteps.FunctionParameters) {
-    const validationResult = await parametersStep.value?.submit()
-    if (validationResult && !hasJsonFormErrors(validationResult)) {
+    const validationResult = (await parametersStep.value?.submit()) || {}
+    if (!hasJsonFormErrors(validationResult)) {
       step.value++
     }
   }

--- a/packages/frontend-2/lib/automate/composables/jsonSchema.ts
+++ b/packages/frontend-2/lib/automate/composables/jsonSchema.ts
@@ -4,7 +4,7 @@ import type { MaybeNullOrUndefined } from '@speckle/shared'
 import { formatJsonFormSchemaInputs } from '~/lib/automate/helpers/jsonSchema'
 
 export const hasJsonFormErrors = (event: JsonFormsChangeEvent) =>
-  (event.errors?.length || 0) > 0
+  event?.errors?.length > 0
 
 export const useJsonFormsChangeHandler = (params: {
   schema: MaybeRef<MaybeNullOrUndefined<JsonSchema>>


### PR DESCRIPTION
Fixes bug where user can't proceed from step 2 in the Create Automation form if the function doesn't have any parameters. Nothing happened when clicking the Next button in this state:
 
![CleanShot 2024-06-10 at 10 20 53@2x](https://github.com/specklesystems/speckle-server/assets/2694102/02fe1ad2-3dbf-4342-a362-742354b88669)
