### PR TITLE
fix(server): 401, 403, 429 & 500 status codes for GQL error responses

### DIFF
--- a/packages/server/app.ts
+++ b/packages/server/app.ts
@@ -63,6 +63,7 @@ import { redactSensitiveVariables } from '@/logging/loggingHelper'
 import { buildMocksConfig } from '@/modules/mocks'
 import { defaultErrorHandler } from '@/modules/core/rest/defaultErrorHandler'
 import { migrateDbToLatest } from '@/db/migrations'
+import { statusCodePlugin } from '@/modules/core/graph/plugins/statusCode'
 
 let graphqlServer: ApolloServer
 
@@ -254,6 +255,7 @@ export async function buildApolloServer(
     schema,
     context: buildContext,
     plugins: [
+      statusCodePlugin,
       require('@/logging/apolloPlugin'),
       ApolloServerPluginLandingPageLocalDefault({
         embed: true,

--- a/packages/server/modules/core/errors/ratelimit.ts
+++ b/packages/server/modules/core/errors/ratelimit.ts
@@ -6,6 +6,7 @@ export class RateLimitError extends BaseError {
   static defaultMessage =
     'You have sent too many requests. You are being rate limited. Please try again later.'
   static code = 'RATE_LIMIT_ERROR'
+  static statusCode = 429
 
   rateLimitBreached: RateLimitBreached
 

--- a/packages/server/modules/core/graph/plugins/statusCode.ts
+++ b/packages/server/modules/core/graph/plugins/statusCode.ts
@@ -1,0 +1,50 @@
+import { RateLimitError } from '@/modules/core/errors/ratelimit'
+import { BaseError, ForbiddenError, UnauthorizedError } from '@/modules/shared/errors'
+import { Nullable } from '@speckle/shared'
+import type { ApolloServerPlugin } from 'apollo-server-plugin-base'
+import type { GraphQLError } from 'graphql'
+
+const getErrorCode = (e: GraphQLError): Nullable<string> => {
+  const extensionsCode = e.extensions?.code as string
+  if (extensionsCode?.length) return extensionsCode
+
+  const ogError = e.originalError
+  if (!(ogError instanceof BaseError)) return null
+
+  const infoCode = (ogError.info().code || null) as Nullable<string>
+  return infoCode
+}
+
+export const statusCodePlugin: ApolloServerPlugin = {
+  requestDidStart: async () => {
+    return {
+      willSendResponse: async (reqCtx) => {
+        const resHttp = reqCtx.response.http
+        if (!resHttp) return
+
+        const hasForbiddenError = reqCtx.errors?.some(
+          (e) => getErrorCode(e) === ForbiddenError.code
+        )
+        const hasUnauthenticatedError = reqCtx.errors?.some((e) =>
+          ['UNAUTHENTICATED', UnauthorizedError.code].includes(getErrorCode(e) || '')
+        )
+        const hasRateLimitError = reqCtx.errors?.some(
+          (e) => getErrorCode(e) === RateLimitError.code
+        )
+        const hasInternalServerError = reqCtx.errors?.some(
+          (e) => getErrorCode(e) === 'INTERNAL_SERVER_ERROR'
+        )
+
+        if (hasForbiddenError) {
+          resHttp.status = ForbiddenError.statusCode
+        } else if (hasUnauthenticatedError) {
+          resHttp.status = UnauthorizedError.statusCode
+        } else if (hasRateLimitError) {
+          resHttp.status = RateLimitError.statusCode
+        } else if (hasInternalServerError) {
+          resHttp.status = 500
+        }
+      }
+    }
+  }
+}

--- a/packages/server/modules/core/graph/resolvers/commits.js
+++ b/packages/server/modules/core/graph/resolvers/commits.js
@@ -30,10 +30,10 @@ const {
 
 const { getUser } = require('../../services/users')
 
+const { RateLimitError } = require('@/modules/core/errors/ratelimit')
 const {
   isRateLimitBreached,
-  getRateLimitResult,
-  RateLimitError
+  getRateLimitResult
 } = require('@/modules/core/services/ratelimiter')
 const {
   batchMoveCommits,

--- a/packages/server/modules/core/graph/resolvers/streams.js
+++ b/packages/server/modules/core/graph/resolvers/streams.js
@@ -20,7 +20,6 @@ const {
 
 const { authorizeResolver, validateScopes } = require(`@/modules/shared`)
 const {
-  RateLimitError,
   getRateLimitResult,
   isRateLimitBreached
 } = require('@/modules/core/services/ratelimiter')
@@ -49,6 +48,7 @@ const { adminOverrideEnabled } = require('@/modules/shared/helpers/envHelper')
 const { Roles, Scopes } = require('@speckle/shared')
 const { StreamNotFoundError } = require('@/modules/core/errors/stream')
 const { throwForNotHavingServerRole } = require('@/modules/shared/authz')
+const { RateLimitError } = require('@/modules/core/errors/ratelimit')
 
 const {
   toProjectIdWhitelist,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -151,6 +151,7 @@
     "@types/zxcvbn": "^4.4.1",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
+    "apollo-server-plugin-base": "^3.7.2",
     "axios": "^1.6.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15732,6 +15732,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^5.39.0"
     ajv: "npm:^8.12.0"
     apollo-server-express: "npm:^3.10.2"
+    apollo-server-plugin-base: "npm:^3.7.2"
     axios: "npm:^1.6.0"
     bcrypt: "npm:^5.0.0"
     bull: "npm:^4.8.5"


### PR DESCRIPTION
Currently GQL responses always return a status code of 200, even if its a rate limit or internal server error response. This new Apollo Server plugin I added responds w/ proper HTTP 401, 403, 429 & 500 status codes when those kinds of errors/issues pop up when processing a GQL request.