### PR TITLE
Fix: Adjust sizes in invite dialog

### DIFF
--- a/packages/frontend-2/components/project/page/InviteDialog.vue
+++ b/packages/frontend-2/components/project/page/InviteDialog.vue
@@ -25,7 +25,7 @@
       </FormTextInput>
       <div
         v-if="searchUsers.length || selectedEmails?.length"
-        class="flex flex-col border bg-foundation border-primary-muted mt-2"
+        class="flex flex-col border bg-foundation border-primary-muted mt-2 rounded-md"
       >
         <template v-if="searchUsers.length">
           <ProjectPageTeamDialogInviteUserServerUserRow
@@ -43,7 +43,7 @@
           :stream-role="role"
           :disabled="loading"
           :is-guest-mode="isGuestMode"
-          class="mx-1 my-2"
+          class="p-2"
           @invite-emails="($event) => onInviteUser($event.emails, $event.serverRole)"
         />
       </div>

--- a/packages/frontend-2/components/project/page/settings/collaborators/Collaborators.vue
+++ b/packages/frontend-2/components/project/page/settings/collaborators/Collaborators.vue
@@ -15,7 +15,7 @@
         :key="collaborator.id"
         class="bg-foundation flex items-center gap-2 py-3 px-4 border-t border-x last:border-b border-outline-3 first:rounded-t-lg last:rounded-b-lg"
       >
-        <UserAvatar :user="collaborator.user" size="sm" />
+        <UserAvatar :user="collaborator.user" />
         <span class="grow truncate text-sm">{{ collaborator.title }}</span>
 
         <template v-if="!collaborator.inviteId">
@@ -40,7 +40,7 @@
             <FormButton
               class="shrink-0"
               color="danger"
-              size="xs"
+              size="sm"
               :disabled="loading"
               @click="
                 cancelInvite({

--- a/packages/frontend-2/components/project/page/team/dialog/invite-user/EmailsRow.vue
+++ b/packages/frontend-2/components/project/page/team/dialog/invite-user/EmailsRow.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex items-center space-x-2">
     <UserAvatar />
-    <span class="grow truncate">{{ selectedEmails.join(', ') }}</span>
+    <span class="grow truncate text-sm">{{ selectedEmails.join(', ') }}</span>
     <div class="flex items-center space-x-2">
       <FormSelectServerRoles
         v-if="showServerRoleSelect"

--- a/packages/frontend-2/components/project/page/team/dialog/invite-user/ServerUserRow.vue
+++ b/packages/frontend-2/components/project/page/team/dialog/invite-user/ServerUserRow.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    class="flex even:bg-primary-muted odd:bg-foundation-2 py-1 px-2 items-center space-x-2"
+    class="flex even:bg-primary-muted odd:bg-foundation-2 p-2 items-center space-x-2"
   >
-    <UserAvatar :user="user" size="sm" />
-    <span class="grow truncate text-xs">{{ user.name }}</span>
+    <UserAvatar :user="user" />
+    <span class="grow truncate text-sm">{{ user.name }}</span>
     <span
       v-tippy="
         isTryingToSetGuestOwner ? `Server guests can't be project owners` : undefined
@@ -11,7 +11,6 @@
     >
       <FormButton
         :disabled="isButtonDisabled"
-        size="xs"
         @click="() => $emit('invite-user', { user, streamRole })"
       >
         Invite


### PR DESCRIPTION
Some small adjustments in the invite to project dialog to align the sizes. Button feels a bit big but it's the only one we have atm that matches the dropdown input. We can probably revisit this when we update the ui components.

<img width="726" alt="Screenshot 2024-07-15 at 19 01 03" src="https://github.com/user-attachments/assets/31152381-7120-4caa-89ca-065f6817b415">
<img width="711" alt="Screenshot 2024-07-15 at 18 52 47" src="https://github.com/user-attachments/assets/14b5763c-8048-4607-a071-bad49a5d15c9">
<img width="978" alt="Screenshot 2024-07-15 at 18 58 02" src="https://github.com/user-attachments/assets/b88dcfc1-4a9e-4a4c-bcbf-29d4538b8846">