### PR TITLE
Fix: Change /downloads links to https://speckle.systems/features/connectors/

### DIFF
--- a/packages/frontend-2/components/header/NavUserMenu.vue
+++ b/packages/frontend-2/components/header/NavUserMenu.vue
@@ -20,17 +20,18 @@
           class="absolute right-4 top-14 w-56 origin-top-right bg-foundation outline outline-2 outline-primary-muted rounded-md shadow-lg overflow-hidden"
         >
           <MenuItem v-slot="{ active }">
-            <a
+            <NuxtLink
               :class="[
                 active ? 'bg-foundation-focus' : '',
                 'flex gap-3 border-b border-primary items-center px-3 py-3 text-sm text-primary cursor-pointer transition mb-1'
               ]"
               target="_blank"
-              href="https://speckle.systems/features/connectors/"
+              external
+              :href="connectorsPageUrl"
             >
               <CloudArrowDownIcon class="w-5 h-5" />
               Connector Downloads
-            </a>
+            </NuxtLink>
           </MenuItem>
           <MenuItem v-if="activeUser" v-slot="{ active }">
             <NuxtLink
@@ -148,8 +149,8 @@ import { useActiveUser } from '~~/lib/auth/composables/activeUser'
 import { useAuthManager } from '~~/lib/auth/composables/auth'
 import { useTheme } from '~~/lib/core/composables/theme'
 import { useServerInfo } from '~/lib/core/composables/server'
+import { homeRoute, profileRoute, connectorsPageUrl } from '~/lib/common/helpers/route'
 import type { RouteLocationRaw } from 'vue-router'
-import { homeRoute, profileRoute } from '~/lib/common/helpers/route'
 
 defineProps<{
   loginUrl?: RouteLocationRaw

--- a/packages/frontend-2/components/header/NavUserMenu.vue
+++ b/packages/frontend-2/components/header/NavUserMenu.vue
@@ -20,16 +20,17 @@
           class="absolute right-4 top-14 w-56 origin-top-right bg-foundation outline outline-2 outline-primary-muted rounded-md shadow-lg overflow-hidden"
         >
           <MenuItem v-slot="{ active }">
-            <NuxtLink
+            <a
               :class="[
                 active ? 'bg-foundation-focus' : '',
                 'flex gap-3 border-b border-primary items-center px-3 py-3 text-sm text-primary cursor-pointer transition mb-1'
               ]"
-              @click="goToConnectors()"
+              target="_blank"
+              href="https://speckle.systems/features/connectors/"
             >
               <CloudArrowDownIcon class="w-5 h-5" />
               Connector Downloads
-            </NuxtLink>
+            </a>
           </MenuItem>
           <MenuItem v-if="activeUser" v-slot="{ active }">
             <NuxtLink
@@ -172,10 +173,6 @@ const isProfileRoute = computed(() => route.path === profileRoute)
 
 const toggleInviteDialog = () => {
   showInviteDialog.value = true
-}
-
-const goToConnectors = () => {
-  router.push('/downloads')
 }
 
 const goToServerManagement = () => {

--- a/packages/frontend-2/components/project/CardImportFileArea.vue
+++ b/packages/frontend-2/components/project/CardImportFileArea.vue
@@ -38,7 +38,15 @@
         :class="isModelCardVariant ? ' opacity-50 group-hover:opacity-100' : ''"
       >
         Use our
-        <FormButton link size="sm" to="/downloads">connectors</FormButton>
+        <FormButton
+          link
+          size="sm"
+          external
+          target="_blank"
+          to="https://speckle.systems/features/connectors/"
+        >
+          connectors
+        </FormButton>
         to publish a {{ modelName ? '' : 'new model' }} version to
         {{ modelName ? 'this model' : 'this project' }}, or drag and drop a IFC/OBJ/STL
         file here.

--- a/packages/frontend-2/components/project/CardImportFileArea.vue
+++ b/packages/frontend-2/components/project/CardImportFileArea.vue
@@ -38,13 +38,7 @@
         :class="isModelCardVariant ? ' opacity-50 group-hover:opacity-100' : ''"
       >
         Use our
-        <FormButton
-          link
-          size="sm"
-          external
-          target="_blank"
-          to="https://speckle.systems/features/connectors/"
-        >
+        <FormButton link size="sm" external target="_blank" :to="connectorsPageUrl">
           connectors
         </FormButton>
         to publish a {{ modelName ? '' : 'new model' }} version to
@@ -58,6 +52,7 @@
 import { useFileImport } from '~~/lib/core/composables/fileImport'
 import { useFileUploadProgressCore } from '~~/lib/form/composables/fileUpload'
 import { ExclamationTriangleIcon } from '@heroicons/vue/24/solid'
+import { connectorsPageUrl } from '~/lib/common/helpers/route'
 import type { Nullable } from '@speckle/shared'
 
 const props = defineProps<{

--- a/packages/frontend-2/lib/common/helpers/route.ts
+++ b/packages/frontend-2/lib/common/helpers/route.ts
@@ -11,6 +11,8 @@ export const forgottenPasswordRoute = '/authn/forgotten-password'
 export const onboardingRoute = '/onboarding'
 export const downloadManagerRoute = '/download-manager'
 export const serverManagementRoute = '/server-management'
+export const connectorsPageUrl = 'https://speckle.systems/features/connectors/'
+
 export const projectRoute = (
   id: string,
   tab?: 'models' | 'discussions' | 'automations' | 'settings'


### PR DESCRIPTION
## Description & motivation

This changes links from `/downloads` to `https://speckle.systems/features/connectors/` to point users in the right direction (desktop app). Also opens in a new tab now it's a link to the speckle website instead of the app