### PR TITLE
feat(metrics): add num pending validations to knex metrics

### DIFF
--- a/packages/fileimport-service/src/prometheusMetrics.js
+++ b/packages/fileimport-service/src/prometheusMetrics.js
@@ -9,6 +9,7 @@ let metricFree = null
 let metricUsed = null
 let metricPendingAquires = null
 let metricPendingCreates = null
+let metricPendingValidations = null
 let metricRemainingCapacity = null
 let metricQueryDuration = null
 let metricQueryErrors = null
@@ -56,6 +57,14 @@ function initKnexPrometheusMetrics() {
     }
   })
 
+  metricPendingValidations = new prometheusClient.Gauge({
+    name: 'speckle_server_knex_pending_validations',
+    help: 'Number of pending DB connection validations. This is a state between pending acquisition and acquiring a connection.',
+    collect() {
+      this.set(knex.client.pool.numPendingValidations())
+    }
+  })
+
   metricRemainingCapacity = new prometheusClient.Gauge({
     name: 'speckle_server_knex_remaining_capacity',
     help: 'Remaining capacity of the DB connection pool',
@@ -65,12 +74,10 @@ function initKnexPrometheusMetrics() {
       const demand =
         knex.client.pool.numUsed() +
         knex.client.pool.numPendingCreates() +
+        knex.client.pool.numPendingValidations() +
         knex.client.pool.numPendingAcquires()
 
-      //the higher value of zero or the difference between the postgresMaxConnections and the demand
-      const remainingCapacity =
-        postgresMaxConnections <= demand ? 0 : postgresMaxConnections - demand
-      this.set(remainingCapacity)
+      this.set(Math.max(postgresMaxConnections - demand, 0))
     }
   })
 

--- a/packages/preview-service/bg_service/prometheusMetrics.js
+++ b/packages/preview-service/bg_service/prometheusMetrics.js
@@ -9,6 +9,7 @@ let metricFree = null
 let metricUsed = null
 let metricPendingAquires = null
 let metricPendingCreates = null
+let metricPendingValidations = null
 let metricRemainingCapacity = null
 let metricQueryDuration = null
 let metricQueryErrors = null
@@ -56,6 +57,14 @@ function initKnexPrometheusMetrics() {
     }
   })
 
+  metricPendingValidations = new prometheusClient.Gauge({
+    name: 'speckle_server_knex_pending_validations',
+    help: 'Number of pending DB connection validations. This is a state between pending acquisition and acquiring a connection.',
+    collect() {
+      this.set(knex.client.pool.numPendingValidations())
+    }
+  })
+
   metricRemainingCapacity = new prometheusClient.Gauge({
     name: 'speckle_server_knex_remaining_capacity',
     help: 'Remaining capacity of the DB connection pool',
@@ -65,12 +74,10 @@ function initKnexPrometheusMetrics() {
       const demand =
         knex.client.pool.numUsed() +
         knex.client.pool.numPendingCreates() +
+        knex.client.pool.numPendingValidations() +
         knex.client.pool.numPendingAcquires()
 
-      //the higher value of zero or the difference between the postgresMaxConnections and the demand
-      const remainingCapacity =
-        postgresMaxConnections <= demand ? 0 : postgresMaxConnections - demand
-      this.set(remainingCapacity)
+      this.set(Math.max(postgresMaxConnections - demand, 0))
     }
   })
 

--- a/packages/webhook-service/src/observability/prometheusMetrics.js
+++ b/packages/webhook-service/src/observability/prometheusMetrics.js
@@ -9,6 +9,7 @@ let metricFree = null
 let metricUsed = null
 let metricPendingAquires = null
 let metricPendingCreates = null
+let metricPendingValidations = null
 let metricRemainingCapacity = null
 let metricQueryDuration = null
 let metricQueryErrors = null
@@ -56,6 +57,14 @@ function initKnexPrometheusMetrics() {
     }
   })
 
+  metricPendingValidations = new prometheusClient.Gauge({
+    name: 'speckle_server_knex_pending_validations',
+    help: 'Number of pending DB connection validations. This is a state between pending acquisition and acquiring a connection.',
+    collect() {
+      this.set(knex.client.pool.numPendingValidations())
+    }
+  })
+
   metricRemainingCapacity = new prometheusClient.Gauge({
     name: 'speckle_server_knex_remaining_capacity',
     help: 'Remaining capacity of the DB connection pool',
@@ -65,12 +74,10 @@ function initKnexPrometheusMetrics() {
       const demand =
         knex.client.pool.numUsed() +
         knex.client.pool.numPendingCreates() +
+        knex.client.pool.numPendingValidations() +
         knex.client.pool.numPendingAcquires()
 
-      //the higher value of zero or the difference between the postgresMaxConnections and the demand
-      const remainingCapacity =
-        postgresMaxConnections <= demand ? 0 : postgresMaxConnections - demand
-      this.set(remainingCapacity)
+      this.set(Math.max(postgresMaxConnections - demand, 0))
     }
   })
 


### PR DESCRIPTION
## Description & motivation

numPendingValidations is a metric exposed by the connection pool. The pending validation state is after the pending acquisition state, before the connection is moved to an 'in use' state.

This state needs to be included in calculations of remaining capacity of the pg connection pool

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
