### PR TITLE
feat(fe2): don't truncate filter name in StringFilterItem

### DIFF
--- a/packages/frontend-2/components/viewer/explorer/StringFilterItem.vue
+++ b/packages/frontend-2/components/viewer/explorer/StringFilterItem.vue
@@ -15,7 +15,7 @@
           :style="`background-color: #${color};`"
         ></span>
         <span class="truncate">
-          {{ item.value.split('.').reverse()[0] || item.value || 'No Name' }}
+          {{ item.value || 'No Name' }}
         </span>
         <div class="flex">
           <span


### PR DESCRIPTION
## Description & motivation
Currently, we parse the item value and display only the string after the last dot. This was deemed unnecessary, as it leads to loss of useful information and can cause different filters to appear identical. The change ensures the full item value is shown, avoiding these issues.

## Changes:
- Remove `item.value.split('.').reverse()[0]`