### PR TITLE
chore(automate): track run duration in ms too

### DIFF
--- a/packages/server/modules/automate/services/tracking.ts
+++ b/packages/server/modules/automate/services/tracking.ts
@@ -83,6 +83,10 @@ const onAutomationRunStatusUpdated =
       durationInSeconds: dayjs(functionRun.updatedAt).diff(
         functionRun.createdAt,
         'second'
+      ),
+      durationInMilliseconds: dayjs(functionRun.updatedAt).diff(
+        functionRun.createdAt,
+        'millisecond'
       )
     })
   }

--- a/packages/server/modules/automate/services/tracking.ts
+++ b/packages/server/modules/automate/services/tracking.ts
@@ -17,7 +17,6 @@ import { getCommit } from '@/modules/core/repositories/commits'
 import { getUserById } from '@/modules/core/services/users'
 import { mixpanel } from '@/modules/shared/utils/mixpanel'
 import { throwUncoveredError } from '@speckle/shared'
-import dayjs from 'dayjs'
 
 const isFinished = (runStatus: AutomationRunStatus) => {
   const finishedStatuses: AutomationRunStatus[] = [
@@ -80,14 +79,8 @@ const onAutomationRunStatusUpdated =
       runId: run.id,
       functionRunId: functionRun.id,
       status: functionRun.status,
-      durationInSeconds: dayjs(functionRun.updatedAt).diff(
-        functionRun.createdAt,
-        'second'
-      ),
-      durationInMilliseconds: dayjs(functionRun.updatedAt).diff(
-        functionRun.createdAt,
-        'millisecond'
-      )
+      durationInSeconds: functionRun.elapsed / 1000,
+      durationInMilliseconds: functionRun.elapsed
     })
   }
 


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- adds `durationInMilliseconds`
- uses `elapsed` because [we have it](https://github.com/specklesystems/speckle-server/blob/9fad4b2d587a4e2b0f15431983640d0783f5d141/packages/server/modules/automate/services/runsManagement.ts#L129) (happy to also do it with dayjs like existing, just saw this was available)
- technically undoes second-level rounding, can preserve if we want it
