### PR TITLE
Chore (dui3): include test binding to listen notifications

### DIFF
--- a/packages/dui3/lib/bindings/definitions/ITestBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/ITestBinding.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/require-await */
 
 import { BaseBridge } from '~~/lib/bridge/base'
-import { IBinding } from '~~/lib/bindings/definitions/IBinding'
+import { IBinding, IBindingSharedEvents } from '~~/lib/bindings/definitions/IBinding'
 
 /**
  * The name under which this binding will be registered.
@@ -19,7 +19,7 @@ export interface ITestBinding extends IBinding<ITestBindingEvents> {
   triggerEvent: (eventName: string) => Promise<void>
 }
 
-export interface ITestBindingEvents {
+export interface ITestBindingEvents extends IBindingSharedEvents {
   emptyTestEvent: () => void
   testEvent: (args: TestEventArgs) => void
 }

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -330,6 +330,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   app.$configBinding?.on('setGlobalNotification', setNotification)
   app.$accountBinding?.on('setGlobalNotification', setNotification)
   app.$selectionBinding?.on('setGlobalNotification', setNotification)
+  app.$testBindings?.on('setGlobalNotification', setNotification)
 
   app.$sendBinding?.on('setModelError', handleModelError)
   app.$receiveBinding?.on('setModelError', handleModelError)


### PR DESCRIPTION
I should have done before. @JR-Morgan keen to trigger `shouldThrow` function from console to trigger some top level exceptions.