### PR TITLE
Fix: Change server settings and discussion to usePaginatedQuery

### DIFF
--- a/packages/frontend-2/components/project/page/discussions/Results.vue
+++ b/packages/frontend-2/components/project/page/discussions/Results.vue
@@ -43,7 +43,7 @@ const {
     projectId: props.project.id,
     filter: { includeArchived: !!props.includeArchived }
   })),
-  resolveKey: (vars) => [vars.projectId, vars.filter.includeArchived],
+  resolveKey: (vars) => [vars.projectId, vars.filter],
   resolveCurrentResult: (res) => res?.project.commentThreads,
   resolveNextPageVariables: (baseVars, cursor) => ({
     ...baseVars,

--- a/packages/frontend-2/components/project/page/discussions/Results.vue
+++ b/packages/frontend-2/components/project/page/discussions/Results.vue
@@ -43,7 +43,7 @@ const {
     projectId: props.project.id,
     filter: { includeArchived: !!props.includeArchived }
   })),
-  resolveKey: (vars) => [vars.projectId],
+  resolveKey: (vars) => [vars.projectId, vars.filter.includeArchived],
   resolveCurrentResult: (res) => res?.project.commentThreads,
   resolveNextPageVariables: (baseVars, cursor) => ({
     ...baseVars,

--- a/packages/frontend-2/components/project/page/discussions/Results.vue
+++ b/packages/frontend-2/components/project/page/discussions/Results.vue
@@ -3,7 +3,7 @@
     <template v-if="hasItems">
       <ProjectPageLatestItemsCommentsGrid
         v-if="gridOrList === GridListToggleValue.Grid"
-        :threads="resul"
+        :threads="result"
       />
       <ProjectPageLatestItemsCommentsList v-else :threads="result" />
       <InfiniteLoading :settings="{ identifier }" @infinite="onInfiniteLoad" />

--- a/packages/frontend-2/components/project/page/discussions/Results.vue
+++ b/packages/frontend-2/components/project/page/discussions/Results.vue
@@ -43,7 +43,9 @@ const {
     projectId: props.project.id,
     filter: { includeArchived: !!props.includeArchived }
   })),
-  resolveKey: (vars) => [vars.projectId, vars.filter],
+  resolveKey: (vars) => {
+    return { projectId: vars.projectId, ...vars.filter }
+  },
   resolveCurrentResult: (res) => res?.project.commentThreads,
   resolveNextPageVariables: (baseVars, cursor) => ({
     ...baseVars,

--- a/packages/frontend-2/components/project/page/discussions/Results.vue
+++ b/packages/frontend-2/components/project/page/discussions/Results.vue
@@ -3,29 +3,23 @@
     <template v-if="hasItems">
       <ProjectPageLatestItemsCommentsGrid
         v-if="gridOrList === GridListToggleValue.Grid"
-        :threads="extraPagesResult"
+        :threads="resul"
       />
-      <ProjectPageLatestItemsCommentsList v-else :threads="extraPagesResult" />
-      <InfiniteLoading
-        :settings="{ identifier: infiniteLoaderId }"
-        @infinite="infiniteLoad"
-      />
+      <ProjectPageLatestItemsCommentsList v-else :threads="result" />
+      <InfiniteLoading :settings="{ identifier }" @infinite="onInfiniteLoad" />
     </template>
+
     <div v-else class="mt-8">
       <ProjectPageLatestItemsCommentsEmptyState />
     </div>
   </div>
 </template>
 <script setup lang="ts">
-import { useQuery } from '@vue/apollo-composable'
 import { graphql } from '~~/lib/common/generated/gql'
-import type {
-  ProjectCommentsFilter,
-  ProjectDiscussionsPageResults_ProjectFragment
-} from '~~/lib/common/generated/gql/graphql'
-import type { InfiniteLoaderState } from '~~/lib/global/helpers/components'
+import type { ProjectDiscussionsPageResults_ProjectFragment } from '~~/lib/common/generated/gql/graphql'
 import { GridListToggleValue } from '~~/lib/layout/helpers/components'
 import { latestCommentThreadsQuery } from '~~/lib/projects/graphql/queries'
+import { usePaginatedQuery } from '~/lib/common/composables/graphql'
 
 graphql(`
   fragment ProjectDiscussionsPageResults_Project on Project {
@@ -39,61 +33,26 @@ const props = defineProps<{
   includeArchived: boolean
 }>()
 
-const logger = useLogger()
-
-const queryFilterVariables = computed(
-  (): ProjectCommentsFilter => ({
-    includeArchived: !!props.includeArchived
-  })
-)
-
-const infiniteLoaderId = ref('')
 const {
-  result: extraPagesResult,
-  fetchMore: fetchMorePages,
-  variables: resultVariables,
-  onResult
-} = useQuery(latestCommentThreadsQuery, () => ({
-  projectId: props.project.id,
-  filter: queryFilterVariables.value
-}))
+  identifier,
+  onInfiniteLoad,
+  query: { result }
+} = usePaginatedQuery({
+  query: latestCommentThreadsQuery,
+  baseVariables: computed(() => ({
+    projectId: props.project.id,
+    filter: { includeArchived: !!props.includeArchived }
+  })),
+  resolveKey: (vars) => [vars.projectId],
+  resolveCurrentResult: (res) => res?.project.commentThreads,
+  resolveNextPageVariables: (baseVars, cursor) => ({
+    ...baseVars,
+    cursor
+  }),
+  resolveCursorFromVariables: (vars) => vars.cursor
+})
 
 const hasItems = computed(
-  () => !!(extraPagesResult.value?.project?.commentThreads.items || []).length
+  () => !!(result.value?.project?.commentThreads.items || []).length
 )
-
-const moreToLoad = computed(
-  () =>
-    !extraPagesResult.value?.project ||
-    extraPagesResult.value.project.commentThreads.items.length <
-      extraPagesResult.value.project.commentThreads.totalCount
-)
-
-const infiniteLoad = async (state: InfiniteLoaderState) => {
-  const cursor = extraPagesResult.value?.project?.commentThreads.cursor || null
-  if (!moreToLoad.value || !cursor) return state.complete()
-
-  try {
-    await fetchMorePages({
-      variables: {
-        cursor
-      }
-    })
-  } catch (e) {
-    logger.error(e)
-    state.error()
-    return
-  }
-
-  state.loaded()
-  if (!moreToLoad.value) {
-    state.complete()
-  }
-}
-
-const calculateLoaderId = () => {
-  infiniteLoaderId.value = JSON.stringify(resultVariables.value?.filter || {})
-}
-
-onResult(calculateLoaderId)
 </script>


### PR DESCRIPTION
Following the comment on the settings modal PR this PR changes the tables that use infinite loading to use `usePaginatedQuery`, as well as the discussions page. 

There are a few more places where this can be done (dashboard and models), I will address these in a separate PR when I have some time in between things or when we touch these pages, which will be soon.

(also fixes some minor styling issues that I noticed in the search bar on the settings pages)