### PR TITLE
Fix (dui3): Do not trigger highlight if baked object ids undefined

### DIFF
--- a/packages/dui3/components/model/CardBase.vue
+++ b/packages/dui3/components/model/CardBase.vue
@@ -198,16 +198,4 @@ const cardBgColor = computed(() => {
     return 'bg-orange-500/10'
   return 'bg-foundation hover:bg-blue-500/10'
 })
-
-watch(
-  () => props.modelCard.progress,
-  (newVal, oldVal) => {
-    console.log('new value for props.modelCard.progress', newVal, oldVal)
-
-    if (newVal === undefined) {
-      // Perform any additional actions if needed when progress is undefined
-    }
-  },
-  { deep: true }
-)
 </script>

--- a/packages/dui3/components/model/CardBase.vue
+++ b/packages/dui3/components/model/CardBase.vue
@@ -141,11 +141,21 @@ const isSender = computed(() => {
 
 const highlightModel = () => {
   if (!modelData.value) return
-  trackEvent('DUI3 Action', { name: 'Highlight Model' }, props.modelCard.accountId)
-  if (!props.modelCard.progress) {
-    // Some host apps aren't friendly enough to handle highlighting models when some other ops are running.
-    app.$baseBinding.highlightModel(props.modelCard.modelCardId)
+
+  // Some host apps aren't friendly enough to handle highlighting models when some other ops are running.
+  if (props.modelCard.progress) return
+
+  // Do not highlight if baked object ids not set yet. Otherwise we rely on connector to handle it, don't if possible to handle here!
+  if (!isSender.value && !(props.modelCard as IReceiverModelCard).bakedObjectIds) {
+    store.setModelError({
+      modelCardId: props.modelCard.modelCardId,
+      error: 'No objects found to highlight.'
+    })
+    return
   }
+
+  app.$baseBinding.highlightModel(props.modelCard.modelCardId)
+  trackEvent('DUI3 Action', { name: 'Highlight Model' }, props.modelCard.accountId)
 }
 
 const viewModel = () => {
@@ -188,4 +198,16 @@ const cardBgColor = computed(() => {
     return 'bg-orange-500/10'
   return 'bg-foundation hover:bg-blue-500/10'
 })
+
+watch(
+  () => props.modelCard.progress,
+  (newVal, oldVal) => {
+    console.log('new value for props.modelCard.progress', newVal, oldVal)
+
+    if (newVal === undefined) {
+      // Perform any additional actions if needed when progress is undefined
+    }
+  },
+  { deep: true }
+)
 </script>

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -309,7 +309,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     model.progress = args.progress
   }
 
-  const handleModelError = (args: { modelCardId: string; error: string }) => {
+  const setModelError = (args: { modelCardId: string; error: string }) => {
     const model = documentModelStore.value.models.find(
       (m) => m.modelCardId === args.modelCardId
     ) as IModelCard
@@ -332,9 +332,9 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   app.$selectionBinding?.on('setGlobalNotification', setNotification)
   app.$testBindings?.on('setGlobalNotification', setNotification)
 
-  app.$sendBinding?.on('setModelError', handleModelError)
-  app.$receiveBinding?.on('setModelError', handleModelError)
-  app.$baseBinding.on('setModelError', handleModelError)
+  app.$sendBinding?.on('setModelError', setModelError)
+  app.$receiveBinding?.on('setModelError', setModelError)
+  app.$baseBinding.on('setModelError', setModelError)
 
   /**
    * Used internally in this store store only for initialisation.
@@ -399,6 +399,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     showErrorDialog,
     hostAppError,
     setNotification,
+    setModelError,
     dismissNotification,
     setHostAppError,
     addModel,


### PR DESCRIPTION
Otherwise we rely on connector devs to handle it for each connector. I would like to handle it UI, bc it is safest.