### PR TITLE
fix(fe2): add `title` attribute to buttons in the view selection menu

### DIFF
--- a/packages/frontend-2/components/viewer/views/Menu.vue
+++ b/packages/frontend-2/components/viewer/views/Menu.vue
@@ -29,6 +29,7 @@
         <div v-for="view in views" :key="view.id">
           <button
             class="hover:bg-primary-muted text-foreground w-full h-full text-xs sm:text-sm py-2 transition"
+            :title="view.name"
             @click="setView(view)"
           >
             <span class="block truncate max-w-28 mx-auto">


### PR DESCRIPTION
## Description & motivation
Ensures full view name is visible on hover when text is truncated.
<img width="305" alt="image" src="https://github.com/specklesystems/speckle-server/assets/139135120/bb2a031a-df63-4308-846a-5a67f4d382e3">

## Changes:
- Add title attribute to buttons in ViewerViewsMenu