### PR TITLE
Object Sender: Adds @Detach and @Chunkable decorators

### DIFF
--- a/packages/objectsender/package.json
+++ b/packages/objectsender/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "@speckle/shared": "workspace:^",
     "lodash": "^4.17.21",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.17.21",
+    "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.5",

--- a/packages/objectsender/src/examples/browser/main.ts
+++ b/packages/objectsender/src/examples/browser/main.ts
@@ -1,5 +1,6 @@
 import { send, Base, type SendResult, Detach } from '../../index'
 import { times } from '#lodash'
+import { createCommit } from './utils'
 
 interface ExampleAppWindow extends Window {
   send: typeof import('../../index').send
@@ -70,6 +71,8 @@ appWindow.loadData = async () => {
       projectId,
       token: apiToken
     })
+
+    await createCommit(res, { serverUrl, projectId, token: apiToken })
   } catch (e) {
     const msg = e instanceof Error ? e.message : JSON.stringify(e)
     setInputValue('result', msg, { valueKey: 'textContent' })

--- a/packages/objectsender/src/examples/browser/main.ts
+++ b/packages/objectsender/src/examples/browser/main.ts
@@ -1,4 +1,4 @@
-import { send, Base, type SendResult } from '../../index'
+import { send, Base, type SendResult, Detach } from '../../index'
 import { times } from '#lodash'
 
 interface ExampleAppWindow extends Window {
@@ -108,6 +108,11 @@ function generateTestObject() {
         .fill(0)
         .map(() => new RandomFoo({ bar: 'baz baz baz' }))
     ],
+    detachedWithDecorator: new Collection<RandomFoo>('Collection of Foo', 'Foo', [
+      ...Array(10)
+        .fill(0)
+        .map(() => new RandomFoo())
+    ]),
     '@(10)chunkedArr': times(100, () => 42)
   })
 }
@@ -116,5 +121,24 @@ class RandomFoo extends Base {
   constructor(props?: Record<string, unknown>) {
     super(props)
     this.noise = Math.random().toString(16)
+  }
+}
+
+export class Collection<T extends Base> extends Base {
+  @Detach()
+  elements: T[]
+  // eslint-disable-next-line camelcase
+  speckle_type = 'Speckle.Core.Models.Collection'
+
+  constructor(
+    name: string,
+    collectionType: string,
+    elements: T[] = [],
+    props?: Record<string, unknown>
+  ) {
+    super(props)
+    this.name = name
+    this.collectionType = collectionType
+    this.elements = elements
   }
 }

--- a/packages/objectsender/src/examples/browser/main.ts
+++ b/packages/objectsender/src/examples/browser/main.ts
@@ -1,4 +1,4 @@
-import { send, Base, type SendResult, Detach } from '../../index'
+import { send, Base, type SendResult, Detach, Chunkable } from '../../index'
 import { times } from '#lodash'
 import { createCommit } from './utils'
 
@@ -116,7 +116,8 @@ function generateTestObject() {
         .fill(0)
         .map(() => new RandomFoo())
     ]),
-    '@(10)chunkedArr': times(100, () => 42)
+    '@(10)chunkedArr': times(100, () => 42),
+    some: new RandomJoe()
   })
 }
 
@@ -124,6 +125,17 @@ class RandomFoo extends Base {
   constructor(props?: Record<string, unknown>) {
     super(props)
     this.noise = Math.random().toString(16)
+  }
+}
+
+class RandomJoe extends Base {
+  @Detach()
+  @Chunkable(10)
+  numbers: number[]
+
+  constructor(props?: Record<string, unknown>) {
+    super(props)
+    this.numbers = times(100, () => 42)
   }
 }
 

--- a/packages/objectsender/src/examples/browser/utils.ts
+++ b/packages/objectsender/src/examples/browser/utils.ts
@@ -1,0 +1,38 @@
+import { SendResult } from '../..'
+
+interface CreateCommitParams {
+  serverUrl: string
+  projectId: string
+  token: string
+  modelName?: string
+}
+
+export async function createCommit(
+  res: SendResult,
+  { serverUrl, projectId, token, modelName }: CreateCommitParams
+) {
+  const response = await fetch(serverUrl + '/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      query: `
+        mutation CreateCommit($commit: CommitCreateInput!) {
+          commitCreate(commit: $commit)
+        }
+      `,
+      variables: {
+        commit: {
+          branchName: modelName || 'main',
+          message: 'Good morning!',
+          objectId: res.hash,
+          streamId: projectId
+        }
+      }
+    })
+  })
+
+  await response.json()
+}

--- a/packages/objectsender/src/index.ts
+++ b/packages/objectsender/src/index.ts
@@ -3,7 +3,7 @@ import { ServerTransport } from './transports/ServerTransport'
 import { Base } from './utils/Base'
 export { Base }
 
-export { Detach } from './utils/Decorators'
+export { Detach, Chunkable } from './utils/Decorators'
 
 export type SendParams = {
   serverUrl?: string

--- a/packages/objectsender/src/index.ts
+++ b/packages/objectsender/src/index.ts
@@ -3,6 +3,8 @@ import { ServerTransport } from './transports/ServerTransport'
 import { Base } from './utils/Base'
 export { Base }
 
+export { Detach } from './utils/Decorators'
+
 export type SendParams = {
   serverUrl?: string
   projectId: string

--- a/packages/objectsender/src/utils/Decorators.ts
+++ b/packages/objectsender/src/utils/Decorators.ts
@@ -1,13 +1,28 @@
 import 'reflect-metadata'
 
 const detachMetadataKey = Symbol('detach')
+const chunkableMetadataKey = Symbol('chunkable')
 
 export function Detach() {
   return Reflect.metadata(detachMetadataKey, true)
+}
+
+export function Chunkable(size: number) {
+  return Reflect.metadata(chunkableMetadataKey, size)
 }
 
 export function isDetached(target: object, propertyKey: string) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const metadata = Reflect.getMetadata(detachMetadataKey, target, propertyKey)
   return metadata ? true : false
+}
+
+export function isChunkable(target: object, propertyKey: string) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const metadata = Reflect.getMetadata(chunkableMetadataKey, target, propertyKey)
+  return metadata ? true : false
+}
+
+export function getChunkSize(target: object, propertyKey: string) {
+  return Reflect.getMetadata(chunkableMetadataKey, target, propertyKey) as number
 }

--- a/packages/objectsender/src/utils/Decorators.ts
+++ b/packages/objectsender/src/utils/Decorators.ts
@@ -1,0 +1,13 @@
+import 'reflect-metadata'
+
+const detachMetadataKey = Symbol('detach')
+
+export function Detach() {
+  return Reflect.metadata(detachMetadataKey, true)
+}
+
+export function isDetached(target: object, propertyKey: string) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const metadata = Reflect.getMetadata(detachMetadataKey, target, propertyKey)
+  return metadata ? true : false
+}

--- a/packages/objectsender/src/utils/Serializer.ts
+++ b/packages/objectsender/src/utils/Serializer.ts
@@ -4,6 +4,7 @@ import { ITransport } from '../transports/ITransport'
 import { Base } from './Base'
 import { IDisposable } from './IDisposable'
 import { isObjectLike, get } from '#lodash'
+import { isDetached } from './Decorators'
 
 type BasicSpeckleObject = Record<string, unknown> & {
   speckle_type: string
@@ -61,7 +62,7 @@ export class Serializer implements IDisposable {
         continue
       }
 
-      const isDetachedProp = propKey.startsWith('@')
+      const isDetachedProp = propKey.startsWith('@') || isDetached(obj, propKey)
 
       // 2. chunked arrays
       const isArray = Array.isArray(value)

--- a/packages/objectsender/src/utils/Serializer.ts
+++ b/packages/objectsender/src/utils/Serializer.ts
@@ -4,7 +4,7 @@ import { ITransport } from '../transports/ITransport'
 import { Base } from './Base'
 import { IDisposable } from './IDisposable'
 import { isObjectLike, get } from '#lodash'
-import { isDetached } from './Decorators'
+import { getChunkSize, isChunkable, isDetached } from './Decorators'
 
 type BasicSpeckleObject = Record<string, unknown> & {
   speckle_type: string
@@ -66,9 +66,18 @@ export class Serializer implements IDisposable {
 
       // 2. chunked arrays
       const isArray = Array.isArray(value)
-      const isChunked = isArray ? propKey.match(/^@\((\d*)\)/) : false // chunk syntax
+      const isChunked = isArray
+        ? isChunkable(obj, propKey) || propKey.match(/^@\((\d*)\)/)
+        : false // chunk syntax
+
       if (isArray && isChunked && value.length !== 0 && typeof value[0] !== 'object') {
-        const chunkSize = isChunked[1] !== '' ? parseInt(isChunked[1]) : this.chunkSize
+        let chunkSize = this.chunkSize
+        if (typeof isChunked === 'boolean') {
+          chunkSize = getChunkSize(obj, propKey)
+        } else {
+          chunkSize = isChunked[1] !== '' ? parseInt(isChunked[1]) : this.chunkSize
+        }
+
         const chunkRefs = []
 
         let chunk = new DataChunk()
@@ -84,7 +93,13 @@ export class Serializer implements IDisposable {
         }
 
         if (chunk.data.length !== 0) chunkRefs.push(await this.#handleChunk(chunk))
-        traversed[propKey.replace(isChunked[0], '')] = chunkRefs // strip chunk syntax
+
+        if (typeof isChunked === 'boolean') {
+          traversed[propKey] = chunkRefs // no need to strip chunk syntax
+        } else {
+          traversed[propKey.replace(isChunked[0], '')] = chunkRefs // strip chunk syntax
+        }
+
         continue
       }
 

--- a/packages/objectsender/tsconfig.json
+++ b/packages/objectsender/tsconfig.json
@@ -6,6 +6,10 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
 
+    /* Decorators */
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15628,6 +15628,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     lodash-es: "npm:^4.17.21"
     prettier: "npm:^3.3.2"
+    reflect-metadata: "npm:^0.2.2"
     typescript: "npm:^5.2.2"
     vite: "npm:^5.2.0"
     vite-plugin-dts: "npm:^3.9.1"
@@ -44687,6 +44688,13 @@ __metadata:
   dependencies:
     "@eslint-community/regexpp": "npm:^4.8.0"
   checksum: 10/b89411434e31637a519c065acd8fd1ec9eabc1dec38eec58dbc69a386ec21d88f97fa175e56fb3133e21c090ddb68fe7b5653ffc4bbcc9f069abc0e88c0d290c
+  languageName: node
+  linkType: hard
+
+"reflect-metadata@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "reflect-metadata@npm:0.2.2"
+  checksum: 10/1c93f9ac790fea1c852fde80c91b2760420069f4862f28e6fae0c00c6937a56508716b0ed2419ab02869dd488d123c4ab92d062ae84e8739ea7417fae10c4745
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description & motivation

Adds the ability for using decorators in class declarations to describe detached and chunkable fields.

```typescript
class RandomJoe extends Base {
  @Detach()
  @Chunkable(10)
  numbers: number[]

  constructor(props?: Record<string, unknown>) {
    super(props)
    this.numbers = times(100, () => 42)
  }
}
```

The main reason why I am proposing is that I noticed while playing with the object sender that the frontend-2 assumes certain shapes. For example: Collection.elements will give me a nice UI, but Collection['@elements'] won't. I imagine there are other parts of the ecosystem that have those behaviours.

<img width="1054" alt="image" src="https://github.com/specklesystems/speckle-server/assets/61347148/07592900-6553-4fdf-ad6c-fbed4a5bee32">

<img width="959" alt="image" src="https://github.com/specklesystems/speckle-server/assets/61347148/8412b7a3-5ba5-4f1b-8cb1-6c3b0254ce76">

## Changes:

- Added @Detach() and @Chunkable(n) decorators
- Added examples of classes using the decorators
- Added a createCommit helper

## References

https://www.typescriptlang.org/docs/handbook/decorators.html#metadata
