### PR TITLE
chore(server): marking all old (non-FE2) GQL schema fields as deprecated

### DIFF
--- a/packages/frontend-2/components/developer-settings/CreateTokenDialog.vue
+++ b/packages/frontend-2/components/developer-settings/CreateTokenDialog.vue
@@ -24,7 +24,7 @@
           name="scopes"
           label="Scopes"
           placeholder="Choose Scopes"
-          help="It's good practice to limit the scopes of your token to the absolute minimum. For example, if your application or script will only read and write streams, select just those scopes."
+          help="It's good practice to limit the scopes of your token to the absolute minimum. For example, if your application or script will only read and write projects/streams, select just those scopes."
           show-required
           :rules="[isItemSelected]"
           show-label

--- a/packages/frontend-2/components/error/page/ProjectInviteBanner.vue
+++ b/packages/frontend-2/components/error/page/ProjectInviteBanner.vue
@@ -3,7 +3,7 @@
     <ProjectsInviteBanner
       v-if="invite"
       :invite="invite"
-      :show-stream-name="false"
+      :show-project-name="false"
       :auto-accept="shouldAutoAcceptInvite"
       @processed="onProcessed"
     />

--- a/packages/frontend-2/components/form/select/Projects.vue
+++ b/packages/frontend-2/components/form/select/Projects.vue
@@ -120,7 +120,7 @@ const props = defineProps({
     default: undefined
   },
   /**
-   * Whether to only return owned streams from server
+   * Whether to only return owned projects from server
    */
   ownedOnly: {
     type: Boolean,

--- a/packages/frontend-2/components/project/page/MoreActions.vue
+++ b/packages/frontend-2/components/project/page/MoreActions.vue
@@ -12,7 +12,7 @@
       <ProjectPageMoreActionsCard :class="cardWidthClasses">
         <template #title>Webhooks</template>
         <template #description>
-          If you need to use webhooks, ask the stream's owner to grant you ownership.
+          If you need to use webhooks, ask the project's owner to grant you ownership.
         </template>
       </ProjectPageMoreActionsCard>
     </div>

--- a/packages/frontend-2/components/projects/invite/Banner.vue
+++ b/packages/frontend-2/components/projects/invite/Banner.vue
@@ -8,7 +8,9 @@
       <div class="text-foreground">
         <span class="font-bold">{{ invite.invitedBy.name }}</span>
         has invited you to be part of the team from
-        <template v-if="showStreamName">the project {{ invite.projectName }}.</template>
+        <template v-if="showProjectName">
+          the project {{ invite.projectName }}.
+        </template>
         <template v-else>this project.</template>
       </div>
     </div>
@@ -66,10 +68,10 @@ const emit = defineEmits<{
 const props = withDefaults(
   defineProps<{
     invite?: ProjectsInviteBannerFragment
-    showStreamName?: boolean
+    showProjectName?: boolean
     autoAccept?: boolean
   }>(),
-  { showStreamName: true }
+  { showProjectName: true }
 )
 
 const route = useRoute()

--- a/packages/frontend-2/lib/common/generated/gql/graphql.ts
+++ b/packages/frontend-2/lib/common/generated/gql/graphql.ts
@@ -439,7 +439,10 @@ export type BlobMetadataCollection = {
 
 export type Branch = {
   __typename?: 'Branch';
-  /** All the recent activity on this branch in chronological order */
+  /**
+   * All the recent activity on this branch in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   activity?: Maybe<ActivityCollection>;
   author?: Maybe<User>;
   commits?: Maybe<CommitCollection>;
@@ -654,7 +657,10 @@ export type CommentThreadActivityMessage = {
 
 export type Commit = {
   __typename?: 'Commit';
-  /** All the recent activity on this commit in chronological order */
+  /**
+   * All the recent activity on this commit in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   activity?: Maybe<ActivityCollection>;
   authorAvatar?: Maybe<Scalars['String']['output']>;
   authorId?: Maybe<Scalars['String']['output']>;
@@ -670,6 +676,7 @@ export type Commit = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -902,21 +909,36 @@ export type LegacyCommentViewerData = {
  */
 export type LimitedUser = {
   __typename?: 'LimitedUser';
-  /** All the recent activity from this user in chronological order */
+  /**
+   * All the recent activity from this user in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']['output']>;
   bio?: Maybe<Scalars['String']['output']>;
-  /** Get public stream commits authored by the user */
+  /**
+   * Get public stream commits authored by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   commits?: Maybe<CommitCollection>;
   company?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
   role?: Maybe<Scalars['String']['output']>;
-  /** Returns all discoverable streams that the user is a collaborator on */
+  /**
+   * Returns all discoverable streams that the user is a collaborator on
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   streams: StreamCollection;
-  /** The user's timeline in chronological order */
+  /**
+   * The user's timeline in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   timeline?: Maybe<ActivityCollection>;
-  /** Total amount of favorites attached to streams owned by the user */
+  /**
+   * Total amount of favorites attached to streams owned by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
   verified?: Maybe<Scalars['Boolean']['output']>;
 };
@@ -1101,8 +1123,11 @@ export type Mutation = {
   appUpdate: Scalars['Boolean']['output'];
   automateFunctionRunStatusReport: Scalars['Boolean']['output'];
   automateMutations: AutomateMutations;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.create instead. */
   branchCreate: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.delete instead. */
   branchDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.update instead. */
   branchUpdate: Scalars['Boolean']['output'];
   /** Broadcast user activity in the viewer */
   broadcastViewerUserActivity: Scalars['Boolean']['output'];
@@ -1132,13 +1157,23 @@ export type Mutation = {
    * @deprecated Use commentMutations version
    */
   commentView: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   commitCreate: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.delete instead. */
   commitDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   commitReceive: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.update/moveToModel instead. */
   commitUpdate: Scalars['Boolean']['output'];
-  /** Delete a batch of commits */
+  /**
+   * Delete a batch of commits
+   * @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.delete instead.
+   */
   commitsDelete: Scalars['Boolean']['output'];
-  /** Move a batch of commits to a new branch */
+  /**
+   * Move a batch of commits to a new branch
+   * @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.moveToModel instead.
+   */
   commitsMove: Scalars['Boolean']['output'];
   /**
    * Delete a pending invite
@@ -1151,6 +1186,7 @@ export type Mutation = {
    */
   inviteResend: Scalars['Boolean']['output'];
   modelMutations: ModelMutations;
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   objectCreate: Array<Maybe<Scalars['String']['output']>>;
   projectMutations: ProjectMutations;
   /** (Re-)send the account verification e-mail */
@@ -1161,37 +1197,71 @@ export type Mutation = {
   serverInviteBatchCreate: Scalars['Boolean']['output'];
   /** Invite a new user to the speckle server and return the invite ID */
   serverInviteCreate: Scalars['Boolean']['output'];
-  /** Request access to a specific stream */
+  /**
+   * Request access to a specific stream
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   streamAccessRequestCreate: StreamAccessRequest;
-  /** Accept or decline a stream access request. Must be a stream owner to invoke this. */
+  /**
+   * Accept or decline a stream access request. Must be a stream owner to invoke this.
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   streamAccessRequestUse: Scalars['Boolean']['output'];
-  /** Creates a new stream. */
+  /**
+   * Creates a new stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.create instead.
+   */
   streamCreate?: Maybe<Scalars['String']['output']>;
-  /** Deletes an existing stream. */
+  /**
+   * Deletes an existing stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.delete instead.
+   */
   streamDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   streamFavorite?: Maybe<Stream>;
-  /** Note: The required scope to invoke this is not given out to app or personal access tokens */
+  /**
+   * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.batchCreate instead.
+   */
   streamInviteBatchCreate: Scalars['Boolean']['output'];
   /**
    * Cancel a pending stream invite. Can only be invoked by a stream owner.
    * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.cancel instead.
    */
   streamInviteCancel: Scalars['Boolean']['output'];
   /**
    * Invite a new or registered user to the specified stream
    * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.create instead.
    */
   streamInviteCreate: Scalars['Boolean']['output'];
-  /** Accept or decline a stream invite */
+  /**
+   * Accept or decline a stream invite
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.use instead.
+   */
   streamInviteUse: Scalars['Boolean']['output'];
-  /** Remove yourself from stream collaborators (not possible for the owner) */
+  /**
+   * Remove yourself from stream collaborators (not possible for the owner)
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.leave instead.
+   */
   streamLeave: Scalars['Boolean']['output'];
-  /** Revokes the permissions of a user on a given stream. */
+  /**
+   * Revokes the permissions of a user on a given stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.updateRole instead.
+   */
   streamRevokePermission?: Maybe<Scalars['Boolean']['output']>;
-  /** Updates an existing stream. */
+  /**
+   * Updates an existing stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.update instead.
+   */
   streamUpdate: Scalars['Boolean']['output'];
-  /** Update permissions of a user on a given stream. */
+  /**
+   * Update permissions of a user on a given stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.updateRole instead.
+   */
   streamUpdatePermission?: Maybe<Scalars['Boolean']['output']>;
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   streamsDelete: Scalars['Boolean']['output'];
   /**
    * Used for broadcasting real time typing status in comment threads. Does not persist any info.
@@ -1523,6 +1593,7 @@ export type Object = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -1586,7 +1657,9 @@ export type PendingStreamCollaborator = {
   projectId: Scalars['String']['output'];
   projectName: Scalars['String']['output'];
   role: Scalars['String']['output'];
+  /** @deprecated Use projectId instead */
   streamId: Scalars['String']['output'];
+  /** @deprecated Use projectName instead */
   streamName: Scalars['String']['output'];
   /** E-mail address or name of the invited user */
   title: Scalars['String']['output'];
@@ -2143,7 +2216,10 @@ export type Query = {
   adminUsers?: Maybe<AdminUsersListCollection>;
   /** Gets a specific app from the server. */
   app?: Maybe<ServerApp>;
-  /** Returns all the publicly available apps on this server. */
+  /**
+   * Returns all the publicly available apps on this server.
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   apps?: Maybe<Array<Maybe<ServerAppListItem>>>;
   /** If user is authenticated using an app token, this will describe the app */
   authenticatedAsApp?: Maybe<ServerAppListItem>;
@@ -2152,15 +2228,19 @@ export type Query = {
   automateFunctions: AutomateFunctionCollection;
   /** Part of the automation/function creation handshake mechanism */
   automateValidateAuthCode: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   comment?: Maybe<Comment>;
   /**
    * This query can be used in the following ways:
    * - get all the comments for a stream: **do not pass in any resource identifiers**.
    * - get the comments targeting any of a set of provided resources (comments/objects): **pass in an array of resources.**
-   * @deprecated Use 'commentThreads' fields instead
+   * @deprecated Use Project/Version/Model 'commentThreads' fields instead
    */
   comments?: Maybe<CommentCollection>;
-  /** All of the discoverable streams of the server */
+  /**
+   * All of the discoverable streams of the server
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   discoverableStreams?: Maybe<StreamCollection>;
   /** Get the (limited) profile information of another server user */
   otherUser?: Maybe<LimitedUser>;
@@ -2182,20 +2262,29 @@ export type Query = {
   /**
    * Returns a specific stream. Will throw an authorization error if active user isn't authorized
    * to see it, for example, if a stream isn't public and the user doesn't have the appropriate rights.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Query.project instead.
    */
   stream?: Maybe<Stream>;
-  /** Get authed user's stream access request */
+  /**
+   * Get authed user's stream access request
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   streamAccessRequest?: Maybe<StreamAccessRequest>;
   /**
    * Look for an invitation to a stream, for the current user (authed or not). If token
    * isn't specified, the server will look for any valid invite.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Query.projectInvite instead.
    */
   streamInvite?: Maybe<PendingStreamCollaborator>;
-  /** Get all invitations to streams that the active user has */
+  /**
+   * Get all invitations to streams that the active user has
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projectInvites instead.
+   */
   streamInvites: Array<PendingStreamCollaborator>;
   /**
    * Returns all streams that the active user is a collaborator on.
    * Pass in the `query` parameter to search by name, description or ID.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projects instead.
    */
   streams?: Maybe<StreamCollection>;
   /**
@@ -2203,7 +2292,10 @@ export type Query = {
    * @deprecated To be removed in the near future! Use 'activeUser' to get info about the active user or 'otherUser' to get info about another user.
    */
   user?: Maybe<User>;
-  /** Validate password strength */
+  /**
+   * Validate password strength
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   userPwdStrength: PasswordStrengthCheckResults;
   /**
    * Search for users and return limited metadata about them, if you have the server:user role.
@@ -2527,13 +2619,22 @@ export enum SortDirection {
 
 export type Stream = {
   __typename?: 'Stream';
-  /** All the recent activity on this stream in chronological order */
+  /**
+   * All the recent activity on this stream in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   activity?: Maybe<ActivityCollection>;
   allowPublicComments: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.blob instead. */
   blob?: Maybe<BlobMetadata>;
-  /** Get the metadata collection of blobs stored for this stream. */
+  /**
+   * Get the metadata collection of blobs stored for this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.blobs instead.
+   */
   blobs?: Maybe<BlobMetadataCollection>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.model instead. */
   branch?: Maybe<Branch>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.models or Project.modelsTree instead. */
   branches?: Maybe<BranchCollection>;
   collaborators: Array<StreamCollaborator>;
   /**
@@ -2545,18 +2646,27 @@ export type Stream = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.version instead. */
   commit?: Maybe<Commit>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.versions instead. */
   commits?: Maybe<CommitCollection>;
   createdAt: Scalars['DateTime']['output'];
   description?: Maybe<Scalars['String']['output']>;
   /** Date when you favorited this stream. `null` if stream isn't viewed from a specific user's perspective or if it isn't favorited. */
   favoritedDate?: Maybe<Scalars['DateTime']['output']>;
   favoritesCount: Scalars['Int']['output'];
-  /** Returns a specific file upload that belongs to this stream. */
+  /**
+   * Returns a specific file upload that belongs to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.pendingImportedModels or Model.pendingImportedVersions instead.
+   */
   fileUpload?: Maybe<FileUpload>;
-  /** Returns a list of all the file uploads for this stream. */
+  /**
+   * Returns a list of all the file uploads for this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.pendingImportedModels or Model.pendingImportedVersions instead.
+   */
   fileUploads: Array<FileUpload>;
   id: Scalars['String']['output'];
   /**
@@ -2567,8 +2677,12 @@ export type Stream = {
   /** Whether the stream can be viewed by non-contributors */
   isPublic: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   object?: Maybe<Object>;
-  /** Pending stream access requests */
+  /**
+   * Pending stream access requests
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   pendingAccessRequests?: Maybe<Array<StreamAccessRequest>>;
   /** Collaborators who have been invited, but not yet accepted. */
   pendingCollaborators?: Maybe<Array<PendingStreamCollaborator>>;
@@ -2576,6 +2690,7 @@ export type Stream = {
   role?: Maybe<Scalars['String']['output']>;
   size?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.webhooks instead. */
   webhooks: WebhookCollection;
 };
 
@@ -2726,11 +2841,20 @@ export type Subscription = {
   __typename?: 'Subscription';
   /** It's lonely in the void. */
   _?: Maybe<Scalars['String']['output']>;
-  /** Subscribe to branch created event */
+  /**
+   * Subscribe to branch created event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchCreated?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to branch deleted event */
+  /**
+   * Subscribe to branch deleted event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to branch updated event. */
+  /**
+   * Subscribe to branch updated event.
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /**
    * Subscribe to new comment events. There's two ways to use this subscription:
@@ -2746,11 +2870,20 @@ export type Subscription = {
    * @deprecated Use projectCommentsUpdated or viewerUserActivityBroadcasted for reply status
    */
   commentThreadActivity: CommentThreadActivityMessage;
-  /** Subscribe to commit created event */
+  /**
+   * Subscribe to commit created event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitCreated?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to commit deleted event */
+  /**
+   * Subscribe to commit deleted event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to commit updated event. */
+  /**
+   * Subscribe to commit updated event.
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /** Subscribe to updates to automations in the project */
   projectAutomationsUpdated: ProjectAutomationsUpdatedMessage;
@@ -2759,7 +2892,10 @@ export type Subscription = {
    * updates regarding comments for those resources.
    */
   projectCommentsUpdated: ProjectCommentsUpdatedMessage;
-  /** Subscribe to changes to any of a project's file imports */
+  /**
+   * Subscribe to changes to any of a project's file imports
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectPendingModelsUpdated or projectPendingVersionsUpdated instead.
+   */
   projectFileImportUpdated: ProjectFileImportUpdatedMessage;
   /** Subscribe to changes to a project's models. Optionally specify modelIds to track. */
   projectModelsUpdated: ProjectModelsUpdatedMessage;
@@ -2777,20 +2913,28 @@ export type Subscription = {
   projectVersionsPreviewGenerated: ProjectVersionsPreviewGeneratedMessage;
   /** Subscribe to changes to a project's versions. */
   projectVersionsUpdated: ProjectVersionsUpdatedMessage;
-  /** Subscribes to stream deleted event. Use this in clients/components that pertain only to this stream. */
+  /**
+   * Subscribes to stream deleted event. Use this in clients/components that pertain only to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectUpdated instead.
+   */
   streamDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribes to stream updated event. Use this in clients/components that pertain only to this stream. */
+  /**
+   * Subscribes to stream updated event. Use this in clients/components that pertain only to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectUpdated instead.
+   */
   streamUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /** Track newly added or deleted projects owned by the active user */
   userProjectsUpdated: UserProjectsUpdatedMessage;
   /**
    * Subscribes to new stream added event for your profile. Use this to display an up-to-date list of streams.
    * **NOTE**: If someone shares a stream with you, this subscription will be triggered with an extra value of `sharedBy` in the payload.
+   * @deprecated Part of the old API surface and will be removed in the future. Use userProjectsUpdated instead.
    */
   userStreamAdded?: Maybe<Scalars['JSONObject']['output']>;
   /**
    * Subscribes to stream removed event for your profile. Use this to display an up-to-date list of streams for your profile.
    * **NOTE**: If someone revokes your permissions on a stream, this subscription will be triggered with an extra value of `revokedBy` in the payload.
+   * @deprecated Part of the old API surface and will be removed in the future. Use userProjectsUpdated instead.
    */
   userStreamRemoved?: Maybe<Scalars['JSONObject']['output']>;
   /**
@@ -3003,7 +3147,10 @@ export type UpdateVersionInput = {
  */
 export type User = {
   __typename?: 'User';
-  /** All the recent activity from this user in chronological order */
+  /**
+   * All the recent activity from this user in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   activity?: Maybe<ActivityCollection>;
   /** Returns a list of your personal api tokens. */
   apiTokens: Array<ApiToken>;
@@ -3015,16 +3162,19 @@ export type User = {
   /**
    * Get commits authored by the user. If requested for another user, then only commits
    * from public streams will be returned.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.versions instead.
    */
   commits?: Maybe<CommitCollection>;
   company?: Maybe<Scalars['String']['output']>;
   /** Returns the apps you have created. */
   createdApps?: Maybe<Array<ServerApp>>;
   createdAt?: Maybe<Scalars['DateTime']['output']>;
+  /** Only returned if API user is the user being requested or an admin */
   email?: Maybe<Scalars['String']['output']>;
   /**
    * All the streams that a active user has favorited.
    * Note: You can't use this to retrieve another user's favorite streams.
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   favoriteStreams: StreamCollection;
   /** Whether the user has a pending/active email verification token */
@@ -3043,11 +3193,18 @@ export type User = {
   /**
    * Returns all streams that the user is a collaborator on. If requested for a user, who isn't the
    * authenticated user, then this will only return discoverable streams.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projects instead.
    */
   streams: StreamCollection;
-  /** The user's timeline in chronological order */
+  /**
+   * The user's timeline in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   timeline?: Maybe<ActivityCollection>;
-  /** Total amount of favorites attached to streams owned by the user */
+  /**
+   * Total amount of favorites attached to streams owned by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
   verified?: Maybe<Scalars['Boolean']['output']>;
   /**

--- a/packages/frontend-2/pages/onboarding.vue
+++ b/packages/frontend-2/pages/onboarding.vue
@@ -2,7 +2,7 @@
   <div class="w-full h-full bg-foundation flex items-center justify-center">
     <!-- 
     Note: You might be asking yourself why do we need this route: the answer is that cloning 
-    a stream is not instant, and it might take some time to get it done. We want to display
+    a project is not instant, and it might take some time to get it done. We want to display
     some sort of progress to the user in the meantime. Moreover, it makes various composables 
     more sane to use rather than in the router navigation guards.
   -->

--- a/packages/frontend-2/pages/projects/[id]/index.vue
+++ b/packages/frontend-2/pages/projects/[id]/index.vue
@@ -3,7 +3,7 @@
     <div v-if="project">
       <ProjectsInviteBanner
         :invite="invite"
-        :show-stream-name="false"
+        :show-project-name="false"
         :auto-accept="shouldAutoAcceptInvite"
         @processed="onInviteAccepted"
       />

--- a/packages/server/assets/accessrequests/typedefs/accessrequests.graphql
+++ b/packages/server/assets/accessrequests/typedefs/accessrequests.graphql
@@ -4,7 +4,9 @@ extend type Query {
   """
   streamAccessRequest(streamId: String!): StreamAccessRequest
     @hasServerRole(role: SERVER_GUEST)
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 extend type Stream {
@@ -13,7 +15,9 @@ extend type Stream {
   """
   pendingAccessRequests: [StreamAccessRequest!]
     @hasStreamRole(role: STREAM_OWNER)
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 extend type Mutation {
@@ -27,7 +31,9 @@ extend type Mutation {
   ): Boolean!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "users:invite")
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 
   """
   Request access to a specific stream
@@ -35,7 +41,9 @@ extend type Mutation {
   streamAccessRequestCreate(streamId: String!): StreamAccessRequest!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "users:invite")
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 """

--- a/packages/server/assets/accessrequests/typedefs/accessrequests.graphql
+++ b/packages/server/assets/accessrequests/typedefs/accessrequests.graphql
@@ -4,13 +4,16 @@ extend type Query {
   """
   streamAccessRequest(streamId: String!): StreamAccessRequest
     @hasServerRole(role: SERVER_GUEST)
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 extend type Stream {
   """
   Pending stream access requests
   """
-  pendingAccessRequests: [StreamAccessRequest!] @hasStreamRole(role: STREAM_OWNER)
+  pendingAccessRequests: [StreamAccessRequest!]
+    @hasStreamRole(role: STREAM_OWNER)
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 extend type Mutation {
@@ -21,7 +24,10 @@ extend type Mutation {
     requestId: String!
     accept: Boolean!
     role: StreamRole! = STREAM_CONTRIBUTOR
-  ): Boolean! @hasServerRole(role: SERVER_GUEST) @hasScope(scope: "users:invite")
+  ): Boolean!
+    @hasServerRole(role: SERVER_GUEST)
+    @hasScope(scope: "users:invite")
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 
   """
   Request access to a specific stream
@@ -29,6 +35,7 @@ extend type Mutation {
   streamAccessRequestCreate(streamId: String!): StreamAccessRequest!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "users:invite")
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 """

--- a/packages/server/assets/activitystream/typedefs/activity.graphql
+++ b/packages/server/assets/activitystream/typedefs/activity.graphql
@@ -11,6 +11,7 @@ extend type User {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "users:read")
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 
   """
   The user's timeline in chronological order
@@ -23,6 +24,7 @@ extend type User {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScopes(scopes: ["users:read", "streams:read"])
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 extend type LimitedUser {
@@ -38,6 +40,7 @@ extend type LimitedUser {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "users:read")
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 
   """
   The user's timeline in chronological order
@@ -50,6 +53,7 @@ extend type LimitedUser {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScopes(scopes: ["users:read", "streams:read"])
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 extend type Stream {
@@ -65,6 +69,7 @@ extend type Stream {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 extend type Branch {
@@ -80,6 +85,7 @@ extend type Branch {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 extend type Commit {
@@ -95,6 +101,7 @@ extend type Commit {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 type ActivityCollection {

--- a/packages/server/assets/activitystream/typedefs/activity.graphql
+++ b/packages/server/assets/activitystream/typedefs/activity.graphql
@@ -11,7 +11,9 @@ extend type User {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "users:read")
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 
   """
   The user's timeline in chronological order
@@ -24,7 +26,9 @@ extend type User {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScopes(scopes: ["users:read", "streams:read"])
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 extend type LimitedUser {
@@ -40,7 +44,9 @@ extend type LimitedUser {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "users:read")
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 
   """
   The user's timeline in chronological order
@@ -53,7 +59,9 @@ extend type LimitedUser {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScopes(scopes: ["users:read", "streams:read"])
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 extend type Stream {
@@ -69,7 +77,9 @@ extend type Stream {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 extend type Branch {
@@ -85,7 +95,9 @@ extend type Branch {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 extend type Commit {
@@ -101,7 +113,9 @@ extend type Commit {
   ): ActivityCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 type ActivityCollection {

--- a/packages/server/assets/auth/typedefs/apps.graphql
+++ b/packages/server/assets/auth/typedefs/apps.graphql
@@ -8,7 +8,9 @@ extend type Query {
   Returns all the publicly available apps on this server.
   """
   apps: [ServerAppListItem]
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 type ServerApp {

--- a/packages/server/assets/auth/typedefs/apps.graphql
+++ b/packages/server/assets/auth/typedefs/apps.graphql
@@ -8,6 +8,7 @@ extend type Query {
   Returns all the publicly available apps on this server.
   """
   apps: [ServerAppListItem]
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 type ServerApp {

--- a/packages/server/assets/blobstorage/typedefs/blobstorage.graphql
+++ b/packages/server/assets/blobstorage/typedefs/blobstorage.graphql
@@ -11,8 +11,14 @@ extend type Stream {
     limit: Int = 25
     cursor: String = null
   ): BlobMetadataCollection
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Project.blobs"
+    )
 
   blob(id: String!): BlobMetadata
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Project.blob"
+    )
 }
 
 extend type Project {

--- a/packages/server/assets/blobstorage/typedefs/blobstorage.graphql
+++ b/packages/server/assets/blobstorage/typedefs/blobstorage.graphql
@@ -12,12 +12,12 @@ extend type Stream {
     cursor: String = null
   ): BlobMetadataCollection
     @deprecated(
-      reason: "Part of the old API surface and will be removed in the future. Use Project.blobs"
+      reason: "Part of the old API surface and will be removed in the future. Use Project.blobs instead."
     )
 
   blob(id: String!): BlobMetadata
     @deprecated(
-      reason: "Part of the old API surface and will be removed in the future. Use Project.blob"
+      reason: "Part of the old API surface and will be removed in the future. Use Project.blob instead."
     )
 }
 

--- a/packages/server/assets/comments/typedefs/comments.gql
+++ b/packages/server/assets/comments/typedefs/comments.gql
@@ -1,6 +1,8 @@
 extend type Query {
   comment(id: String!, streamId: String!): Comment
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
   """
   This query can be used in the following ways:
   - get all the comments for a stream: **do not pass in any resource identifiers**.
@@ -53,7 +55,9 @@ extend type Stream {
   ```
   """
   commentCount: Int!
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 extend type Commit {
@@ -68,7 +72,9 @@ extend type Commit {
   ```
   """
   commentCount: Int!
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 extend type Object {
@@ -83,7 +89,9 @@ extend type Object {
   ```
   """
   commentCount: Int!
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 type CommentDataFilters {

--- a/packages/server/assets/comments/typedefs/comments.gql
+++ b/packages/server/assets/comments/typedefs/comments.gql
@@ -1,5 +1,6 @@
 extend type Query {
   comment(id: String!, streamId: String!): Comment
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
   """
   This query can be used in the following ways:
   - get all the comments for a stream: **do not pass in any resource identifiers**.
@@ -11,7 +12,8 @@ extend type Query {
     limit: Int = 25
     cursor: String
     archived: Boolean! = false
-  ): CommentCollection @deprecated(reason: "Use 'commentThreads' fields instead")
+  ): CommentCollection
+    @deprecated(reason: "Use Project/Version/Model 'commentThreads' fields instead")
 }
 
 extend type Project {
@@ -51,6 +53,7 @@ extend type Stream {
   ```
   """
   commentCount: Int!
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 extend type Commit {
@@ -65,6 +68,7 @@ extend type Commit {
   ```
   """
   commentCount: Int!
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 extend type Object {
@@ -79,6 +83,7 @@ extend type Object {
   ```
   """
   commentCount: Int!
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 type CommentDataFilters {

--- a/packages/server/assets/core/typedefs/branchesAndCommits.graphql
+++ b/packages/server/assets/core/typedefs/branchesAndCommits.graphql
@@ -1,8 +1,20 @@
 extend type Stream {
   commits(limit: Int! = 25, cursor: String): CommitCollection
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Project.versions instead."
+    )
   commit(id: String): Commit
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Project.version instead."
+    )
   branches(limit: Int! = 25, cursor: String): BranchCollection
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Project.models or Project.modelsTree instead."
+    )
   branch(name: String = "main"): Branch
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Project.model instead."
+    )
 }
 
 extend type User {
@@ -11,6 +23,9 @@ extend type User {
   from public streams will be returned.
   """
   commits(limit: Int! = 25, cursor: String): CommitCollection
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use User.versions instead."
+    )
 }
 
 extend type LimitedUser {
@@ -18,6 +33,9 @@ extend type LimitedUser {
   Get public stream commits authored by the user
   """
   commits(limit: Int! = 25, cursor: String): CommitCollection
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 type Branch {
@@ -67,25 +85,50 @@ extend type Mutation {
   branchCreate(branch: BranchCreateInput!): String!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ModelMutations.create instead."
+    )
   branchUpdate(branch: BranchUpdateInput!): Boolean!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ModelMutations.update instead."
+    )
+
   branchDelete(branch: BranchDeleteInput!): Boolean!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ModelMutations.delete instead."
+    )
 
   commitCreate(commit: CommitCreateInput!): String!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
+
   commitUpdate(commit: CommitUpdateInput!): Boolean!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use VersionMutations.update/moveToModel instead."
+    )
+
   commitReceive(input: CommitReceivedInput!): Boolean!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
+
   commitDelete(commit: CommitDeleteInput!): Boolean!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use VersionMutations.delete instead."
+    )
 
   """
   Move a batch of commits to a new branch
@@ -93,6 +136,9 @@ extend type Mutation {
   commitsMove(input: CommitsMoveInput!): Boolean!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use VersionMutations.moveToModel instead."
+    )
 
   """
   Delete a batch of commits
@@ -100,6 +146,9 @@ extend type Mutation {
   commitsDelete(input: CommitsDeleteInput!): Boolean!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use VersionMutations.delete instead."
+    )
 }
 
 extend type Subscription {
@@ -110,18 +159,29 @@ extend type Subscription {
   branchCreated(streamId: String!): JSONObject
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead."
+    )
+
   """
   Subscribe to branch updated event.
   """
   branchUpdated(streamId: String!, branchId: String): JSONObject
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead."
+    )
+
   """
   Subscribe to branch deleted event
   """
   branchDeleted(streamId: String!): JSONObject
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead."
+    )
 
   """
   Subscribe to commit created event
@@ -129,18 +189,29 @@ extend type Subscription {
   commitCreated(streamId: String!): JSONObject
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead."
+    )
+
   """
   Subscribe to commit updated event.
   """
   commitUpdated(streamId: String!, commitId: String): JSONObject
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead."
+    )
+
   """
   Subscribe to commit deleted event
   """
   commitDeleted(streamId: String!): JSONObject
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead."
+    )
 }
 
 input BranchCreateInput {

--- a/packages/server/assets/core/typedefs/objects.graphql
+++ b/packages/server/assets/core/typedefs/objects.graphql
@@ -1,6 +1,8 @@
 extend type Stream {
   object(id: String!): Object
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 type Object {
@@ -35,7 +37,9 @@ type ObjectCollection {
 
 extend type Mutation {
   objectCreate(objectInput: ObjectCreateInput!): [String]!
-    @deprecated(reason: "Part of the old API surface and will be removed in the future")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 input ObjectCreateInput {

--- a/packages/server/assets/core/typedefs/objects.graphql
+++ b/packages/server/assets/core/typedefs/objects.graphql
@@ -1,5 +1,6 @@
 extend type Stream {
   object(id: String!): Object
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 type Object {
@@ -34,6 +35,7 @@ type ObjectCollection {
 
 extend type Mutation {
   objectCreate(objectInput: ObjectCreateInput!): [String]!
+    @deprecated(reason: "Part of the old API surface and will be removed in the future")
 }
 
 input ObjectCreateInput {

--- a/packages/server/assets/core/typedefs/streams.graphql
+++ b/packages/server/assets/core/typedefs/streams.graphql
@@ -148,8 +148,8 @@ type PendingStreamCollaborator {
   inviteId: String!
   projectId: String!
   projectName: String!
-  streamId: String!
-  streamName: String!
+  streamId: String! @deprecated(reason: "Use projectId instead")
+  streamName: String! @deprecated(reason: "Use projectName instead")
   """
   E-mail address or name of the invited user
   """

--- a/packages/server/assets/core/typedefs/streams.graphql
+++ b/packages/server/assets/core/typedefs/streams.graphql
@@ -4,6 +4,9 @@ extend type Query {
   to see it, for example, if a stream isn't public and the user doesn't have the appropriate rights.
   """
   stream(id: String!): Stream
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Query.project instead."
+    )
 
   """
   Returns all streams that the active user is a collaborator on.
@@ -12,6 +15,9 @@ extend type Query {
   streams(query: String, limit: Int = 25, cursor: String): StreamCollection
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use User.projects instead."
+    )
 
   """
   All the streams of the server. Available to admins only.
@@ -37,6 +43,9 @@ extend type Query {
     """
     sort: DiscoverableStreamsSortingInput
   ): StreamCollection
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 type Stream {
@@ -81,6 +90,9 @@ extend type User {
   streams(limit: Int! = 25, cursor: String): StreamCollection!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use User.projects instead."
+    )
 
   """
   All the streams that a active user has favorited.
@@ -89,11 +101,17 @@ extend type User {
   favoriteStreams(limit: Int! = 25, cursor: String): StreamCollection!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 
   """
   Total amount of favorites attached to streams owned by the user
   """
   totalOwnedStreamsFavorites: Int!
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 extend type LimitedUser {
@@ -103,11 +121,17 @@ extend type LimitedUser {
   streams(limit: Int! = 25, cursor: String): StreamCollection!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 
   """
   Total amount of favorites attached to streams owned by the user
   """
   totalOwnedStreamsFavorites: Int!
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 type StreamCollaborator {
@@ -155,41 +179,71 @@ extend type Mutation {
   streamCreate(stream: StreamCreateInput!): String
     @hasServerRole(role: SERVER_USER)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ProjectMutations.create instead."
+    )
+
   """
   Updates an existing stream.
   """
   streamUpdate(stream: StreamUpdateInput!): Boolean!
     @hasServerRole(role: SERVER_USER)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ProjectMutations.update instead."
+    )
+
   """
   Deletes an existing stream.
   """
   streamDelete(id: String!): Boolean!
     @hasServerRole(role: SERVER_USER)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ProjectMutations.delete instead."
+    )
 
-  streamsDelete(ids: [String!]): Boolean! @hasServerRole(role: SERVER_ADMIN)
+  streamsDelete(ids: [String!]): Boolean!
+    @hasServerRole(role: SERVER_ADMIN)
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
+
   """
   Update permissions of a user on a given stream.
   """
   streamUpdatePermission(permissionParams: StreamUpdatePermissionInput!): Boolean
     @hasServerRole(role: SERVER_USER)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ProjectMutations.updateRole instead."
+    )
+
   """
   Revokes the permissions of a user on a given stream.
   """
   streamRevokePermission(permissionParams: StreamRevokePermissionInput!): Boolean
     @hasServerRole(role: SERVER_USER)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ProjectMutations.updateRole instead."
+    )
 
   # Favorite/unfavorite the given stream
   streamFavorite(streamId: String!, favorited: Boolean!): Stream
     @hasServerRole(role: SERVER_GUEST)
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 
   """
   Remove yourself from stream collaborators (not possible for the owner)
   """
-  streamLeave(streamId: String!): Boolean! @hasServerRole(role: SERVER_GUEST)
+  streamLeave(streamId: String!): Boolean!
+    @hasServerRole(role: SERVER_GUEST)
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ProjectMutations.leave instead."
+    )
 }
 
 extend type Subscription {
@@ -205,6 +259,9 @@ extend type Subscription {
   userStreamAdded: JSONObject
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "profile:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use userProjectsUpdated instead."
+    )
 
   """
   Subscribes to stream removed event for your profile. Use this to display an up-to-date list of streams for your profile.
@@ -213,6 +270,9 @@ extend type Subscription {
   userStreamRemoved: JSONObject
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "profile:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use userProjectsUpdated instead."
+    )
 
   #
   # Stream bound subscriptions that operate on the stream itself.
@@ -225,6 +285,9 @@ extend type Subscription {
   streamUpdated(streamId: String): JSONObject
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use projectUpdated instead."
+    )
 
   """
   Subscribes to stream deleted event. Use this in clients/components that pertain only to this stream.
@@ -232,6 +295,9 @@ extend type Subscription {
   streamDeleted(streamId: String): JSONObject
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use projectUpdated instead."
+    )
 }
 
 input StreamCreateInput {

--- a/packages/server/assets/core/typedefs/user.graphql
+++ b/packages/server/assets/core/typedefs/user.graphql
@@ -48,6 +48,9 @@ extend type Query {
   Validate password strength
   """
   userPwdStrength(pwd: String!): PasswordStrengthCheckResults!
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future."
+    )
 }
 
 type PasswordStrengthCheckResults {
@@ -78,6 +81,9 @@ when a user is reading/writing info about himself
 """
 type User {
   id: ID!
+  """
+  Only returned if API user is the user being requested or an admin
+  """
   email: String
   name: String!
   bio: String

--- a/packages/server/assets/fileuploads/typedefs/fileuploads.graphql
+++ b/packages/server/assets/fileuploads/typedefs/fileuploads.graphql
@@ -3,10 +3,17 @@ extend type Stream {
   Returns a list of all the file uploads for this stream.
   """
   fileUploads: [FileUpload!]!
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Project.pendingImportedModels or Model.pendingImportedVersions instead."
+    )
+
   """
   Returns a specific file upload that belongs to this stream.
   """
   fileUpload(id: String!): FileUpload
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Project.pendingImportedModels or Model.pendingImportedVersions instead."
+    )
 }
 
 extend type Project {
@@ -123,4 +130,7 @@ extend type Subscription {
   Subscribe to changes to any of a project's file imports
   """
   projectFileImportUpdated(id: String!): ProjectFileImportUpdatedMessage!
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use projectPendingModelsUpdated or projectPendingVersionsUpdated instead."
+    )
 }

--- a/packages/server/assets/serverinvites/typedefs/serverInvites.graphql
+++ b/packages/server/assets/serverinvites/typedefs/serverInvites.graphql
@@ -13,6 +13,9 @@ extend type Mutation {
   streamInviteCreate(input: StreamInviteCreateInput!): Boolean!
     @hasServerRole(role: SERVER_USER)
     @hasScope(scope: "users:invite")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.create instead."
+    )
 
   """
   Note: The required scope to invoke this is not given out to app or personal access tokens
@@ -27,12 +30,18 @@ extend type Mutation {
   streamInviteBatchCreate(input: [StreamInviteCreateInput!]!): Boolean!
     @hasServerRole(role: SERVER_ADMIN)
     @hasScope(scope: "users:invite")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.batchCreate instead."
+    )
 
   """
   Accept or decline a stream invite
   """
   streamInviteUse(accept: Boolean!, streamId: String!, token: String!): Boolean!
     @hasServerRole(role: SERVER_GUEST)
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.use instead."
+    )
 
   """
   Cancel a pending stream invite. Can only be invoked by a stream owner.
@@ -41,6 +50,9 @@ extend type Mutation {
   streamInviteCancel(streamId: String!, inviteId: String!): Boolean!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "users:invite")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.cancel instead."
+    )
 
   """
   Re-send a pending invite
@@ -65,6 +77,9 @@ extend type Query {
   isn't specified, the server will look for any valid invite.
   """
   streamInvite(streamId: String!, token: String): PendingStreamCollaborator
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Query.projectInvite instead."
+    )
 
   """
   Look for an invitation to a project, for the current user (authed or not). If token
@@ -78,6 +93,9 @@ extend type Query {
   streamInvites: [PendingStreamCollaborator!]!
     @hasServerRole(role: SERVER_GUEST)
     @hasScope(scope: "streams:read")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use User.projectInvites instead."
+    )
 
   """
   Receive metadata about an invite by the invite token

--- a/packages/server/assets/webhooks/typedefs/webhooks.graphql
+++ b/packages/server/assets/webhooks/typedefs/webhooks.graphql
@@ -2,6 +2,9 @@ extend type Stream {
   webhooks(id: String): WebhookCollection!
     @hasServerRole(role: SERVER_USER)
     @hasScope(scope: "streams:write")
+    @deprecated(
+      reason: "Part of the old API surface and will be removed in the future. Use Project.webhooks instead."
+    )
 }
 
 extend type Project {

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -938,14 +938,20 @@ export type LimitedUser = {
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
   role?: Maybe<Scalars['String']['output']>;
-  /** Returns all discoverable streams that the user is a collaborator on */
+  /**
+   * Returns all discoverable streams that the user is a collaborator on
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   streams: StreamCollection;
   /**
    * The user's timeline in chronological order
    * @deprecated Part of the old API surface and will be removed in the future
    */
   timeline?: Maybe<ActivityCollection>;
-  /** Total amount of favorites attached to streams owned by the user */
+  /**
+   * Total amount of favorites attached to streams owned by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
   verified?: Maybe<Scalars['Boolean']['output']>;
 };
@@ -1193,6 +1199,7 @@ export type Mutation = {
    */
   inviteResend: Scalars['Boolean']['output'];
   modelMutations: ModelMutations;
+  /** @deprecated Part of the old API surface and will be removed in the future */
   objectCreate: Array<Maybe<Scalars['String']['output']>>;
   projectMutations: ProjectMutations;
   /** (Re-)send the account verification e-mail */
@@ -1213,10 +1220,17 @@ export type Mutation = {
    * @deprecated Part of the old API surface and will be removed in the future
    */
   streamAccessRequestUse: Scalars['Boolean']['output'];
-  /** Creates a new stream. */
+  /**
+   * Creates a new stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.create instead.
+   */
   streamCreate?: Maybe<Scalars['String']['output']>;
-  /** Deletes an existing stream. */
+  /**
+   * Deletes an existing stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.delete instead.
+   */
   streamDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   streamFavorite?: Maybe<Stream>;
   /** Note: The required scope to invoke this is not given out to app or personal access tokens */
   streamInviteBatchCreate: Scalars['Boolean']['output'];
@@ -1232,14 +1246,27 @@ export type Mutation = {
   streamInviteCreate: Scalars['Boolean']['output'];
   /** Accept or decline a stream invite */
   streamInviteUse: Scalars['Boolean']['output'];
-  /** Remove yourself from stream collaborators (not possible for the owner) */
+  /**
+   * Remove yourself from stream collaborators (not possible for the owner)
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.leave instead.
+   */
   streamLeave: Scalars['Boolean']['output'];
-  /** Revokes the permissions of a user on a given stream. */
+  /**
+   * Revokes the permissions of a user on a given stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.updateRole instead.
+   */
   streamRevokePermission?: Maybe<Scalars['Boolean']['output']>;
-  /** Updates an existing stream. */
+  /**
+   * Updates an existing stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.update instead.
+   */
   streamUpdate: Scalars['Boolean']['output'];
-  /** Update permissions of a user on a given stream. */
+  /**
+   * Update permissions of a user on a given stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.updateRole instead.
+   */
   streamUpdatePermission?: Maybe<Scalars['Boolean']['output']>;
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   streamsDelete: Scalars['Boolean']['output'];
   /**
    * Used for broadcasting real time typing status in comment threads. Does not persist any info.
@@ -2213,7 +2240,10 @@ export type Query = {
    * @deprecated Use Project/Version/Model 'commentThreads' fields instead
    */
   comments?: Maybe<CommentCollection>;
-  /** All of the discoverable streams of the server */
+  /**
+   * All of the discoverable streams of the server
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   discoverableStreams?: Maybe<StreamCollection>;
   /** Get the (limited) profile information of another server user */
   otherUser?: Maybe<LimitedUser>;
@@ -2235,6 +2265,7 @@ export type Query = {
   /**
    * Returns a specific stream. Will throw an authorization error if active user isn't authorized
    * to see it, for example, if a stream isn't public and the user doesn't have the appropriate rights.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Query.project instead.
    */
   stream?: Maybe<Stream>;
   /**
@@ -2252,6 +2283,7 @@ export type Query = {
   /**
    * Returns all streams that the active user is a collaborator on.
    * Pass in the `query` parameter to search by name, description or ID.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projects instead.
    */
   streams?: Maybe<StreamCollection>;
   /**
@@ -2259,7 +2291,10 @@ export type Query = {
    * @deprecated To be removed in the near future! Use 'activeUser' to get info about the active user or 'otherUser' to get info about another user.
    */
   user?: Maybe<User>;
-  /** Validate password strength */
+  /**
+   * Validate password strength
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   userPwdStrength: PasswordStrengthCheckResults;
   /**
    * Search for users and return limited metadata about them, if you have the server:user role.
@@ -2635,6 +2670,7 @@ export type Stream = {
   /** Whether the stream can be viewed by non-contributors */
   isPublic: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future */
   object?: Maybe<Object>;
   /**
    * Pending stream access requests
@@ -2866,20 +2902,28 @@ export type Subscription = {
   projectVersionsPreviewGenerated: ProjectVersionsPreviewGeneratedMessage;
   /** Subscribe to changes to a project's versions. */
   projectVersionsUpdated: ProjectVersionsUpdatedMessage;
-  /** Subscribes to stream deleted event. Use this in clients/components that pertain only to this stream. */
+  /**
+   * Subscribes to stream deleted event. Use this in clients/components that pertain only to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectUpdated instead.
+   */
   streamDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribes to stream updated event. Use this in clients/components that pertain only to this stream. */
+  /**
+   * Subscribes to stream updated event. Use this in clients/components that pertain only to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectUpdated instead.
+   */
   streamUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /** Track newly added or deleted projects owned by the active user */
   userProjectsUpdated: UserProjectsUpdatedMessage;
   /**
    * Subscribes to new stream added event for your profile. Use this to display an up-to-date list of streams.
    * **NOTE**: If someone shares a stream with you, this subscription will be triggered with an extra value of `sharedBy` in the payload.
+   * @deprecated Part of the old API surface and will be removed in the future. Use userProjectsUpdated instead.
    */
   userStreamAdded?: Maybe<Scalars['JSONObject']['output']>;
   /**
    * Subscribes to stream removed event for your profile. Use this to display an up-to-date list of streams for your profile.
    * **NOTE**: If someone revokes your permissions on a stream, this subscription will be triggered with an extra value of `revokedBy` in the payload.
+   * @deprecated Part of the old API surface and will be removed in the future. Use userProjectsUpdated instead.
    */
   userStreamRemoved?: Maybe<Scalars['JSONObject']['output']>;
   /**
@@ -3114,10 +3158,12 @@ export type User = {
   /** Returns the apps you have created. */
   createdApps?: Maybe<Array<ServerApp>>;
   createdAt?: Maybe<Scalars['DateTime']['output']>;
+  /** Only returned if API user is the user being requested or an admin */
   email?: Maybe<Scalars['String']['output']>;
   /**
    * All the streams that a active user has favorited.
    * Note: You can't use this to retrieve another user's favorite streams.
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   favoriteStreams: StreamCollection;
   /** Whether the user has a pending/active email verification token */
@@ -3136,6 +3182,7 @@ export type User = {
   /**
    * Returns all streams that the user is a collaborator on. If requested for a user, who isn't the
    * authenticated user, then this will only return discoverable streams.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projects instead.
    */
   streams: StreamCollection;
   /**
@@ -3143,7 +3190,10 @@ export type User = {
    * @deprecated Part of the old API surface and will be removed in the future
    */
   timeline?: Maybe<ActivityCollection>;
-  /** Total amount of favorites attached to streams owned by the user */
+  /**
+   * Total amount of favorites attached to streams owned by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
   verified?: Maybe<Scalars['Boolean']['output']>;
   /**

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -684,6 +684,7 @@ export type Commit = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -928,7 +929,10 @@ export type LimitedUser = {
   activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']['output']>;
   bio?: Maybe<Scalars['String']['output']>;
-  /** Get public stream commits authored by the user */
+  /**
+   * Get public stream commits authored by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   commits?: Maybe<CommitCollection>;
   company?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
@@ -1126,8 +1130,11 @@ export type Mutation = {
   appUpdate: Scalars['Boolean']['output'];
   automateFunctionRunStatusReport: Scalars['Boolean']['output'];
   automateMutations: AutomateMutations;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.create instead. */
   branchCreate: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.delete instead. */
   branchDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.update instead. */
   branchUpdate: Scalars['Boolean']['output'];
   /** Broadcast user activity in the viewer */
   broadcastViewerUserActivity: Scalars['Boolean']['output'];
@@ -1157,13 +1164,23 @@ export type Mutation = {
    * @deprecated Use commentMutations version
    */
   commentView: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   commitCreate: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.delete instead. */
   commitDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   commitReceive: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.update/moveToModel instead. */
   commitUpdate: Scalars['Boolean']['output'];
-  /** Delete a batch of commits */
+  /**
+   * Delete a batch of commits
+   * @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.delete instead.
+   */
   commitsDelete: Scalars['Boolean']['output'];
-  /** Move a batch of commits to a new branch */
+  /**
+   * Move a batch of commits to a new branch
+   * @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.moveToModel instead.
+   */
   commitsMove: Scalars['Boolean']['output'];
   /**
    * Delete a pending invite
@@ -1554,6 +1571,7 @@ export type Object = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -2186,12 +2204,13 @@ export type Query = {
   automateFunctions: AutomateFunctionCollection;
   /** Part of the automation/function creation handshake mechanism */
   automateValidateAuthCode: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future */
   comment?: Maybe<Comment>;
   /**
    * This query can be used in the following ways:
    * - get all the comments for a stream: **do not pass in any resource identifiers**.
    * - get the comments targeting any of a set of provided resources (comments/objects): **pass in an array of resources.**
-   * @deprecated Use 'commentThreads' fields instead
+   * @deprecated Use Project/Version/Model 'commentThreads' fields instead
    */
   comments?: Maybe<CommentCollection>;
   /** All of the discoverable streams of the server */
@@ -2570,10 +2589,16 @@ export type Stream = {
    */
   activity?: Maybe<ActivityCollection>;
   allowPublicComments: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.blob */
   blob?: Maybe<BlobMetadata>;
-  /** Get the metadata collection of blobs stored for this stream. */
+  /**
+   * Get the metadata collection of blobs stored for this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.blobs
+   */
   blobs?: Maybe<BlobMetadataCollection>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.model instead. */
   branch?: Maybe<Branch>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.models or Project.modelsTree instead. */
   branches?: Maybe<BranchCollection>;
   collaborators: Array<StreamCollaborator>;
   /**
@@ -2585,9 +2610,12 @@ export type Stream = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future
    */
   commentCount: Scalars['Int']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.version instead. */
   commit?: Maybe<Commit>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.versions instead. */
   commits?: Maybe<CommitCollection>;
   createdAt: Scalars['DateTime']['output'];
   description?: Maybe<Scalars['String']['output']>;
@@ -2769,11 +2797,20 @@ export type Subscription = {
   __typename?: 'Subscription';
   /** It's lonely in the void. */
   _?: Maybe<Scalars['String']['output']>;
-  /** Subscribe to branch created event */
+  /**
+   * Subscribe to branch created event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchCreated?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to branch deleted event */
+  /**
+   * Subscribe to branch deleted event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to branch updated event. */
+  /**
+   * Subscribe to branch updated event.
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /**
    * Subscribe to new comment events. There's two ways to use this subscription:
@@ -2789,11 +2826,20 @@ export type Subscription = {
    * @deprecated Use projectCommentsUpdated or viewerUserActivityBroadcasted for reply status
    */
   commentThreadActivity: CommentThreadActivityMessage;
-  /** Subscribe to commit created event */
+  /**
+   * Subscribe to commit created event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitCreated?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to commit deleted event */
+  /**
+   * Subscribe to commit deleted event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to commit updated event. */
+  /**
+   * Subscribe to commit updated event.
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /** Subscribe to updates to automations in the project */
   projectAutomationsUpdated: ProjectAutomationsUpdatedMessage;
@@ -3061,6 +3107,7 @@ export type User = {
   /**
    * Get commits authored by the user. If requested for another user, then only commits
    * from public streams will be returned.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.versions instead.
    */
   commits?: Maybe<CommitCollection>;
   company?: Maybe<Scalars['String']['output']>;

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -449,7 +449,7 @@ export type Branch = {
   __typename?: 'Branch';
   /**
    * All the recent activity on this branch in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   author?: Maybe<User>;
@@ -667,7 +667,7 @@ export type Commit = {
   __typename?: 'Commit';
   /**
    * All the recent activity on this commit in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   authorAvatar?: Maybe<Scalars['String']['output']>;
@@ -684,7 +684,7 @@ export type Commit = {
    *     ...
    *   }
    * ```
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -924,7 +924,7 @@ export type LimitedUser = {
   __typename?: 'LimitedUser';
   /**
    * All the recent activity from this user in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']['output']>;
@@ -945,7 +945,7 @@ export type LimitedUser = {
   streams: StreamCollection;
   /**
    * The user's timeline in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   timeline?: Maybe<ActivityCollection>;
   /**
@@ -1199,7 +1199,7 @@ export type Mutation = {
    */
   inviteResend: Scalars['Boolean']['output'];
   modelMutations: ModelMutations;
-  /** @deprecated Part of the old API surface and will be removed in the future */
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   objectCreate: Array<Maybe<Scalars['String']['output']>>;
   projectMutations: ProjectMutations;
   /** (Re-)send the account verification e-mail */
@@ -1212,12 +1212,12 @@ export type Mutation = {
   serverInviteCreate: Scalars['Boolean']['output'];
   /**
    * Request access to a specific stream
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   streamAccessRequestCreate: StreamAccessRequest;
   /**
    * Accept or decline a stream access request. Must be a stream owner to invoke this.
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   streamAccessRequestUse: Scalars['Boolean']['output'];
   /**
@@ -1606,7 +1606,7 @@ export type Object = {
    *     ...
    *   }
    * ```
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -1670,7 +1670,9 @@ export type PendingStreamCollaborator = {
   projectId: Scalars['String']['output'];
   projectName: Scalars['String']['output'];
   role: Scalars['String']['output'];
+  /** @deprecated Use projectId instead */
   streamId: Scalars['String']['output'];
+  /** @deprecated Use projectName instead */
   streamName: Scalars['String']['output'];
   /** E-mail address or name of the invited user */
   title: Scalars['String']['output'];
@@ -2229,7 +2231,7 @@ export type Query = {
   app?: Maybe<ServerApp>;
   /**
    * Returns all the publicly available apps on this server.
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   apps?: Maybe<Array<Maybe<ServerAppListItem>>>;
   /** If user is authenticated using an app token, this will describe the app */
@@ -2239,7 +2241,7 @@ export type Query = {
   automateFunctions: AutomateFunctionCollection;
   /** Part of the automation/function creation handshake mechanism */
   automateValidateAuthCode: Scalars['Boolean']['output'];
-  /** @deprecated Part of the old API surface and will be removed in the future */
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   comment?: Maybe<Comment>;
   /**
    * This query can be used in the following ways:
@@ -2278,7 +2280,7 @@ export type Query = {
   stream?: Maybe<Stream>;
   /**
    * Get authed user's stream access request
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   streamAccessRequest?: Maybe<StreamAccessRequest>;
   /**
@@ -2632,15 +2634,15 @@ export type Stream = {
   __typename?: 'Stream';
   /**
    * All the recent activity on this stream in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   allowPublicComments: Scalars['Boolean']['output'];
-  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.blob */
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.blob instead. */
   blob?: Maybe<BlobMetadata>;
   /**
    * Get the metadata collection of blobs stored for this stream.
-   * @deprecated Part of the old API surface and will be removed in the future. Use Project.blobs
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.blobs instead.
    */
   blobs?: Maybe<BlobMetadataCollection>;
   /** @deprecated Part of the old API surface and will be removed in the future. Use Project.model instead. */
@@ -2657,7 +2659,7 @@ export type Stream = {
    *     ...
    *   }
    * ```
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   /** @deprecated Part of the old API surface and will be removed in the future. Use Project.version instead. */
@@ -2688,11 +2690,11 @@ export type Stream = {
   /** Whether the stream can be viewed by non-contributors */
   isPublic: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
-  /** @deprecated Part of the old API surface and will be removed in the future */
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   object?: Maybe<Object>;
   /**
    * Pending stream access requests
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   pendingAccessRequests?: Maybe<Array<StreamAccessRequest>>;
   /** Collaborators who have been invited, but not yet accepted. */
@@ -3160,7 +3162,7 @@ export type User = {
   __typename?: 'User';
   /**
    * All the recent activity from this user in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   /** Returns a list of your personal api tokens. */
@@ -3209,7 +3211,7 @@ export type User = {
   streams: StreamCollection;
   /**
    * The user's timeline in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   timeline?: Maybe<ActivityCollection>;
   /**

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -447,7 +447,10 @@ export type BlobMetadataCollection = {
 
 export type Branch = {
   __typename?: 'Branch';
-  /** All the recent activity on this branch in chronological order */
+  /**
+   * All the recent activity on this branch in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   author?: Maybe<User>;
   commits?: Maybe<CommitCollection>;
@@ -662,7 +665,10 @@ export type CommentThreadActivityMessage = {
 
 export type Commit = {
   __typename?: 'Commit';
-  /** All the recent activity on this commit in chronological order */
+  /**
+   * All the recent activity on this commit in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   authorAvatar?: Maybe<Scalars['String']['output']>;
   authorId?: Maybe<Scalars['String']['output']>;
@@ -915,7 +921,10 @@ export type LegacyCommentViewerData = {
  */
 export type LimitedUser = {
   __typename?: 'LimitedUser';
-  /** All the recent activity from this user in chronological order */
+  /**
+   * All the recent activity from this user in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']['output']>;
   bio?: Maybe<Scalars['String']['output']>;
@@ -927,7 +936,10 @@ export type LimitedUser = {
   role?: Maybe<Scalars['String']['output']>;
   /** Returns all discoverable streams that the user is a collaborator on */
   streams: StreamCollection;
-  /** The user's timeline in chronological order */
+  /**
+   * The user's timeline in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   timeline?: Maybe<ActivityCollection>;
   /** Total amount of favorites attached to streams owned by the user */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
@@ -1174,9 +1186,15 @@ export type Mutation = {
   serverInviteBatchCreate: Scalars['Boolean']['output'];
   /** Invite a new user to the speckle server and return the invite ID */
   serverInviteCreate: Scalars['Boolean']['output'];
-  /** Request access to a specific stream */
+  /**
+   * Request access to a specific stream
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   streamAccessRequestCreate: StreamAccessRequest;
-  /** Accept or decline a stream access request. Must be a stream owner to invoke this. */
+  /**
+   * Accept or decline a stream access request. Must be a stream owner to invoke this.
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   streamAccessRequestUse: Scalars['Boolean']['output'];
   /** Creates a new stream. */
   streamCreate?: Maybe<Scalars['String']['output']>;
@@ -2156,7 +2174,10 @@ export type Query = {
   adminUsers?: Maybe<AdminUsersListCollection>;
   /** Gets a specific app from the server. */
   app?: Maybe<ServerApp>;
-  /** Returns all the publicly available apps on this server. */
+  /**
+   * Returns all the publicly available apps on this server.
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   apps?: Maybe<Array<Maybe<ServerAppListItem>>>;
   /** If user is authenticated using an app token, this will describe the app */
   authenticatedAsApp?: Maybe<ServerAppListItem>;
@@ -2197,7 +2218,10 @@ export type Query = {
    * to see it, for example, if a stream isn't public and the user doesn't have the appropriate rights.
    */
   stream?: Maybe<Stream>;
-  /** Get authed user's stream access request */
+  /**
+   * Get authed user's stream access request
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   streamAccessRequest?: Maybe<StreamAccessRequest>;
   /**
    * Look for an invitation to a stream, for the current user (authed or not). If token
@@ -2540,7 +2564,10 @@ export enum SortDirection {
 
 export type Stream = {
   __typename?: 'Stream';
-  /** All the recent activity on this stream in chronological order */
+  /**
+   * All the recent activity on this stream in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   allowPublicComments: Scalars['Boolean']['output'];
   blob?: Maybe<BlobMetadata>;
@@ -2581,7 +2608,10 @@ export type Stream = {
   isPublic: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
   object?: Maybe<Object>;
-  /** Pending stream access requests */
+  /**
+   * Pending stream access requests
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   pendingAccessRequests?: Maybe<Array<StreamAccessRequest>>;
   /** Collaborators who have been invited, but not yet accepted. */
   pendingCollaborators?: Maybe<Array<PendingStreamCollaborator>>;
@@ -3016,7 +3046,10 @@ export type UpdateVersionInput = {
  */
 export type User = {
   __typename?: 'User';
-  /** All the recent activity from this user in chronological order */
+  /**
+   * All the recent activity from this user in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   /** Returns a list of your personal api tokens. */
   apiTokens: Array<ApiToken>;
@@ -3058,7 +3091,10 @@ export type User = {
    * authenticated user, then this will only return discoverable streams.
    */
   streams: StreamCollection;
-  /** The user's timeline in chronological order */
+  /**
+   * The user's timeline in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   timeline?: Maybe<ActivityCollection>;
   /** Total amount of favorites attached to streams owned by the user */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -2701,6 +2701,7 @@ export type Stream = {
   role?: Maybe<Scalars['String']['output']>;
   size?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.webhooks instead. */
   webhooks: WebhookCollection;
 };
 

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -1232,19 +1232,27 @@ export type Mutation = {
   streamDelete: Scalars['Boolean']['output'];
   /** @deprecated Part of the old API surface and will be removed in the future. */
   streamFavorite?: Maybe<Stream>;
-  /** Note: The required scope to invoke this is not given out to app or personal access tokens */
+  /**
+   * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.batchCreate instead.
+   */
   streamInviteBatchCreate: Scalars['Boolean']['output'];
   /**
    * Cancel a pending stream invite. Can only be invoked by a stream owner.
    * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.cancel instead.
    */
   streamInviteCancel: Scalars['Boolean']['output'];
   /**
    * Invite a new or registered user to the specified stream
    * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.create instead.
    */
   streamInviteCreate: Scalars['Boolean']['output'];
-  /** Accept or decline a stream invite */
+  /**
+   * Accept or decline a stream invite
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.use instead.
+   */
   streamInviteUse: Scalars['Boolean']['output'];
   /**
    * Remove yourself from stream collaborators (not possible for the owner)
@@ -2276,9 +2284,13 @@ export type Query = {
   /**
    * Look for an invitation to a stream, for the current user (authed or not). If token
    * isn't specified, the server will look for any valid invite.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Query.projectInvite instead.
    */
   streamInvite?: Maybe<PendingStreamCollaborator>;
-  /** Get all invitations to streams that the active user has */
+  /**
+   * Get all invitations to streams that the active user has
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projectInvites instead.
+   */
   streamInvites: Array<PendingStreamCollaborator>;
   /**
    * Returns all streams that the active user is a collaborator on.
@@ -2657,9 +2669,15 @@ export type Stream = {
   /** Date when you favorited this stream. `null` if stream isn't viewed from a specific user's perspective or if it isn't favorited. */
   favoritedDate?: Maybe<Scalars['DateTime']['output']>;
   favoritesCount: Scalars['Int']['output'];
-  /** Returns a specific file upload that belongs to this stream. */
+  /**
+   * Returns a specific file upload that belongs to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.pendingImportedModels or Model.pendingImportedVersions instead.
+   */
   fileUpload?: Maybe<FileUpload>;
-  /** Returns a list of all the file uploads for this stream. */
+  /**
+   * Returns a list of all the file uploads for this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.pendingImportedModels or Model.pendingImportedVersions instead.
+   */
   fileUploads: Array<FileUpload>;
   id: Scalars['String']['output'];
   /**
@@ -2884,7 +2902,10 @@ export type Subscription = {
    * updates regarding comments for those resources.
    */
   projectCommentsUpdated: ProjectCommentsUpdatedMessage;
-  /** Subscribe to changes to any of a project's file imports */
+  /**
+   * Subscribe to changes to any of a project's file imports
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectPendingModelsUpdated or projectPendingVersionsUpdated instead.
+   */
   projectFileImportUpdated: ProjectFileImportUpdatedMessage;
   /** Subscribe to changes to a project's models. Optionally specify modelIds to track. */
   projectModelsUpdated: ProjectModelsUpdatedMessage;

--- a/packages/server/modules/core/graph/resolvers/appTokens.ts
+++ b/packages/server/modules/core/graph/resolvers/appTokens.ts
@@ -3,23 +3,6 @@ import { canCreateAppToken } from '@/modules/core/helpers/token'
 import { getTokenAppInfo } from '@/modules/core/repositories/tokens'
 import { createAppToken } from '@/modules/core/services/tokens'
 
-/**
- * RESOURCE ACCESS CHECKING:
- *
- * GQL:
- * 1. Scopes - if project scope used, also check resource access rules (also - if ask for all projects, filter out the ones that are not allowed)
- * 2. Project rights (any directives to check?) - not only check access to project (authorizeResolver?), but also check access rules
- * 3. Some resolvers have custom checks, no directives - check manually
- *
- * REST:
- * ???
- *
- * - [X] Validate rules before insert? THat way we can rely on them being correct?
- * - - Not really, user can change roles after token creation
- *
- * - [X] What if rules exist, but only for projects? We still want to treat other types as unlimited
- */
-
 export = {
   Query: {
     async authenticatedAsApp(_parent, _args, ctx) {

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -928,14 +928,20 @@ export type LimitedUser = {
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
   role?: Maybe<Scalars['String']['output']>;
-  /** Returns all discoverable streams that the user is a collaborator on */
+  /**
+   * Returns all discoverable streams that the user is a collaborator on
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   streams: StreamCollection;
   /**
    * The user's timeline in chronological order
    * @deprecated Part of the old API surface and will be removed in the future
    */
   timeline?: Maybe<ActivityCollection>;
-  /** Total amount of favorites attached to streams owned by the user */
+  /**
+   * Total amount of favorites attached to streams owned by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
   verified?: Maybe<Scalars['Boolean']['output']>;
 };
@@ -1183,6 +1189,7 @@ export type Mutation = {
    */
   inviteResend: Scalars['Boolean']['output'];
   modelMutations: ModelMutations;
+  /** @deprecated Part of the old API surface and will be removed in the future */
   objectCreate: Array<Maybe<Scalars['String']['output']>>;
   projectMutations: ProjectMutations;
   /** (Re-)send the account verification e-mail */
@@ -1203,10 +1210,17 @@ export type Mutation = {
    * @deprecated Part of the old API surface and will be removed in the future
    */
   streamAccessRequestUse: Scalars['Boolean']['output'];
-  /** Creates a new stream. */
+  /**
+   * Creates a new stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.create instead.
+   */
   streamCreate?: Maybe<Scalars['String']['output']>;
-  /** Deletes an existing stream. */
+  /**
+   * Deletes an existing stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.delete instead.
+   */
   streamDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   streamFavorite?: Maybe<Stream>;
   /** Note: The required scope to invoke this is not given out to app or personal access tokens */
   streamInviteBatchCreate: Scalars['Boolean']['output'];
@@ -1222,14 +1236,27 @@ export type Mutation = {
   streamInviteCreate: Scalars['Boolean']['output'];
   /** Accept or decline a stream invite */
   streamInviteUse: Scalars['Boolean']['output'];
-  /** Remove yourself from stream collaborators (not possible for the owner) */
+  /**
+   * Remove yourself from stream collaborators (not possible for the owner)
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.leave instead.
+   */
   streamLeave: Scalars['Boolean']['output'];
-  /** Revokes the permissions of a user on a given stream. */
+  /**
+   * Revokes the permissions of a user on a given stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.updateRole instead.
+   */
   streamRevokePermission?: Maybe<Scalars['Boolean']['output']>;
-  /** Updates an existing stream. */
+  /**
+   * Updates an existing stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.update instead.
+   */
   streamUpdate: Scalars['Boolean']['output'];
-  /** Update permissions of a user on a given stream. */
+  /**
+   * Update permissions of a user on a given stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.updateRole instead.
+   */
   streamUpdatePermission?: Maybe<Scalars['Boolean']['output']>;
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   streamsDelete: Scalars['Boolean']['output'];
   /**
    * Used for broadcasting real time typing status in comment threads. Does not persist any info.
@@ -2203,7 +2230,10 @@ export type Query = {
    * @deprecated Use Project/Version/Model 'commentThreads' fields instead
    */
   comments?: Maybe<CommentCollection>;
-  /** All of the discoverable streams of the server */
+  /**
+   * All of the discoverable streams of the server
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   discoverableStreams?: Maybe<StreamCollection>;
   /** Get the (limited) profile information of another server user */
   otherUser?: Maybe<LimitedUser>;
@@ -2225,6 +2255,7 @@ export type Query = {
   /**
    * Returns a specific stream. Will throw an authorization error if active user isn't authorized
    * to see it, for example, if a stream isn't public and the user doesn't have the appropriate rights.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Query.project instead.
    */
   stream?: Maybe<Stream>;
   /**
@@ -2242,6 +2273,7 @@ export type Query = {
   /**
    * Returns all streams that the active user is a collaborator on.
    * Pass in the `query` parameter to search by name, description or ID.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projects instead.
    */
   streams?: Maybe<StreamCollection>;
   /**
@@ -2249,7 +2281,10 @@ export type Query = {
    * @deprecated To be removed in the near future! Use 'activeUser' to get info about the active user or 'otherUser' to get info about another user.
    */
   user?: Maybe<User>;
-  /** Validate password strength */
+  /**
+   * Validate password strength
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   userPwdStrength: PasswordStrengthCheckResults;
   /**
    * Search for users and return limited metadata about them, if you have the server:user role.
@@ -2625,6 +2660,7 @@ export type Stream = {
   /** Whether the stream can be viewed by non-contributors */
   isPublic: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future */
   object?: Maybe<Object>;
   /**
    * Pending stream access requests
@@ -2856,20 +2892,28 @@ export type Subscription = {
   projectVersionsPreviewGenerated: ProjectVersionsPreviewGeneratedMessage;
   /** Subscribe to changes to a project's versions. */
   projectVersionsUpdated: ProjectVersionsUpdatedMessage;
-  /** Subscribes to stream deleted event. Use this in clients/components that pertain only to this stream. */
+  /**
+   * Subscribes to stream deleted event. Use this in clients/components that pertain only to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectUpdated instead.
+   */
   streamDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribes to stream updated event. Use this in clients/components that pertain only to this stream. */
+  /**
+   * Subscribes to stream updated event. Use this in clients/components that pertain only to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectUpdated instead.
+   */
   streamUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /** Track newly added or deleted projects owned by the active user */
   userProjectsUpdated: UserProjectsUpdatedMessage;
   /**
    * Subscribes to new stream added event for your profile. Use this to display an up-to-date list of streams.
    * **NOTE**: If someone shares a stream with you, this subscription will be triggered with an extra value of `sharedBy` in the payload.
+   * @deprecated Part of the old API surface and will be removed in the future. Use userProjectsUpdated instead.
    */
   userStreamAdded?: Maybe<Scalars['JSONObject']['output']>;
   /**
    * Subscribes to stream removed event for your profile. Use this to display an up-to-date list of streams for your profile.
    * **NOTE**: If someone revokes your permissions on a stream, this subscription will be triggered with an extra value of `revokedBy` in the payload.
+   * @deprecated Part of the old API surface and will be removed in the future. Use userProjectsUpdated instead.
    */
   userStreamRemoved?: Maybe<Scalars['JSONObject']['output']>;
   /**
@@ -3104,10 +3148,12 @@ export type User = {
   /** Returns the apps you have created. */
   createdApps?: Maybe<Array<ServerApp>>;
   createdAt?: Maybe<Scalars['DateTime']['output']>;
+  /** Only returned if API user is the user being requested or an admin */
   email?: Maybe<Scalars['String']['output']>;
   /**
    * All the streams that a active user has favorited.
    * Note: You can't use this to retrieve another user's favorite streams.
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   favoriteStreams: StreamCollection;
   /** Whether the user has a pending/active email verification token */
@@ -3126,6 +3172,7 @@ export type User = {
   /**
    * Returns all streams that the user is a collaborator on. If requested for a user, who isn't the
    * authenticated user, then this will only return discoverable streams.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projects instead.
    */
   streams: StreamCollection;
   /**
@@ -3133,7 +3180,10 @@ export type User = {
    * @deprecated Part of the old API surface and will be removed in the future
    */
   timeline?: Maybe<ActivityCollection>;
-  /** Total amount of favorites attached to streams owned by the user */
+  /**
+   * Total amount of favorites attached to streams owned by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
   verified?: Maybe<Scalars['Boolean']['output']>;
   /**

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -674,6 +674,7 @@ export type Commit = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -918,7 +919,10 @@ export type LimitedUser = {
   activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']['output']>;
   bio?: Maybe<Scalars['String']['output']>;
-  /** Get public stream commits authored by the user */
+  /**
+   * Get public stream commits authored by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   commits?: Maybe<CommitCollection>;
   company?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
@@ -1116,8 +1120,11 @@ export type Mutation = {
   appUpdate: Scalars['Boolean']['output'];
   automateFunctionRunStatusReport: Scalars['Boolean']['output'];
   automateMutations: AutomateMutations;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.create instead. */
   branchCreate: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.delete instead. */
   branchDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.update instead. */
   branchUpdate: Scalars['Boolean']['output'];
   /** Broadcast user activity in the viewer */
   broadcastViewerUserActivity: Scalars['Boolean']['output'];
@@ -1147,13 +1154,23 @@ export type Mutation = {
    * @deprecated Use commentMutations version
    */
   commentView: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   commitCreate: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.delete instead. */
   commitDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   commitReceive: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.update/moveToModel instead. */
   commitUpdate: Scalars['Boolean']['output'];
-  /** Delete a batch of commits */
+  /**
+   * Delete a batch of commits
+   * @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.delete instead.
+   */
   commitsDelete: Scalars['Boolean']['output'];
-  /** Move a batch of commits to a new branch */
+  /**
+   * Move a batch of commits to a new branch
+   * @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.moveToModel instead.
+   */
   commitsMove: Scalars['Boolean']['output'];
   /**
    * Delete a pending invite
@@ -1544,6 +1561,7 @@ export type Object = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -2176,12 +2194,13 @@ export type Query = {
   automateFunctions: AutomateFunctionCollection;
   /** Part of the automation/function creation handshake mechanism */
   automateValidateAuthCode: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future */
   comment?: Maybe<Comment>;
   /**
    * This query can be used in the following ways:
    * - get all the comments for a stream: **do not pass in any resource identifiers**.
    * - get the comments targeting any of a set of provided resources (comments/objects): **pass in an array of resources.**
-   * @deprecated Use 'commentThreads' fields instead
+   * @deprecated Use Project/Version/Model 'commentThreads' fields instead
    */
   comments?: Maybe<CommentCollection>;
   /** All of the discoverable streams of the server */
@@ -2560,10 +2579,16 @@ export type Stream = {
    */
   activity?: Maybe<ActivityCollection>;
   allowPublicComments: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.blob */
   blob?: Maybe<BlobMetadata>;
-  /** Get the metadata collection of blobs stored for this stream. */
+  /**
+   * Get the metadata collection of blobs stored for this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.blobs
+   */
   blobs?: Maybe<BlobMetadataCollection>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.model instead. */
   branch?: Maybe<Branch>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.models or Project.modelsTree instead. */
   branches?: Maybe<BranchCollection>;
   collaborators: Array<StreamCollaborator>;
   /**
@@ -2575,9 +2600,12 @@ export type Stream = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future
    */
   commentCount: Scalars['Int']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.version instead. */
   commit?: Maybe<Commit>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.versions instead. */
   commits?: Maybe<CommitCollection>;
   createdAt: Scalars['DateTime']['output'];
   description?: Maybe<Scalars['String']['output']>;
@@ -2759,11 +2787,20 @@ export type Subscription = {
   __typename?: 'Subscription';
   /** It's lonely in the void. */
   _?: Maybe<Scalars['String']['output']>;
-  /** Subscribe to branch created event */
+  /**
+   * Subscribe to branch created event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchCreated?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to branch deleted event */
+  /**
+   * Subscribe to branch deleted event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to branch updated event. */
+  /**
+   * Subscribe to branch updated event.
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /**
    * Subscribe to new comment events. There's two ways to use this subscription:
@@ -2779,11 +2816,20 @@ export type Subscription = {
    * @deprecated Use projectCommentsUpdated or viewerUserActivityBroadcasted for reply status
    */
   commentThreadActivity: CommentThreadActivityMessage;
-  /** Subscribe to commit created event */
+  /**
+   * Subscribe to commit created event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitCreated?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to commit deleted event */
+  /**
+   * Subscribe to commit deleted event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to commit updated event. */
+  /**
+   * Subscribe to commit updated event.
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /** Subscribe to updates to automations in the project */
   projectAutomationsUpdated: ProjectAutomationsUpdatedMessage;
@@ -3051,6 +3097,7 @@ export type User = {
   /**
    * Get commits authored by the user. If requested for another user, then only commits
    * from public streams will be returned.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.versions instead.
    */
   commits?: Maybe<CommitCollection>;
   company?: Maybe<Scalars['String']['output']>;

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -437,7 +437,10 @@ export type BlobMetadataCollection = {
 
 export type Branch = {
   __typename?: 'Branch';
-  /** All the recent activity on this branch in chronological order */
+  /**
+   * All the recent activity on this branch in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   author?: Maybe<User>;
   commits?: Maybe<CommitCollection>;
@@ -652,7 +655,10 @@ export type CommentThreadActivityMessage = {
 
 export type Commit = {
   __typename?: 'Commit';
-  /** All the recent activity on this commit in chronological order */
+  /**
+   * All the recent activity on this commit in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   authorAvatar?: Maybe<Scalars['String']['output']>;
   authorId?: Maybe<Scalars['String']['output']>;
@@ -905,7 +911,10 @@ export type LegacyCommentViewerData = {
  */
 export type LimitedUser = {
   __typename?: 'LimitedUser';
-  /** All the recent activity from this user in chronological order */
+  /**
+   * All the recent activity from this user in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']['output']>;
   bio?: Maybe<Scalars['String']['output']>;
@@ -917,7 +926,10 @@ export type LimitedUser = {
   role?: Maybe<Scalars['String']['output']>;
   /** Returns all discoverable streams that the user is a collaborator on */
   streams: StreamCollection;
-  /** The user's timeline in chronological order */
+  /**
+   * The user's timeline in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   timeline?: Maybe<ActivityCollection>;
   /** Total amount of favorites attached to streams owned by the user */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
@@ -1164,9 +1176,15 @@ export type Mutation = {
   serverInviteBatchCreate: Scalars['Boolean']['output'];
   /** Invite a new user to the speckle server and return the invite ID */
   serverInviteCreate: Scalars['Boolean']['output'];
-  /** Request access to a specific stream */
+  /**
+   * Request access to a specific stream
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   streamAccessRequestCreate: StreamAccessRequest;
-  /** Accept or decline a stream access request. Must be a stream owner to invoke this. */
+  /**
+   * Accept or decline a stream access request. Must be a stream owner to invoke this.
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   streamAccessRequestUse: Scalars['Boolean']['output'];
   /** Creates a new stream. */
   streamCreate?: Maybe<Scalars['String']['output']>;
@@ -2146,7 +2164,10 @@ export type Query = {
   adminUsers?: Maybe<AdminUsersListCollection>;
   /** Gets a specific app from the server. */
   app?: Maybe<ServerApp>;
-  /** Returns all the publicly available apps on this server. */
+  /**
+   * Returns all the publicly available apps on this server.
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   apps?: Maybe<Array<Maybe<ServerAppListItem>>>;
   /** If user is authenticated using an app token, this will describe the app */
   authenticatedAsApp?: Maybe<ServerAppListItem>;
@@ -2187,7 +2208,10 @@ export type Query = {
    * to see it, for example, if a stream isn't public and the user doesn't have the appropriate rights.
    */
   stream?: Maybe<Stream>;
-  /** Get authed user's stream access request */
+  /**
+   * Get authed user's stream access request
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   streamAccessRequest?: Maybe<StreamAccessRequest>;
   /**
    * Look for an invitation to a stream, for the current user (authed or not). If token
@@ -2530,7 +2554,10 @@ export enum SortDirection {
 
 export type Stream = {
   __typename?: 'Stream';
-  /** All the recent activity on this stream in chronological order */
+  /**
+   * All the recent activity on this stream in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   allowPublicComments: Scalars['Boolean']['output'];
   blob?: Maybe<BlobMetadata>;
@@ -2571,7 +2598,10 @@ export type Stream = {
   isPublic: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
   object?: Maybe<Object>;
-  /** Pending stream access requests */
+  /**
+   * Pending stream access requests
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   pendingAccessRequests?: Maybe<Array<StreamAccessRequest>>;
   /** Collaborators who have been invited, but not yet accepted. */
   pendingCollaborators?: Maybe<Array<PendingStreamCollaborator>>;
@@ -3006,7 +3036,10 @@ export type UpdateVersionInput = {
  */
 export type User = {
   __typename?: 'User';
-  /** All the recent activity from this user in chronological order */
+  /**
+   * All the recent activity from this user in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   /** Returns a list of your personal api tokens. */
   apiTokens: Array<ApiToken>;
@@ -3048,7 +3081,10 @@ export type User = {
    * authenticated user, then this will only return discoverable streams.
    */
   streams: StreamCollection;
-  /** The user's timeline in chronological order */
+  /**
+   * The user's timeline in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   timeline?: Maybe<ActivityCollection>;
   /** Total amount of favorites attached to streams owned by the user */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -2691,6 +2691,7 @@ export type Stream = {
   role?: Maybe<Scalars['String']['output']>;
   size?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.webhooks instead. */
   webhooks: WebhookCollection;
 };
 

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -1222,19 +1222,27 @@ export type Mutation = {
   streamDelete: Scalars['Boolean']['output'];
   /** @deprecated Part of the old API surface and will be removed in the future. */
   streamFavorite?: Maybe<Stream>;
-  /** Note: The required scope to invoke this is not given out to app or personal access tokens */
+  /**
+   * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.batchCreate instead.
+   */
   streamInviteBatchCreate: Scalars['Boolean']['output'];
   /**
    * Cancel a pending stream invite. Can only be invoked by a stream owner.
    * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.cancel instead.
    */
   streamInviteCancel: Scalars['Boolean']['output'];
   /**
    * Invite a new or registered user to the specified stream
    * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.create instead.
    */
   streamInviteCreate: Scalars['Boolean']['output'];
-  /** Accept or decline a stream invite */
+  /**
+   * Accept or decline a stream invite
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.use instead.
+   */
   streamInviteUse: Scalars['Boolean']['output'];
   /**
    * Remove yourself from stream collaborators (not possible for the owner)
@@ -2266,9 +2274,13 @@ export type Query = {
   /**
    * Look for an invitation to a stream, for the current user (authed or not). If token
    * isn't specified, the server will look for any valid invite.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Query.projectInvite instead.
    */
   streamInvite?: Maybe<PendingStreamCollaborator>;
-  /** Get all invitations to streams that the active user has */
+  /**
+   * Get all invitations to streams that the active user has
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projectInvites instead.
+   */
   streamInvites: Array<PendingStreamCollaborator>;
   /**
    * Returns all streams that the active user is a collaborator on.
@@ -2647,9 +2659,15 @@ export type Stream = {
   /** Date when you favorited this stream. `null` if stream isn't viewed from a specific user's perspective or if it isn't favorited. */
   favoritedDate?: Maybe<Scalars['DateTime']['output']>;
   favoritesCount: Scalars['Int']['output'];
-  /** Returns a specific file upload that belongs to this stream. */
+  /**
+   * Returns a specific file upload that belongs to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.pendingImportedModels or Model.pendingImportedVersions instead.
+   */
   fileUpload?: Maybe<FileUpload>;
-  /** Returns a list of all the file uploads for this stream. */
+  /**
+   * Returns a list of all the file uploads for this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.pendingImportedModels or Model.pendingImportedVersions instead.
+   */
   fileUploads: Array<FileUpload>;
   id: Scalars['String']['output'];
   /**
@@ -2874,7 +2892,10 @@ export type Subscription = {
    * updates regarding comments for those resources.
    */
   projectCommentsUpdated: ProjectCommentsUpdatedMessage;
-  /** Subscribe to changes to any of a project's file imports */
+  /**
+   * Subscribe to changes to any of a project's file imports
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectPendingModelsUpdated or projectPendingVersionsUpdated instead.
+   */
   projectFileImportUpdated: ProjectFileImportUpdatedMessage;
   /** Subscribe to changes to a project's models. Optionally specify modelIds to track. */
   projectModelsUpdated: ProjectModelsUpdatedMessage;

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -439,7 +439,7 @@ export type Branch = {
   __typename?: 'Branch';
   /**
    * All the recent activity on this branch in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   author?: Maybe<User>;
@@ -657,7 +657,7 @@ export type Commit = {
   __typename?: 'Commit';
   /**
    * All the recent activity on this commit in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   authorAvatar?: Maybe<Scalars['String']['output']>;
@@ -674,7 +674,7 @@ export type Commit = {
    *     ...
    *   }
    * ```
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -914,7 +914,7 @@ export type LimitedUser = {
   __typename?: 'LimitedUser';
   /**
    * All the recent activity from this user in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']['output']>;
@@ -935,7 +935,7 @@ export type LimitedUser = {
   streams: StreamCollection;
   /**
    * The user's timeline in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   timeline?: Maybe<ActivityCollection>;
   /**
@@ -1189,7 +1189,7 @@ export type Mutation = {
    */
   inviteResend: Scalars['Boolean']['output'];
   modelMutations: ModelMutations;
-  /** @deprecated Part of the old API surface and will be removed in the future */
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   objectCreate: Array<Maybe<Scalars['String']['output']>>;
   projectMutations: ProjectMutations;
   /** (Re-)send the account verification e-mail */
@@ -1202,12 +1202,12 @@ export type Mutation = {
   serverInviteCreate: Scalars['Boolean']['output'];
   /**
    * Request access to a specific stream
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   streamAccessRequestCreate: StreamAccessRequest;
   /**
    * Accept or decline a stream access request. Must be a stream owner to invoke this.
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   streamAccessRequestUse: Scalars['Boolean']['output'];
   /**
@@ -1596,7 +1596,7 @@ export type Object = {
    *     ...
    *   }
    * ```
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -1660,7 +1660,9 @@ export type PendingStreamCollaborator = {
   projectId: Scalars['String']['output'];
   projectName: Scalars['String']['output'];
   role: Scalars['String']['output'];
+  /** @deprecated Use projectId instead */
   streamId: Scalars['String']['output'];
+  /** @deprecated Use projectName instead */
   streamName: Scalars['String']['output'];
   /** E-mail address or name of the invited user */
   title: Scalars['String']['output'];
@@ -2219,7 +2221,7 @@ export type Query = {
   app?: Maybe<ServerApp>;
   /**
    * Returns all the publicly available apps on this server.
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   apps?: Maybe<Array<Maybe<ServerAppListItem>>>;
   /** If user is authenticated using an app token, this will describe the app */
@@ -2229,7 +2231,7 @@ export type Query = {
   automateFunctions: AutomateFunctionCollection;
   /** Part of the automation/function creation handshake mechanism */
   automateValidateAuthCode: Scalars['Boolean']['output'];
-  /** @deprecated Part of the old API surface and will be removed in the future */
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   comment?: Maybe<Comment>;
   /**
    * This query can be used in the following ways:
@@ -2268,7 +2270,7 @@ export type Query = {
   stream?: Maybe<Stream>;
   /**
    * Get authed user's stream access request
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   streamAccessRequest?: Maybe<StreamAccessRequest>;
   /**
@@ -2622,15 +2624,15 @@ export type Stream = {
   __typename?: 'Stream';
   /**
    * All the recent activity on this stream in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   allowPublicComments: Scalars['Boolean']['output'];
-  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.blob */
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.blob instead. */
   blob?: Maybe<BlobMetadata>;
   /**
    * Get the metadata collection of blobs stored for this stream.
-   * @deprecated Part of the old API surface and will be removed in the future. Use Project.blobs
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.blobs instead.
    */
   blobs?: Maybe<BlobMetadataCollection>;
   /** @deprecated Part of the old API surface and will be removed in the future. Use Project.model instead. */
@@ -2647,7 +2649,7 @@ export type Stream = {
    *     ...
    *   }
    * ```
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   /** @deprecated Part of the old API surface and will be removed in the future. Use Project.version instead. */
@@ -2678,11 +2680,11 @@ export type Stream = {
   /** Whether the stream can be viewed by non-contributors */
   isPublic: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
-  /** @deprecated Part of the old API surface and will be removed in the future */
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   object?: Maybe<Object>;
   /**
    * Pending stream access requests
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   pendingAccessRequests?: Maybe<Array<StreamAccessRequest>>;
   /** Collaborators who have been invited, but not yet accepted. */
@@ -3150,7 +3152,7 @@ export type User = {
   __typename?: 'User';
   /**
    * All the recent activity from this user in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   /** Returns a list of your personal api tokens. */
@@ -3199,7 +3201,7 @@ export type User = {
   streams: StreamCollection;
   /**
    * The user's timeline in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   timeline?: Maybe<ActivityCollection>;
   /**

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -675,6 +675,7 @@ export type Commit = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -919,7 +920,10 @@ export type LimitedUser = {
   activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']['output']>;
   bio?: Maybe<Scalars['String']['output']>;
-  /** Get public stream commits authored by the user */
+  /**
+   * Get public stream commits authored by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   commits?: Maybe<CommitCollection>;
   company?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
@@ -1117,8 +1121,11 @@ export type Mutation = {
   appUpdate: Scalars['Boolean']['output'];
   automateFunctionRunStatusReport: Scalars['Boolean']['output'];
   automateMutations: AutomateMutations;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.create instead. */
   branchCreate: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.delete instead. */
   branchDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use ModelMutations.update instead. */
   branchUpdate: Scalars['Boolean']['output'];
   /** Broadcast user activity in the viewer */
   broadcastViewerUserActivity: Scalars['Boolean']['output'];
@@ -1148,13 +1155,23 @@ export type Mutation = {
    * @deprecated Use commentMutations version
    */
   commentView: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   commitCreate: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.delete instead. */
   commitDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   commitReceive: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.update/moveToModel instead. */
   commitUpdate: Scalars['Boolean']['output'];
-  /** Delete a batch of commits */
+  /**
+   * Delete a batch of commits
+   * @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.delete instead.
+   */
   commitsDelete: Scalars['Boolean']['output'];
-  /** Move a batch of commits to a new branch */
+  /**
+   * Move a batch of commits to a new branch
+   * @deprecated Part of the old API surface and will be removed in the future. Use VersionMutations.moveToModel instead.
+   */
   commitsMove: Scalars['Boolean']['output'];
   /**
    * Delete a pending invite
@@ -1545,6 +1562,7 @@ export type Object = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -2177,12 +2195,13 @@ export type Query = {
   automateFunctions: AutomateFunctionCollection;
   /** Part of the automation/function creation handshake mechanism */
   automateValidateAuthCode: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future */
   comment?: Maybe<Comment>;
   /**
    * This query can be used in the following ways:
    * - get all the comments for a stream: **do not pass in any resource identifiers**.
    * - get the comments targeting any of a set of provided resources (comments/objects): **pass in an array of resources.**
-   * @deprecated Use 'commentThreads' fields instead
+   * @deprecated Use Project/Version/Model 'commentThreads' fields instead
    */
   comments?: Maybe<CommentCollection>;
   /** All of the discoverable streams of the server */
@@ -2561,10 +2580,16 @@ export type Stream = {
    */
   activity?: Maybe<ActivityCollection>;
   allowPublicComments: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.blob */
   blob?: Maybe<BlobMetadata>;
-  /** Get the metadata collection of blobs stored for this stream. */
+  /**
+   * Get the metadata collection of blobs stored for this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.blobs
+   */
   blobs?: Maybe<BlobMetadataCollection>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.model instead. */
   branch?: Maybe<Branch>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.models or Project.modelsTree instead. */
   branches?: Maybe<BranchCollection>;
   collaborators: Array<StreamCollaborator>;
   /**
@@ -2576,9 +2601,12 @@ export type Stream = {
    *     ...
    *   }
    * ```
+   * @deprecated Part of the old API surface and will be removed in the future
    */
   commentCount: Scalars['Int']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.version instead. */
   commit?: Maybe<Commit>;
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.versions instead. */
   commits?: Maybe<CommitCollection>;
   createdAt: Scalars['DateTime']['output'];
   description?: Maybe<Scalars['String']['output']>;
@@ -2760,11 +2788,20 @@ export type Subscription = {
   __typename?: 'Subscription';
   /** It's lonely in the void. */
   _?: Maybe<Scalars['String']['output']>;
-  /** Subscribe to branch created event */
+  /**
+   * Subscribe to branch created event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchCreated?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to branch deleted event */
+  /**
+   * Subscribe to branch deleted event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to branch updated event. */
+  /**
+   * Subscribe to branch updated event.
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectModelsUpdated' instead.
+   */
   branchUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /**
    * Subscribe to new comment events. There's two ways to use this subscription:
@@ -2780,11 +2817,20 @@ export type Subscription = {
    * @deprecated Use projectCommentsUpdated or viewerUserActivityBroadcasted for reply status
    */
   commentThreadActivity: CommentThreadActivityMessage;
-  /** Subscribe to commit created event */
+  /**
+   * Subscribe to commit created event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitCreated?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to commit deleted event */
+  /**
+   * Subscribe to commit deleted event
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribe to commit updated event. */
+  /**
+   * Subscribe to commit updated event.
+   * @deprecated Part of the old API surface and will be removed in the future. Use 'projectVersionsUpdated' instead.
+   */
   commitUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /** Subscribe to updates to automations in the project */
   projectAutomationsUpdated: ProjectAutomationsUpdatedMessage;
@@ -3052,6 +3098,7 @@ export type User = {
   /**
    * Get commits authored by the user. If requested for another user, then only commits
    * from public streams will be returned.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.versions instead.
    */
   commits?: Maybe<CommitCollection>;
   company?: Maybe<Scalars['String']['output']>;

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -440,7 +440,7 @@ export type Branch = {
   __typename?: 'Branch';
   /**
    * All the recent activity on this branch in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   author?: Maybe<User>;
@@ -658,7 +658,7 @@ export type Commit = {
   __typename?: 'Commit';
   /**
    * All the recent activity on this commit in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   authorAvatar?: Maybe<Scalars['String']['output']>;
@@ -675,7 +675,7 @@ export type Commit = {
    *     ...
    *   }
    * ```
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -915,7 +915,7 @@ export type LimitedUser = {
   __typename?: 'LimitedUser';
   /**
    * All the recent activity from this user in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']['output']>;
@@ -936,7 +936,7 @@ export type LimitedUser = {
   streams: StreamCollection;
   /**
    * The user's timeline in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   timeline?: Maybe<ActivityCollection>;
   /**
@@ -1190,7 +1190,7 @@ export type Mutation = {
    */
   inviteResend: Scalars['Boolean']['output'];
   modelMutations: ModelMutations;
-  /** @deprecated Part of the old API surface and will be removed in the future */
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   objectCreate: Array<Maybe<Scalars['String']['output']>>;
   projectMutations: ProjectMutations;
   /** (Re-)send the account verification e-mail */
@@ -1203,12 +1203,12 @@ export type Mutation = {
   serverInviteCreate: Scalars['Boolean']['output'];
   /**
    * Request access to a specific stream
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   streamAccessRequestCreate: StreamAccessRequest;
   /**
    * Accept or decline a stream access request. Must be a stream owner to invoke this.
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   streamAccessRequestUse: Scalars['Boolean']['output'];
   /**
@@ -1597,7 +1597,7 @@ export type Object = {
    *     ...
    *   }
    * ```
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
@@ -1661,7 +1661,9 @@ export type PendingStreamCollaborator = {
   projectId: Scalars['String']['output'];
   projectName: Scalars['String']['output'];
   role: Scalars['String']['output'];
+  /** @deprecated Use projectId instead */
   streamId: Scalars['String']['output'];
+  /** @deprecated Use projectName instead */
   streamName: Scalars['String']['output'];
   /** E-mail address or name of the invited user */
   title: Scalars['String']['output'];
@@ -2220,7 +2222,7 @@ export type Query = {
   app?: Maybe<ServerApp>;
   /**
    * Returns all the publicly available apps on this server.
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   apps?: Maybe<Array<Maybe<ServerAppListItem>>>;
   /** If user is authenticated using an app token, this will describe the app */
@@ -2230,7 +2232,7 @@ export type Query = {
   automateFunctions: AutomateFunctionCollection;
   /** Part of the automation/function creation handshake mechanism */
   automateValidateAuthCode: Scalars['Boolean']['output'];
-  /** @deprecated Part of the old API surface and will be removed in the future */
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   comment?: Maybe<Comment>;
   /**
    * This query can be used in the following ways:
@@ -2269,7 +2271,7 @@ export type Query = {
   stream?: Maybe<Stream>;
   /**
    * Get authed user's stream access request
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   streamAccessRequest?: Maybe<StreamAccessRequest>;
   /**
@@ -2623,15 +2625,15 @@ export type Stream = {
   __typename?: 'Stream';
   /**
    * All the recent activity on this stream in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   allowPublicComments: Scalars['Boolean']['output'];
-  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.blob */
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.blob instead. */
   blob?: Maybe<BlobMetadata>;
   /**
    * Get the metadata collection of blobs stored for this stream.
-   * @deprecated Part of the old API surface and will be removed in the future. Use Project.blobs
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.blobs instead.
    */
   blobs?: Maybe<BlobMetadataCollection>;
   /** @deprecated Part of the old API surface and will be removed in the future. Use Project.model instead. */
@@ -2648,7 +2650,7 @@ export type Stream = {
    *     ...
    *   }
    * ```
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   commentCount: Scalars['Int']['output'];
   /** @deprecated Part of the old API surface and will be removed in the future. Use Project.version instead. */
@@ -2679,11 +2681,11 @@ export type Stream = {
   /** Whether the stream can be viewed by non-contributors */
   isPublic: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
-  /** @deprecated Part of the old API surface and will be removed in the future */
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   object?: Maybe<Object>;
   /**
    * Pending stream access requests
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   pendingAccessRequests?: Maybe<Array<StreamAccessRequest>>;
   /** Collaborators who have been invited, but not yet accepted. */
@@ -3151,7 +3153,7 @@ export type User = {
   __typename?: 'User';
   /**
    * All the recent activity from this user in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   activity?: Maybe<ActivityCollection>;
   /** Returns a list of your personal api tokens. */
@@ -3200,7 +3202,7 @@ export type User = {
   streams: StreamCollection;
   /**
    * The user's timeline in chronological order
-   * @deprecated Part of the old API surface and will be removed in the future
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   timeline?: Maybe<ActivityCollection>;
   /**

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -438,7 +438,10 @@ export type BlobMetadataCollection = {
 
 export type Branch = {
   __typename?: 'Branch';
-  /** All the recent activity on this branch in chronological order */
+  /**
+   * All the recent activity on this branch in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   author?: Maybe<User>;
   commits?: Maybe<CommitCollection>;
@@ -653,7 +656,10 @@ export type CommentThreadActivityMessage = {
 
 export type Commit = {
   __typename?: 'Commit';
-  /** All the recent activity on this commit in chronological order */
+  /**
+   * All the recent activity on this commit in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   authorAvatar?: Maybe<Scalars['String']['output']>;
   authorId?: Maybe<Scalars['String']['output']>;
@@ -906,7 +912,10 @@ export type LegacyCommentViewerData = {
  */
 export type LimitedUser = {
   __typename?: 'LimitedUser';
-  /** All the recent activity from this user in chronological order */
+  /**
+   * All the recent activity from this user in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   avatar?: Maybe<Scalars['String']['output']>;
   bio?: Maybe<Scalars['String']['output']>;
@@ -918,7 +927,10 @@ export type LimitedUser = {
   role?: Maybe<Scalars['String']['output']>;
   /** Returns all discoverable streams that the user is a collaborator on */
   streams: StreamCollection;
-  /** The user's timeline in chronological order */
+  /**
+   * The user's timeline in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   timeline?: Maybe<ActivityCollection>;
   /** Total amount of favorites attached to streams owned by the user */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
@@ -1165,9 +1177,15 @@ export type Mutation = {
   serverInviteBatchCreate: Scalars['Boolean']['output'];
   /** Invite a new user to the speckle server and return the invite ID */
   serverInviteCreate: Scalars['Boolean']['output'];
-  /** Request access to a specific stream */
+  /**
+   * Request access to a specific stream
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   streamAccessRequestCreate: StreamAccessRequest;
-  /** Accept or decline a stream access request. Must be a stream owner to invoke this. */
+  /**
+   * Accept or decline a stream access request. Must be a stream owner to invoke this.
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   streamAccessRequestUse: Scalars['Boolean']['output'];
   /** Creates a new stream. */
   streamCreate?: Maybe<Scalars['String']['output']>;
@@ -2147,7 +2165,10 @@ export type Query = {
   adminUsers?: Maybe<AdminUsersListCollection>;
   /** Gets a specific app from the server. */
   app?: Maybe<ServerApp>;
-  /** Returns all the publicly available apps on this server. */
+  /**
+   * Returns all the publicly available apps on this server.
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   apps?: Maybe<Array<Maybe<ServerAppListItem>>>;
   /** If user is authenticated using an app token, this will describe the app */
   authenticatedAsApp?: Maybe<ServerAppListItem>;
@@ -2188,7 +2209,10 @@ export type Query = {
    * to see it, for example, if a stream isn't public and the user doesn't have the appropriate rights.
    */
   stream?: Maybe<Stream>;
-  /** Get authed user's stream access request */
+  /**
+   * Get authed user's stream access request
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   streamAccessRequest?: Maybe<StreamAccessRequest>;
   /**
    * Look for an invitation to a stream, for the current user (authed or not). If token
@@ -2531,7 +2555,10 @@ export enum SortDirection {
 
 export type Stream = {
   __typename?: 'Stream';
-  /** All the recent activity on this stream in chronological order */
+  /**
+   * All the recent activity on this stream in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   allowPublicComments: Scalars['Boolean']['output'];
   blob?: Maybe<BlobMetadata>;
@@ -2572,7 +2599,10 @@ export type Stream = {
   isPublic: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
   object?: Maybe<Object>;
-  /** Pending stream access requests */
+  /**
+   * Pending stream access requests
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   pendingAccessRequests?: Maybe<Array<StreamAccessRequest>>;
   /** Collaborators who have been invited, but not yet accepted. */
   pendingCollaborators?: Maybe<Array<PendingStreamCollaborator>>;
@@ -3007,7 +3037,10 @@ export type UpdateVersionInput = {
  */
 export type User = {
   __typename?: 'User';
-  /** All the recent activity from this user in chronological order */
+  /**
+   * All the recent activity from this user in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   activity?: Maybe<ActivityCollection>;
   /** Returns a list of your personal api tokens. */
   apiTokens: Array<ApiToken>;
@@ -3049,7 +3082,10 @@ export type User = {
    * authenticated user, then this will only return discoverable streams.
    */
   streams: StreamCollection;
-  /** The user's timeline in chronological order */
+  /**
+   * The user's timeline in chronological order
+   * @deprecated Part of the old API surface and will be removed in the future
+   */
   timeline?: Maybe<ActivityCollection>;
   /** Total amount of favorites attached to streams owned by the user */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -2692,6 +2692,7 @@ export type Stream = {
   role?: Maybe<Scalars['String']['output']>;
   size?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. Use Project.webhooks instead. */
   webhooks: WebhookCollection;
 };
 

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -1223,19 +1223,27 @@ export type Mutation = {
   streamDelete: Scalars['Boolean']['output'];
   /** @deprecated Part of the old API surface and will be removed in the future. */
   streamFavorite?: Maybe<Stream>;
-  /** Note: The required scope to invoke this is not given out to app or personal access tokens */
+  /**
+   * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.batchCreate instead.
+   */
   streamInviteBatchCreate: Scalars['Boolean']['output'];
   /**
    * Cancel a pending stream invite. Can only be invoked by a stream owner.
    * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.cancel instead.
    */
   streamInviteCancel: Scalars['Boolean']['output'];
   /**
    * Invite a new or registered user to the specified stream
    * Note: The required scope to invoke this is not given out to app or personal access tokens
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.create instead.
    */
   streamInviteCreate: Scalars['Boolean']['output'];
-  /** Accept or decline a stream invite */
+  /**
+   * Accept or decline a stream invite
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectInviteMutations.use instead.
+   */
   streamInviteUse: Scalars['Boolean']['output'];
   /**
    * Remove yourself from stream collaborators (not possible for the owner)
@@ -2267,9 +2275,13 @@ export type Query = {
   /**
    * Look for an invitation to a stream, for the current user (authed or not). If token
    * isn't specified, the server will look for any valid invite.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Query.projectInvite instead.
    */
   streamInvite?: Maybe<PendingStreamCollaborator>;
-  /** Get all invitations to streams that the active user has */
+  /**
+   * Get all invitations to streams that the active user has
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projectInvites instead.
+   */
   streamInvites: Array<PendingStreamCollaborator>;
   /**
    * Returns all streams that the active user is a collaborator on.
@@ -2648,9 +2660,15 @@ export type Stream = {
   /** Date when you favorited this stream. `null` if stream isn't viewed from a specific user's perspective or if it isn't favorited. */
   favoritedDate?: Maybe<Scalars['DateTime']['output']>;
   favoritesCount: Scalars['Int']['output'];
-  /** Returns a specific file upload that belongs to this stream. */
+  /**
+   * Returns a specific file upload that belongs to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.pendingImportedModels or Model.pendingImportedVersions instead.
+   */
   fileUpload?: Maybe<FileUpload>;
-  /** Returns a list of all the file uploads for this stream. */
+  /**
+   * Returns a list of all the file uploads for this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Project.pendingImportedModels or Model.pendingImportedVersions instead.
+   */
   fileUploads: Array<FileUpload>;
   id: Scalars['String']['output'];
   /**
@@ -2875,7 +2893,10 @@ export type Subscription = {
    * updates regarding comments for those resources.
    */
   projectCommentsUpdated: ProjectCommentsUpdatedMessage;
-  /** Subscribe to changes to any of a project's file imports */
+  /**
+   * Subscribe to changes to any of a project's file imports
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectPendingModelsUpdated or projectPendingVersionsUpdated instead.
+   */
   projectFileImportUpdated: ProjectFileImportUpdatedMessage;
   /** Subscribe to changes to a project's models. Optionally specify modelIds to track. */
   projectModelsUpdated: ProjectModelsUpdatedMessage;

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -929,14 +929,20 @@ export type LimitedUser = {
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
   role?: Maybe<Scalars['String']['output']>;
-  /** Returns all discoverable streams that the user is a collaborator on */
+  /**
+   * Returns all discoverable streams that the user is a collaborator on
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   streams: StreamCollection;
   /**
    * The user's timeline in chronological order
    * @deprecated Part of the old API surface and will be removed in the future
    */
   timeline?: Maybe<ActivityCollection>;
-  /** Total amount of favorites attached to streams owned by the user */
+  /**
+   * Total amount of favorites attached to streams owned by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
   verified?: Maybe<Scalars['Boolean']['output']>;
 };
@@ -1184,6 +1190,7 @@ export type Mutation = {
    */
   inviteResend: Scalars['Boolean']['output'];
   modelMutations: ModelMutations;
+  /** @deprecated Part of the old API surface and will be removed in the future */
   objectCreate: Array<Maybe<Scalars['String']['output']>>;
   projectMutations: ProjectMutations;
   /** (Re-)send the account verification e-mail */
@@ -1204,10 +1211,17 @@ export type Mutation = {
    * @deprecated Part of the old API surface and will be removed in the future
    */
   streamAccessRequestUse: Scalars['Boolean']['output'];
-  /** Creates a new stream. */
+  /**
+   * Creates a new stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.create instead.
+   */
   streamCreate?: Maybe<Scalars['String']['output']>;
-  /** Deletes an existing stream. */
+  /**
+   * Deletes an existing stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.delete instead.
+   */
   streamDelete: Scalars['Boolean']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   streamFavorite?: Maybe<Stream>;
   /** Note: The required scope to invoke this is not given out to app or personal access tokens */
   streamInviteBatchCreate: Scalars['Boolean']['output'];
@@ -1223,14 +1237,27 @@ export type Mutation = {
   streamInviteCreate: Scalars['Boolean']['output'];
   /** Accept or decline a stream invite */
   streamInviteUse: Scalars['Boolean']['output'];
-  /** Remove yourself from stream collaborators (not possible for the owner) */
+  /**
+   * Remove yourself from stream collaborators (not possible for the owner)
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.leave instead.
+   */
   streamLeave: Scalars['Boolean']['output'];
-  /** Revokes the permissions of a user on a given stream. */
+  /**
+   * Revokes the permissions of a user on a given stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.updateRole instead.
+   */
   streamRevokePermission?: Maybe<Scalars['Boolean']['output']>;
-  /** Updates an existing stream. */
+  /**
+   * Updates an existing stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.update instead.
+   */
   streamUpdate: Scalars['Boolean']['output'];
-  /** Update permissions of a user on a given stream. */
+  /**
+   * Update permissions of a user on a given stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use ProjectMutations.updateRole instead.
+   */
   streamUpdatePermission?: Maybe<Scalars['Boolean']['output']>;
+  /** @deprecated Part of the old API surface and will be removed in the future. */
   streamsDelete: Scalars['Boolean']['output'];
   /**
    * Used for broadcasting real time typing status in comment threads. Does not persist any info.
@@ -2204,7 +2231,10 @@ export type Query = {
    * @deprecated Use Project/Version/Model 'commentThreads' fields instead
    */
   comments?: Maybe<CommentCollection>;
-  /** All of the discoverable streams of the server */
+  /**
+   * All of the discoverable streams of the server
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   discoverableStreams?: Maybe<StreamCollection>;
   /** Get the (limited) profile information of another server user */
   otherUser?: Maybe<LimitedUser>;
@@ -2226,6 +2256,7 @@ export type Query = {
   /**
    * Returns a specific stream. Will throw an authorization error if active user isn't authorized
    * to see it, for example, if a stream isn't public and the user doesn't have the appropriate rights.
+   * @deprecated Part of the old API surface and will be removed in the future. Use Query.project instead.
    */
   stream?: Maybe<Stream>;
   /**
@@ -2243,6 +2274,7 @@ export type Query = {
   /**
    * Returns all streams that the active user is a collaborator on.
    * Pass in the `query` parameter to search by name, description or ID.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projects instead.
    */
   streams?: Maybe<StreamCollection>;
   /**
@@ -2250,7 +2282,10 @@ export type Query = {
    * @deprecated To be removed in the near future! Use 'activeUser' to get info about the active user or 'otherUser' to get info about another user.
    */
   user?: Maybe<User>;
-  /** Validate password strength */
+  /**
+   * Validate password strength
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   userPwdStrength: PasswordStrengthCheckResults;
   /**
    * Search for users and return limited metadata about them, if you have the server:user role.
@@ -2626,6 +2661,7 @@ export type Stream = {
   /** Whether the stream can be viewed by non-contributors */
   isPublic: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
+  /** @deprecated Part of the old API surface and will be removed in the future */
   object?: Maybe<Object>;
   /**
    * Pending stream access requests
@@ -2857,20 +2893,28 @@ export type Subscription = {
   projectVersionsPreviewGenerated: ProjectVersionsPreviewGeneratedMessage;
   /** Subscribe to changes to a project's versions. */
   projectVersionsUpdated: ProjectVersionsUpdatedMessage;
-  /** Subscribes to stream deleted event. Use this in clients/components that pertain only to this stream. */
+  /**
+   * Subscribes to stream deleted event. Use this in clients/components that pertain only to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectUpdated instead.
+   */
   streamDeleted?: Maybe<Scalars['JSONObject']['output']>;
-  /** Subscribes to stream updated event. Use this in clients/components that pertain only to this stream. */
+  /**
+   * Subscribes to stream updated event. Use this in clients/components that pertain only to this stream.
+   * @deprecated Part of the old API surface and will be removed in the future. Use projectUpdated instead.
+   */
   streamUpdated?: Maybe<Scalars['JSONObject']['output']>;
   /** Track newly added or deleted projects owned by the active user */
   userProjectsUpdated: UserProjectsUpdatedMessage;
   /**
    * Subscribes to new stream added event for your profile. Use this to display an up-to-date list of streams.
    * **NOTE**: If someone shares a stream with you, this subscription will be triggered with an extra value of `sharedBy` in the payload.
+   * @deprecated Part of the old API surface and will be removed in the future. Use userProjectsUpdated instead.
    */
   userStreamAdded?: Maybe<Scalars['JSONObject']['output']>;
   /**
    * Subscribes to stream removed event for your profile. Use this to display an up-to-date list of streams for your profile.
    * **NOTE**: If someone revokes your permissions on a stream, this subscription will be triggered with an extra value of `revokedBy` in the payload.
+   * @deprecated Part of the old API surface and will be removed in the future. Use userProjectsUpdated instead.
    */
   userStreamRemoved?: Maybe<Scalars['JSONObject']['output']>;
   /**
@@ -3105,10 +3149,12 @@ export type User = {
   /** Returns the apps you have created. */
   createdApps?: Maybe<Array<ServerApp>>;
   createdAt?: Maybe<Scalars['DateTime']['output']>;
+  /** Only returned if API user is the user being requested or an admin */
   email?: Maybe<Scalars['String']['output']>;
   /**
    * All the streams that a active user has favorited.
    * Note: You can't use this to retrieve another user's favorite streams.
+   * @deprecated Part of the old API surface and will be removed in the future.
    */
   favoriteStreams: StreamCollection;
   /** Whether the user has a pending/active email verification token */
@@ -3127,6 +3173,7 @@ export type User = {
   /**
    * Returns all streams that the user is a collaborator on. If requested for a user, who isn't the
    * authenticated user, then this will only return discoverable streams.
+   * @deprecated Part of the old API surface and will be removed in the future. Use User.projects instead.
    */
   streams: StreamCollection;
   /**
@@ -3134,7 +3181,10 @@ export type User = {
    * @deprecated Part of the old API surface and will be removed in the future
    */
   timeline?: Maybe<ActivityCollection>;
-  /** Total amount of favorites attached to streams owned by the user */
+  /**
+   * Total amount of favorites attached to streams owned by the user
+   * @deprecated Part of the old API surface and will be removed in the future.
+   */
   totalOwnedStreamsFavorites: Scalars['Int']['output'];
   verified?: Maybe<Scalars['Boolean']['output']>;
   /**


### PR DESCRIPTION
Note that this includes fields still in use by DUI3 and Connectors/Manager