### PR TITLE
Don't tint projects select input

### DIFF
--- a/packages/frontend-2/components/automate/automation/create-dialog/AutomationDetailsStep.vue
+++ b/packages/frontend-2/components/automate/automation/create-dialog/AutomationDetailsStep.vue
@@ -7,7 +7,6 @@
       show-label
       help="Choose the project where your target model is located"
       show-required
-      button-style="tinted"
       mount-menu-on-body
       :rules="projectRules"
       :allow-unset="false"


### PR DESCRIPTION
Aligns the styling of the project select input with the model input

![CleanShot 2024-06-06 at 15 56 48@2x](https://github.com/specklesystems/speckle-server/assets/2694102/1cf7bea2-e18d-4cc4-a70a-f065c1667e4d)
