### PR TITLE
fix(workspaces): correctly initialize and import workspaces core module

### DIFF
--- a/packages/server/modules/index.js
+++ b/packages/server/modules/index.js
@@ -64,7 +64,7 @@ const getEnabledModuleNames = () => {
     'serverinvites',
     'stats',
     'webhooks',
-    'workspaces'
+    'workspacesCore'
   ]
 
   if (FF_AUTOMATE_MODULE_ENABLED) moduleNames.push('automate')

--- a/packages/server/modules/workspacesCore/index.ts
+++ b/packages/server/modules/workspacesCore/index.ts
@@ -1,0 +1,6 @@
+import { SpeckleModule } from '@/modules/shared/helpers/typeHelper'
+import { moduleLogger } from '@/logging/logging'
+
+export const init: SpeckleModule['init'] = () => {
+  moduleLogger.info('⚒️  Init workspaces core module')
+}


### PR DESCRIPTION
We need to correctly initialize the new `workspaces` and `workspacesCore` modules in a license-safe way:

- Initialize `workspacesCore` in all cases
- Initialize `workspaces` _if_ environment variable `FF_WORKSPACES_MODULE_ENABLED` is true
  - The license checks are not yet implemented and guaranteeing this is true but will in the future

PR corrects the logic in `getEnabledModuleNames()` and adds a minimal `index.ts` for `workspacesCore`.