### PR TITLE
chore(helm chart): fe2 enabled by default

### DIFF
--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -1496,7 +1496,7 @@
         },
         "enabled": {
           "type": "boolean",
-          "description": "Feature flag to enable running the new experimental frontend.",
+          "description": "Feature flag to enable running the new web application frontend.",
           "default": true
         },
         "replicas": {

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -930,7 +930,7 @@ frontend:
 
 ## @section frontend_2
 ## @descriptionStart
-## Defines parameters related to the frontend_2 component of Speckle
+## Defines parameters related to the new web application component of Speckle
 ## @descriptionEnd
 ##
 frontend_2:
@@ -946,7 +946,7 @@ frontend_2:
   ## @param frontend_2.logLevel The minimum level of logs which will be output. Suitable values are trace, debug, info, warn, error, fatal, or silent
   ##
   logLevel: 'info'
-  ## @param frontend_2.enabled Feature flag to enable running the new experimental frontend.
+  ## @param frontend_2.enabled Feature flag to enable running the new web application frontend.
   ##
   enabled: true
   ## @param frontend_2.replicas The number of instances of the Frontend 2 server prod to be deployed withing the cluster.


### PR DESCRIPTION
## Description & motivation

The New Web Application should be deployed by default via our Helm Chart for Kubernetes.

For the moment it is still possible to deploy the old frontend by disabling the new:

```
frontend_2:
  enabled: false
```

This will eventually be deprecated, but is outside the scope of this PR.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
