### PR TITLE
refactor(fe2): remove certain revit elements from SceneExplorer

### DIFF
--- a/packages/frontend-2/components/viewer/explorer/TreeItem.vue
+++ b/packages/frontend-2/components/viewer/explorer/TreeItem.vue
@@ -307,8 +307,18 @@ const isNonEmptyObjectArray = (x: unknown) => isNonEmptyArray(x) && isObject(x[0
 const isObject = (x: unknown) =>
   typeof x === 'object' && !Array.isArray(x) && x !== null
 
-const isAllowedType = (node: ExplorerNode) =>
-  !['Objects.Other.DisplayStyle'].includes(node.raw?.speckle_type || '')
+const hiddenSpeckleTypes = [
+  'Objects.Other.DisplayStyle',
+  'Objects.Other.Revit.RevitMaterial',
+  'Objects.BuiltElements.Revit.ProjectInfo',
+  'Objects.BuiltElements.View',
+  'Objects.BuiltElements.View3D'
+]
+
+const isAllowedType = (node: ExplorerNode) => {
+  const speckleType = node.raw?.speckle_type || ''
+  return !hiddenSpeckleTypes.some((substring) => speckleType.includes(substring))
+}
 
 const unfold = ref(false)
 


### PR DESCRIPTION
## Description & motivation
We had previously hidden elements with the speckle_type `DisplayStyle` from the Scene Explorer. This task to do the same for these speckle_types:
- ProjectInfo
- RevitMaterial / Materials
- View
- View3D

## Changes:
- Updated `ViewerExplorerTreeItem` to include an array of types to be hidden
- Refactored `isAllowedType` function to check for these hidden types using substring matching