### PR TITLE
Set global notification from bindings

### DIFF
--- a/packages/dui3/lib/bindings/definitions/IAccountBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IAccountBinding.ts
@@ -1,8 +1,9 @@
+import { IBinding, IBindingSharedEvents } from 'lib/bindings/definitions/IBinding'
 import { BaseBridge } from '~~/lib/bridge/base'
 
 export const IAccountBindingKey = 'accountsBinding'
 
-export interface IAccountBinding {
+export interface IAccountBinding extends IBinding<IAccountBindingEvents> {
   getAccounts: () => Promise<Account[]>
 }
 
@@ -25,6 +26,8 @@ export type Account = {
     streams: { totalCount: number }
   }
 }
+
+export interface IAccountBindingEvents extends IBindingSharedEvents {}
 
 export class MockedAccountBinding extends BaseBridge {
   constructor() {

--- a/packages/dui3/lib/bindings/definitions/IBasicConnectorBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IBasicConnectorBinding.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/require-await */
 
 import { BaseBridge } from '~~/lib/bridge/base'
-import { IBinding } from '~~/lib/bindings/definitions/IBinding'
+import { IBinding, IBindingSharedEvents } from '~~/lib/bindings/definitions/IBinding'
 import { IModelCard, IModelCardSharedEvents } from '~~/lib/models/card'
 
 export const IBasicConnectorBindingKey = 'baseBinding'
@@ -24,7 +24,9 @@ export interface IBasicConnectorBinding
   removeModel: (model: IModelCard) => Promise<void>
 }
 
-export interface IBasicConnectorBindingHostEvents extends IModelCardSharedEvents {
+export interface IBasicConnectorBindingHostEvents
+  extends IBindingSharedEvents,
+    IModelCardSharedEvents {
   documentChanged: () => void
 }
 

--- a/packages/dui3/lib/bindings/definitions/IBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IBinding.ts
@@ -1,3 +1,5 @@
+import { ToastNotification } from '@speckle/ui-components'
+
 /**
  * Basic interface scaffolding two standard method.
  */
@@ -15,4 +17,8 @@ export interface IBinding<T> {
    * Opens an url in the OS's default browser.
    */
   openUrl: (url: string) => Promise<void>
+}
+
+export interface IBindingSharedEvents {
+  setGlobalNotification: (toastNotification: ToastNotification) => void
 }

--- a/packages/dui3/lib/bindings/definitions/IConfigBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IConfigBinding.ts
@@ -1,5 +1,5 @@
 import { BaseBridge } from '~/lib/bridge/base'
-import { IBinding } from '~/lib/bindings/definitions/IBinding'
+import { IBinding, IBindingSharedEvents } from '~/lib/bindings/definitions/IBinding'
 
 /**
  * The name under which this binding will be registered.
@@ -14,7 +14,7 @@ export interface IConfigBinding extends IBinding<IConfigBindingEvents> {
   updateConfig: (config: ConnectorConfig) => void
 }
 
-export interface IConfigBindingEvents {}
+export interface IConfigBindingEvents extends IBindingSharedEvents {}
 
 export type ConnectorConfig = {
   darkTheme: boolean

--- a/packages/dui3/lib/bindings/definitions/IReceiveBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IReceiveBinding.ts
@@ -1,7 +1,7 @@
 import { ConversionResult } from 'lib/conversions/conversionResult'
 import { IModelCardSharedEvents } from '~/lib/models/card'
 import { CardSetting } from '~/lib/models/card/setting'
-import { IBinding } from '~~/lib/bindings/definitions/IBinding'
+import { IBinding, IBindingSharedEvents } from '~~/lib/bindings/definitions/IBinding'
 import { BaseBridge } from '~~/lib/bridge/base'
 
 export const IReceiveBindingKey = 'receiveBinding'
@@ -12,7 +12,9 @@ export interface IReceiveBinding extends IBinding<IReceiveBindingEvents> {
   cancelReceive: (modelId: string) => Promise<void>
 }
 
-export interface IReceiveBindingEvents extends IModelCardSharedEvents {
+export interface IReceiveBindingEvents
+  extends IBindingSharedEvents,
+    IModelCardSharedEvents {
   // See note oon timeout in bridge v2; we might not need this
   setModelReceiveResult: (args: {
     modelCardId: string

--- a/packages/dui3/lib/bindings/definitions/ISelectionBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/ISelectionBinding.ts
@@ -1,4 +1,4 @@
-import { IBinding } from '~~/lib/bindings/definitions/IBinding'
+import { IBinding, IBindingSharedEvents } from '~~/lib/bindings/definitions/IBinding'
 import { BaseBridge } from '~~/lib/bridge/base'
 
 export const ISelectionBindingKey = 'selectionBinding'
@@ -7,7 +7,7 @@ export interface ISelectionBinding extends IBinding<ISelectionBindingHostEvents>
   getSelection: () => Promise<SelectionInfo>
 }
 
-export interface ISelectionBindingHostEvents {
+export interface ISelectionBindingHostEvents extends IBindingSharedEvents {
   setSelection: (args: SelectionInfo) => void
 }
 

--- a/packages/dui3/lib/bindings/definitions/ISendBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/ISendBinding.ts
@@ -1,5 +1,5 @@
 import { ISendFilter } from '~~/lib/models/card/send'
-import { IBinding } from '~~/lib/bindings/definitions/IBinding'
+import { IBinding, IBindingSharedEvents } from '~~/lib/bindings/definitions/IBinding'
 import { BaseBridge } from '~~/lib/bridge/base'
 import { CardSetting } from '~/lib/models/card/setting'
 import { IModelCardSharedEvents } from '~/lib/models/card'
@@ -14,7 +14,9 @@ export interface ISendBinding extends IBinding<ISendBindingEvents> {
   cancelSend: (modelId: string) => Promise<void>
 }
 
-export interface ISendBindingEvents extends IModelCardSharedEvents {
+export interface ISendBindingEvents
+  extends IBindingSharedEvents,
+    IModelCardSharedEvents {
   refreshSendFilters: () => void
   setModelsExpired: (modelCardIds: string[]) => void
   setModelSendResult: (args: {

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -323,6 +323,13 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   app.$sendBinding?.on('setModelProgress', handleModelProgressEvents)
   app.$receiveBinding?.on('setModelProgress', handleModelProgressEvents)
 
+  app.$baseBinding?.on('setGlobalNotification', setNotification)
+  app.$sendBinding?.on('setGlobalNotification', setNotification)
+  app.$receiveBinding?.on('setGlobalNotification', setNotification)
+  app.$configBinding?.on('setGlobalNotification', setNotification)
+  app.$accountBinding?.on('setGlobalNotification', setNotification)
+  app.$selectionBinding?.on('setGlobalNotification', setNotification)
+
   app.$sendBinding?.on('setModelError', handleModelError)
   app.$receiveBinding?.on('setModelError', handleModelError)
   app.$baseBinding.on('setModelError', handleModelError)


### PR DESCRIPTION
I've created `IBindingSharedEvents` and extend all bindings event with it to enable setting toast notification from every binding