### PR TITLE
Adjust table so run details button is visible

### DIFF
--- a/packages/frontend-2/components/automate/runs/Table.vue
+++ b/packages/frontend-2/components/automate/runs/Table.vue
@@ -4,9 +4,9 @@
       :columns="[
         { id: 'status', header: 'status', classes: 'col-span-2' },
         { id: 'runId', header: 'Run ID', classes: 'col-span-3' },
-        { id: 'modelVersion', header: 'Model Version', classes: 'col-span-2' },
+        { id: 'modelVersion', header: 'Model Version', classes: 'col-span-3' },
         { id: 'date', header: 'Date', classes: 'col-span-2' },
-        { id: 'duration', header: 'Duration', classes: 'col-span-3' }
+        { id: 'duration', header: 'Duration', classes: 'col-span-2' }
       ]"
       :items="runs"
       :buttons="[

--- a/packages/ui-components/src/components/layout/Table.vue
+++ b/packages/ui-components/src/components/layout/Table.vue
@@ -5,7 +5,7 @@
     >
       <div
         v-if="items.length > 0"
-        class="grid z-10 grid-cols-12 items-center gap-6 font-semibold bg-foundation-page rounded-t-lg w-full border-b border-outline-3 pb-2 pt-4 px-4 min-w-[900px]"
+        class="grid z-10 grid-cols-12 items-center gap-6 font-semibold bg-foundation-page rounded-t-lg w-full border-b border-outline-3 pb-2 pt-4 px-4 min-w-[750px]"
         :style="{ paddingRight: paddingRightStyle }"
       >
         <div
@@ -118,7 +118,7 @@ const paddingRightStyle = computed(() => {
 
 const rowsWrapperClasses = computed(() => {
   const classParts = [
-    'relative grid grid-cols-12 items-center gap-6 px-4 py-1 min-w-[900px] bg-foundation'
+    'relative grid grid-cols-12 items-center gap-6 px-4 py-1 min-w-[750px] bg-foundation'
   ]
 
   if (props.onRowClick && props.items.length) {


### PR DESCRIPTION
The button to view the run details isn't visible on the lg breakpoint on the automation page. I've decreased the table's general min width to fix this, but we need to follow up soon with a better responsive table behaviour. I've checked other tables in the product after this change and it doesn't introduce any problems.

### Before
![CleanShot 2024-06-10 at 12 52 44@2x](https://github.com/specklesystems/speckle-server/assets/2694102/66f87b10-6558-4913-a13a-560b65923984)

### After
![CleanShot 2024-06-10 at 12 48 16@2x](https://github.com/specklesystems/speckle-server/assets/2694102/249b096d-63fd-4506-ade0-403a3546b21e)
