### PR TITLE
Fix: Change quote type for header

### DIFF
--- a/packages/frontend-2/middleware/headers.global.ts
+++ b/packages/frontend-2/middleware/headers.global.ts
@@ -10,7 +10,7 @@ export default defineNuxtRouteMiddleware((to) => {
     if (to.name !== 'model-viewer') {
       ssrContext.event.node.res.setHeader(
         'Content-Security-Policy',
-        'frame-ancestors "none"'
+        "frame-ancestors 'none'"
       )
     }
   }


### PR DESCRIPTION
I found out some browsers are very particular about the type of quotes in the header, and won't accept `frame-ancestors "none"` so I had to change it to `frame-ancestors 'none'`