### PR TITLE
Update use/select actions on functions

### DIFF
--- a/packages/frontend-2/components/automate/automation/create-dialog/SelectFunctionStep.vue
+++ b/packages/frontend-2/components/automate/automation/create-dialog/SelectFunctionStep.vue
@@ -21,7 +21,11 @@
             :fn="fn"
             external-more-info
             :selected="selectedFunction && selectedFunction?.id === fn.id"
-            @use="() => (selectedFunction = fn)"
+            @use="
+              () =>
+                (selectedFunction =
+                  selectedFunction && selectedFunction.id === fn.id ? null : fn)
+            "
           />
         </AutomateFunctionCardView>
         <InfiniteLoading :settings="{ identifier }" @infinite="onInfiniteLoad" />

--- a/packages/frontend-2/components/automate/automation/create-dialog/SelectFunctionStep.vue
+++ b/packages/frontend-2/components/automate/automation/create-dialog/SelectFunctionStep.vue
@@ -24,7 +24,7 @@
             @use="
               () =>
                 (selectedFunction =
-                  selectedFunction && selectedFunction.id === fn.id ? null : fn)
+                  selectedFunction && selectedFunction.id === fn.id ? undefined : fn)
             "
           />
         </AutomateFunctionCardView>

--- a/packages/frontend-2/components/automate/function/Card.vue
+++ b/packages/frontend-2/components/automate/function/Card.vue
@@ -51,14 +51,12 @@
           >
             Learn More
           </FormButton>
-          <template v-if="selected">
-            <FormButton :icon-left="CheckIcon" @click="$emit('use')">
-              Selected
-            </FormButton>
-          </template>
-          <template v-else>
-            <FormButton @click="$emit('use')">Select</FormButton>
-          </template>
+          <FormButton
+            :icon-left="selected ? CheckIcon : undefined"
+            @click="$emit('use')"
+          >
+            {{ selected ? 'Selected' : 'Select' }}
+          </FormButton>
         </template>
       </div>
       <div class="absolute top-0 right-0">

--- a/packages/frontend-2/components/automate/function/Card.vue
+++ b/packages/frontend-2/components/automate/function/Card.vue
@@ -51,7 +51,14 @@
           >
             Learn More
           </FormButton>
-          <FormButton :icon-left="BoltIcon" @click="$emit('use')">Use</FormButton>
+          <template v-if="selected">
+            <FormButton :icon-left="CheckIcon" @click="$emit('use')">
+              Selected
+            </FormButton>
+          </template>
+          <template v-else>
+            <FormButton @click="$emit('use')">Select</FormButton>
+          </template>
         </template>
       </div>
       <div class="absolute top-0 right-0">
@@ -73,7 +80,7 @@
 <script setup lang="ts">
 import { graphql } from '~/lib/common/generated/gql'
 import type { AutomationsFunctionsCard_AutomateFunctionFragment } from '~/lib/common/generated/gql/graphql'
-import { BoltIcon, PencilIcon } from '@heroicons/vue/24/outline'
+import { CheckIcon, PencilIcon } from '@heroicons/vue/24/outline'
 import { automationFunctionRoute } from '~/lib/common/helpers/route'
 import { useMarkdown } from '~/lib/common/composables/markdown'
 

--- a/packages/frontend-2/components/automate/function/page/Header.vue
+++ b/packages/frontend-2/components/automate/function/page/Header.vue
@@ -24,7 +24,7 @@
         full-width
         @click="$emit('createAutomation')"
       >
-        Use in Automation
+        Use in an Automation
       </FormButton>
     </div>
   </div>

--- a/packages/frontend-2/components/automate/function/page/Info.vue
+++ b/packages/frontend-2/components/automate/function/page/Info.vue
@@ -81,7 +81,7 @@
         class="shrink-0"
         @click="$emit('createAutomation')"
       >
-        Use in Automation
+        Use in an Automation
       </FormButton>
     </div>
     <AutomateFunctionPageParametersDialog

--- a/packages/frontend-2/components/automate/functions/page/Items.vue
+++ b/packages/frontend-2/components/automate/functions/page/Items.vue
@@ -5,6 +5,7 @@
         v-for="fn in fns"
         :key="fn.id"
         :fn="fn"
+        no-buttons
         @use="() => $emit('createAutomationFrom', fn)"
       />
     </AutomateFunctionCardView>

--- a/packages/frontend-2/components/project/page/automations/EmptyState.vue
+++ b/packages/frontend-2/components/project/page/automations/EmptyState.vue
@@ -53,7 +53,7 @@
           v-for="fn in functions"
           :key="fn.id"
           :fn="fn"
-          @use="() => $emit('new-automation', fn)"
+          no-buttons
         />
       </AutomateFunctionCardView>
       <CommonGenericEmptyState v-else />


### PR DESCRIPTION
This PR changes various little things to improve the UX of selecting or learning more about a function. 

1. Changes button copy to "Use in **an** automation" on a functions page (Jonathon suggestion)
2. Removes the "Learn more" and "Use" buttons on the function cards in the functions gallery and on the empty state of the Automations tab. Clicking the entire a card will instead take you to the full function page. It's a much cleaner layout and I think it's a better UX even from the Automations tab.
3. Updates the "Use" button on step 1 of the Create Automation flow:
  3.1. From "Use" to "Select"
  3.2 On click it becomes "✔︎ Selected"
  3.3 Clicking again deselects 

### After

![CleanShot 2024-06-10 at 14 12 21@2x](https://github.com/specklesystems/speckle-server/assets/2694102/f364ace9-5f98-458b-ae2f-e70060daea4c)

![CleanShot 2024-06-10 at 14 41 57@2x](https://github.com/specklesystems/speckle-server/assets/2694102/9ac723b0-b123-49d1-aae0-ec69283d76be)

![CleanShot 2024-06-10 at 14 42 10@2x](https://github.com/specklesystems/speckle-server/assets/2694102/9571397f-f37f-4a67-9f8d-8d9ef5527014)
