### PR TITLE
fix(modules): correct module names list for workspaces / core spli

### DIFF
--- a/packages/server/modules/index.js
+++ b/packages/server/modules/index.js
@@ -64,7 +64,7 @@ const getEnabledModuleNames = () => {
     'serverinvites',
     'stats',
     'webhooks',
-    'workspaces'
+    'workspacesCore'
   ]
 
   if (FF_AUTOMATE_MODULE_ENABLED) moduleNames.push('automate')


### PR DESCRIPTION
We caught this was wrong and then we made it right