### PR TITLE
Fix: Improve comment/reply attachment styling 

### DIFF
--- a/packages/frontend-2/components/form/file-upload/Progress.vue
+++ b/packages/frontend-2/components/form/file-upload/Progress.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col space-y-1">
+  <div class="flex flex-col space-y-2 pb-2">
     <FormFileUploadProgressRow
       v-for="item in items"
       :key="item.id"

--- a/packages/frontend-2/components/form/file-upload/Progress.vue
+++ b/packages/frontend-2/components/form/file-upload/Progress.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col space-y-2 pb-2">
+  <div class="flex flex-col space-y-2">
     <FormFileUploadProgressRow
       v-for="item in items"
       :key="item.id"

--- a/packages/frontend-2/components/form/file-upload/ProgressRow.vue
+++ b/packages/frontend-2/components/form/file-upload/ProgressRow.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="bg-foundation rounded-lg p-2 pr-1 w-full max-w-full relative">
+  <div
+    class="bg-foundation rounded-lg p-2 pr-1 w-full max-w-full relative dark:bg-foundation-2"
+  >
     <div class="flex space-x-1 items-center">
       <span class="truncate text-xs pr-4 flex-1">{{ item.file.name }}</span>
       <span class="text-tiny text-foreground-2">

--- a/packages/frontend-2/components/form/file-upload/ProgressRow.vue
+++ b/packages/frontend-2/components/form/file-upload/ProgressRow.vue
@@ -8,7 +8,7 @@
         {{ prettyFileSize(item.file.size) }}
       </span>
       <button class="p-0.5 text-foreground hover:text-primary" @click="onDelete">
-        <XMarkIcon class="h-4 w-4" alt="close" />
+        <XMarkIcon class="h-4 w-4" alt="delete" />
       </button>
     </div>
     <div

--- a/packages/frontend-2/components/form/file-upload/ProgressRow.vue
+++ b/packages/frontend-2/components/form/file-upload/ProgressRow.vue
@@ -7,16 +7,8 @@
       <span class="text-tiny text-foreground-2">
         {{ prettyFileSize(item.file.size) }}
       </span>
-      <!-- <FormButton
-        color="danger"
-        size="xs"
-        rounded
-        hide-text
-        :icon-left="XMarkIcon"
-        @click="onDelete"
-      ></FormButton> -->
       <button class="p-0.5 text-foreground hover:text-primary" @click="onDelete">
-        <XMarkIcon class="h-4 w-4" />
+        <XMarkIcon class="h-4 w-4" alt="close" />
       </button>
     </div>
     <div

--- a/packages/frontend-2/components/form/file-upload/ProgressRow.vue
+++ b/packages/frontend-2/components/form/file-upload/ProgressRow.vue
@@ -1,21 +1,26 @@
 <template>
-  <div class="bg-foundation rounded-4xl px-4 py-3 w-full max-w-full relative">
+  <div
+    class="bg-foundation rounded-lg p-2 pr-1 w-full max-w-full relative dark:bg-foundation-2 bg-neutral-100"
+  >
     <div class="flex space-x-1 items-center">
-      <span class="truncate text-sm flex-shrink">{{ item.file.name }}</span>
-      <span class="text-tiny flex-grow text-foreground-2">
+      <span class="truncate text-xs pr-4 flex-1">{{ item.file.name }}</span>
+      <span class="text-tiny text-foreground-2">
         {{ prettyFileSize(item.file.size) }}
       </span>
-      <FormButton
+      <!-- <FormButton
         color="danger"
         size="xs"
         rounded
         hide-text
         :icon-left="XMarkIcon"
         @click="onDelete"
-      ></FormButton>
+      ></FormButton> -->
+      <button class="p-0.5 text-foreground hover:text-primary" @click="onDelete">
+        <XMarkIcon class="h-4 w-4" />
+      </button>
     </div>
     <div
-      v-if="item.progress > 0"
+      v-if="item.progress > 0 && item.progress < 100"
       :class="[' w-full mt-2', progressBarClasses]"
       :style="progressBarStyle"
     />

--- a/packages/frontend-2/components/form/file-upload/ProgressRow.vue
+++ b/packages/frontend-2/components/form/file-upload/ProgressRow.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="bg-foundation rounded-lg p-2 pr-1 w-full max-w-full relative dark:bg-foundation-2 bg-neutral-100"
+    class="bg-foundation rounded-lg p-2 pr-1 w-full max-w-full relative dark:bg-foundation-2"
   >
     <div class="flex space-x-1 items-center">
       <span class="truncate text-xs pr-4 flex-1">{{ item.file.name }}</span>

--- a/packages/frontend-2/components/form/file-upload/ProgressRow.vue
+++ b/packages/frontend-2/components/form/file-upload/ProgressRow.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="bg-foundation rounded-lg p-2 pr-1 w-full max-w-full relative dark:bg-foundation-2"
-  >
+  <div class="bg-foundation rounded-lg p-2 pr-1 w-full max-w-full relative">
     <div class="flex space-x-1 items-center">
       <span class="truncate text-xs pr-4 flex-1">{{ item.file.name }}</span>
       <span class="text-tiny text-foreground-2">

--- a/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/NewThread.vue
@@ -48,24 +48,22 @@
               @submit="() => onSubmit()"
               @keydown="onKeyDownHandler"
             />
-            <div class="w-full flex justify-end p-2 space-x-2">
-              <div class="space-x-2">
-                <FormButton
-                  v-tippy="'Attach'"
-                  :icon-left="PaperClipIcon"
-                  hide-text
-                  text
-                  :disabled="isPostingNewThread"
-                  @click="trackAttachAndOpenFilePicker()"
-                />
-
-                <FormButton
-                  :icon-left="PaperAirplaneIcon"
-                  hide-text
-                  :loading="isPostingNewThread"
-                  @click="() => onSubmit()"
-                />
-              </div>
+            <div class="w-full flex p-2 justify-between">
+              <FormButton
+                v-tippy="'Attach'"
+                :icon-left="PaperClipIcon"
+                hide-text
+                text
+                class="sm:px-1"
+                :disabled="isPostingNewThread"
+                @click="trackAttachAndOpenFilePicker()"
+              />
+              <FormButton
+                :icon-left="PaperAirplaneIcon"
+                hide-text
+                :loading="isPostingNewThread"
+                @click="() => onSubmit()"
+              />
             </div>
           </div>
         </div>

--- a/packages/frontend-2/components/viewer/anchored-point/thread/Comment.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/Comment.vue
@@ -4,9 +4,7 @@
       <span>{{ absoluteDate }}</span>
       <span>{{ timeFromNow }}</span>
     </div> -->
-    <div
-      class="xxx-bg-foundation sm:rounded-xl py-2 px-3 sm:p-4 sm:pb-3 w-full relative"
-    >
+    <div class="xxx-bg-foundation sm:rounded-xl py-2 sm:p-4 sm:pb-2 w-full relative">
       <div class="flex items-center space-x-1">
         <UserAvatar :user="comment.author" class="mr-1" />
         <span class="grow truncate text-xs sm:text-sm font-bold">

--- a/packages/frontend-2/components/viewer/anchored-point/thread/Comment.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/Comment.vue
@@ -4,7 +4,7 @@
       <span>{{ absoluteDate }}</span>
       <span>{{ timeFromNow }}</span>
     </div> -->
-    <div class="xxx-bg-foundation sm:rounded-xl py-2 sm:p-4 sm:pb-2 w-full relative">
+    <div class="xxx-bg-foundation sm:rounded-xl p-4 sm:pb-2 w-full relative">
       <div class="flex items-center space-x-1">
         <UserAvatar :user="comment.author" class="mr-1" />
         <span class="grow truncate text-xs sm:text-sm font-bold">
@@ -24,7 +24,7 @@
           </CommonTextLink>
         </div> -->
       </div>
-      <div class="truncate text-xs sm:text-sm text-foreground flex flex-col mt-3">
+      <div class="truncate text-xs sm:text-sm text-foreground flex flex-col mt-2">
         <CommonTiptapTextEditor
           v-if="comment.text.doc"
           :model-value="comment.text.doc"

--- a/packages/frontend-2/components/viewer/anchored-point/thread/Comment.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/Comment.vue
@@ -4,7 +4,9 @@
       <span>{{ absoluteDate }}</span>
       <span>{{ timeFromNow }}</span>
     </div> -->
-    <div class="xxx-bg-foundation sm:rounded-xl py-2 px-3 sm:p-4 w-full relative">
+    <div
+      class="xxx-bg-foundation sm:rounded-xl py-2 px-3 sm:p-4 sm:pb-3 w-full relative"
+    >
       <div class="flex items-center space-x-1">
         <UserAvatar :user="comment.author" class="mr-1" />
         <span class="grow truncate text-xs sm:text-sm font-bold">

--- a/packages/frontend-2/components/viewer/anchored-point/thread/Comment.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/Comment.vue
@@ -26,7 +26,7 @@
           </CommonTextLink>
         </div> -->
       </div>
-      <div class="truncate text-xs sm:text-sm text-foreground flex flex-col mt-2">
+      <div class="truncate text-xs sm:text-sm text-foreground flex flex-col mt-3">
         <CommonTiptapTextEditor
           v-if="comment.text.doc"
           :model-value="comment.text.doc"

--- a/packages/frontend-2/components/viewer/anchored-point/thread/CommentAttachments.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/CommentAttachments.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col w-full items-start mt-1">
+  <div class="flex flex-col w-full items-start pt-2">
     <CommonTextLink
       v-for="attachment in attachments.text.attachments || []"
       :key="attachment.id"
@@ -7,7 +7,7 @@
       size="sm"
       @click="() => onAttachmentClick(attachment)"
     >
-      <span class="truncate relative text-xs">
+      <span class="truncate relative text-xs pl-1">
         {{ attachment.fileName }}
       </span>
     </CommonTextLink>

--- a/packages/frontend-2/components/viewer/anchored-point/thread/CommentAttachments.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/CommentAttachments.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col w-full items-start">
+  <div class="flex flex-col w-full items-start mt-1">
     <CommonTextLink
       v-for="attachment in attachments.text.attachments || []"
       :key="attachment.id"

--- a/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
@@ -21,13 +21,11 @@
         :disabled="loading"
         color="card"
         class="sm:px-0"
-        size="sm"
         @click="trackAttachAndOpenFilePicker()"
       />
       <FormButton
         :icon-left="PaperAirplaneIcon"
         hide-text
-        size="sm"
         color="primary"
         :disabled="loading"
         @click="onSubmit"

--- a/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
@@ -1,33 +1,42 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
   <div
-    class="hidden sm:flex bg-foundation pl-4 pr-3 py-2 sm:py-1.5 sm:pb-3 rounded-b w-full relative"
+    class="hidden sm:flex bg-foundation pl-4 pr-3 py-2 sm:pt-1 sm:pr-1 sm:pb-3 rounded-b w-full relative"
   >
-    <FormButton
+    <!-- <FormButton
       :icon-left="PaperClipIcon"
       hide-text
       text
       :disabled="loading"
       size="sm"
-      class="-ml-2 sm:mr-2 sm:mt-2"
+      class="-ml-2 sm:mt-3 sm:pr-1"
       @click="trackAttachAndOpenFilePicker()"
-    />
-    <ViewerCommentsEditor
-      ref="editor"
-      v-model="commentValue"
-      prompt="Press enter to reply"
-      autofocus
-      max-height="150px"
-      @keydown="onKeyDownHandler"
-      @submit="onSubmit"
-    />
+    /> -->
+    <div class="flex flex-col">
+      <ViewerCommentsEditor
+        ref="editor"
+        v-model="commentValue"
+        prompt="Press enter to reply"
+        autofocus
+        max-height="150px"
+        @keydown="onKeyDownHandler"
+        @submit="onSubmit"
+      />
+      <CommonTextLink
+        :icon-left="PaperClipIcon"
+        size="sm"
+        @click="trackAttachAndOpenFilePicker()"
+      >
+        <span class="truncate relative text-xs">Add attachment</span>
+      </CommonTextLink>
+    </div>
     <FormButton
       :icon-left="PaperAirplaneIcon"
       hide-text
       size="sm"
       color="invert"
       :disabled="loading"
-      class="absolute right-5 top-4"
+      class="absolute right-5 top-5"
       @click="onSubmit"
     />
   </div>

--- a/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
@@ -26,7 +26,7 @@
       <FormButton
         :icon-left="PaperAirplaneIcon"
         hide-text
-        color="standard"
+        color="default"
         :disabled="loading"
         @click="onSubmit"
       />

--- a/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
@@ -1,44 +1,38 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
   <div
-    class="hidden sm:flex bg-foundation pl-4 pr-3 py-2 sm:pt-1 sm:pr-1 sm:pb-3 rounded-b w-full relative"
+    class="hidden sm:flex bg-foundation pl-4 pr-3 py-2 sm:p-1 sm:pb-3 rounded-b w-full relative flex flex-col"
   >
-    <!-- <FormButton
-      :icon-left="PaperClipIcon"
-      hide-text
-      text
-      :disabled="loading"
-      size="sm"
-      class="-ml-2 sm:mt-3 sm:pr-1"
-      @click="trackAttachAndOpenFilePicker()"
-    /> -->
-    <div class="flex flex-col">
-      <ViewerCommentsEditor
-        ref="editor"
-        v-model="commentValue"
-        prompt="Press enter to reply"
-        autofocus
-        max-height="150px"
-        @keydown="onKeyDownHandler"
-        @submit="onSubmit"
-      />
-      <CommonTextLink
+    <ViewerCommentsEditor
+      ref="editor"
+      v-model="commentValue"
+      prompt="Press enter to reply"
+      autofocus
+      max-height="150px"
+      @keydown="onKeyDownHandler"
+      @submit="onSubmit"
+    />
+    <div class="flex justify-between items-center p-3 pb-0">
+      <FormButton
+        v-tippy="'Attach'"
         :icon-left="PaperClipIcon"
+        hide-text
+        text
+        :disabled="loading"
+        color="card"
+        class="sm:px-0"
         size="sm"
         @click="trackAttachAndOpenFilePicker()"
-      >
-        <span class="truncate relative text-xs">Add attachment</span>
-      </CommonTextLink>
+      />
+      <FormButton
+        :icon-left="PaperAirplaneIcon"
+        hide-text
+        size="sm"
+        color="primary"
+        :disabled="loading"
+        @click="onSubmit"
+      />
     </div>
-    <FormButton
-      :icon-left="PaperAirplaneIcon"
-      hide-text
-      size="sm"
-      color="invert"
-      :disabled="loading"
-      class="absolute right-5 top-5"
-      @click="onSubmit"
-    />
   </div>
 </template>
 <script setup lang="ts">

--- a/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
   <div
-    class="hidden sm:flex bg-foundation pl-4 pr-3 py-2 sm:py-1.5 rounded-b items-center w-full"
+    class="hidden sm:flex bg-foundation pl-4 pr-3 py-2 sm:py-1.5 sm:pb-3 rounded-b w-full relative"
   >
     <FormButton
       :icon-left="PaperClipIcon"
@@ -9,7 +9,7 @@
       text
       :disabled="loading"
       size="sm"
-      class="-ml-2 sm:mr-2"
+      class="-ml-2 sm:mr-2 sm:mt-2"
       @click="trackAttachAndOpenFilePicker()"
     />
     <ViewerCommentsEditor
@@ -27,7 +27,7 @@
       size="sm"
       color="invert"
       :disabled="loading"
-      class="absolute right-6 sm:right-6"
+      class="absolute right-5 top-4"
       @click="onSubmit"
     />
   </div>

--- a/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/thread/NewReply.vue
@@ -26,7 +26,7 @@
       <FormButton
         :icon-left="PaperAirplaneIcon"
         hide-text
-        color="primary"
+        color="standard"
         :disabled="loading"
         @click="onSubmit"
       />

--- a/packages/frontend-2/components/viewer/comments/Editor.vue
+++ b/packages/frontend-2/components/viewer/comments/Editor.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
   <div
-    class="flex flex-col w-full max-h-28 overflow-y-auto imple-scrollbar p-2 sm:pb-0"
+    class="flex flex-col w-full max-h-28 overflow-y-auto simple-scrollbar p-2 sm:pb-0"
   >
     <FormFileUploadZone
       ref="uploadZone"

--- a/packages/frontend-2/components/viewer/comments/Editor.vue
+++ b/packages/frontend-2/components/viewer/comments/Editor.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
   <div
-    class="flex flex-col w-full max-h-28 overflow-y-auto simple-scrollbar sm:p-2 sm:pb-0"
+    class="flex flex-col w-full max-h-28 overflow-y-auto p-2 simple-scrollbar sm:pb-0"
   >
     <FormFileUploadZone
       ref="uploadZone"
@@ -15,7 +15,7 @@
       <CommonTiptapTextEditor
         v-model="doc"
         :class="[
-          'dark:bg-foundation-2 bg-neutral-100 sm:rounded-lg p-2 pr-12 border text-sm min-h-[50px]',
+          'dark:bg-foundation-2 bg-neutral-100 sm:rounded-lg p-2 pr-12 border text-sm min-h-[52px]',
           isDraggingFiles ? 'border-success' : 'border-transparent'
         ]"
         :autofocus="autofocus"

--- a/packages/frontend-2/components/viewer/comments/Editor.vue
+++ b/packages/frontend-2/components/viewer/comments/Editor.vue
@@ -1,6 +1,8 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
-  <div class="flex flex-col w-full max-h-28 overflow-y-auto simple-scrollbar">
+  <div
+    class="flex flex-col w-full max-h-28 overflow-y-auto simple-scrollbar sm:p-2 sm:pb-0"
+  >
     <FormFileUploadZone
       ref="uploadZone"
       v-slot="{ isDraggingFiles }"
@@ -13,7 +15,7 @@
       <CommonTiptapTextEditor
         v-model="doc"
         :class="[
-          'dark:bg-foundation-2 bg-neutral-100 sm:rounded-lg p-2 pr-12 border text-sm min-h-[60px]',
+          'dark:bg-foundation-2 bg-neutral-100 sm:rounded-lg p-2 pr-12 border text-sm min-h-[50px]',
           isDraggingFiles ? 'border-success' : 'border-transparent'
         ]"
         :autofocus="autofocus"

--- a/packages/frontend-2/components/viewer/comments/Editor.vue
+++ b/packages/frontend-2/components/viewer/comments/Editor.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vuejs-accessibility/no-autofocus -->
 <template>
   <div
-    class="flex flex-col w-full max-h-28 overflow-y-auto p-2 simple-scrollbar sm:pb-0"
+    class="flex flex-col w-full max-h-28 overflow-y-auto imple-scrollbar p-2 sm:pb-0"
   >
     <FormFileUploadZone
       ref="uploadZone"
@@ -15,7 +15,7 @@
       <CommonTiptapTextEditor
         v-model="doc"
         :class="[
-          'dark:bg-foundation-2 bg-neutral-100 sm:rounded-lg p-2 pr-12 border text-sm min-h-[52px]',
+          'dark:bg-foundation-2 bg-neutral-100 sm:rounded-lg p-2 pr-12 border text-sm min-h-[56px]',
           isDraggingFiles ? 'border-success' : 'border-transparent'
         ]"
         :autofocus="autofocus"


### PR DESCRIPTION
There were some small UI/UX issues and differences between comments and replies on the viewer. This PR aligns them and fixes some of the UI issues (such as overlapping buttons).

Fixes https://linear.app/speckle/issue/WEB-450/improve-design-when-attaching-a-file-to-a-comment

<img width="391" alt="Screenshot 2024-06-19 at 15 03 30" src="https://github.com/specklesystems/speckle-server/assets/29700836/b58e39d6-fff2-41cb-b1c1-693119d3cc98">
<img width="279" alt="Screenshot 2024-06-19 at 15 03 47" src="https://github.com/specklesystems/speckle-server/assets/29700836/3a610aab-a678-4d03-a34f-e27aadcc44bc">
<img width="386" alt="Screenshot 2024-06-19 at 16 50 47" src="https://github.com/specklesystems/speckle-server/assets/29700836/fe89a707-079b-4cfa-929b-214315e0fdbd">
<img width="280" alt="Screenshot 2024-06-19 at 16 51 00" src="https://github.com/specklesystems/speckle-server/assets/29700836/16e86599-75fc-43cd-a1c8-cb0d5b1bd71b">
