### PR TITLE
Dim/closures patches

### DIFF
--- a/packages/server/modules/core/services/objects.js
+++ b/packages/server/modules/core/services/objects.js
@@ -286,7 +286,7 @@ module.exports = {
     const q = knex.with(
       'object_children_closure',
       knex.raw(
-        `SELECT objects.id as parent, d.key as child, d.value as minDepth, ? as "streamId"
+        `SELECT objects.id as parent, d.key as child, d.value as mindepth, ? as "streamId"
         FROM objects
         JOIN jsonb_each_text(objects.data->'__closure') d ON true
         where objects.id = ?`,
@@ -328,7 +328,7 @@ module.exports = {
           objectId
         ])
       )
-      .andWhere(knex.raw('object_children_closure."mindepth" < ?', [depth]))
+      .andWhere(knex.raw('object_children_closure.mindepth < ?', [depth]))
       .andWhere(knex.raw('id > ?', [cursor ? cursor : '0']))
       .orderBy('objects.id')
       .limit(limit)
@@ -398,6 +398,16 @@ module.exports = {
     const operatorsWhitelist = ['=', '>', '>=', '<', '<=', '!=']
 
     const mainQuery = knex
+      .with(
+        'object_children_closure',
+        knex.raw(
+          `SELECT objects.id as parent, d.key as child, d.value as mindepth, ? as "streamId"
+        FROM objects
+        JOIN jsonb_each_text(objects.data->'__closure') d ON true
+        where objects.id = ?`,
+          [streamId, objectId]
+        )
+      )
       .with('objs', (cteInnerQuery) => {
         // always select the id
         cteInnerQuery.select('id').from('object_children_closure')
@@ -431,7 +441,7 @@ module.exports = {
           })
           .where('object_children_closure.streamId', streamId)
           .andWhere('parent', objectId)
-          .andWhere('minDepth', '<', depth)
+          .andWhere('mindepth', '<', depth)
 
         // Add user provided filters/queries.
         if (Array.isArray(query) && query.length > 0) {


### PR DESCRIPTION
Wraps up fixes for the no more writing in closure table push. Should follow up with https://speckle.community/t/missing-model-definitions-in-graphql-response/11965/4 once merged and deployed