### PR TITLE
Fix: Add 'day' to dateFormatter check

### DIFF
--- a/packages/frontend-2/utils/dateFormatter.ts
+++ b/packages/frontend-2/utils/dateFormatter.ts
@@ -30,15 +30,19 @@ const customRelativeTime = (date: ConfigType, capitalize?: boolean): string => {
 }
 
 /**
- * Determines if the given date input is formatting with a clock unit (seconds, minutes, or hours).
- * Only meant to be used by formattedRelativeDate() and formattedFullDate()
+ * Determines if the given date input is using timeframe formatting
  * @example
- * isClockUnit('2023-07-16') - returns false
- * isClockUnit(new Date()) - returns true or false depending on the current time
+ * isTimeframe('2023-07-16') - returns false
+ * isTimeframe(new Date()) - returns true or false depending on the current time
  */
-const isClockUnit = (date: ConfigType) => {
+const isTimeframe = (date: ConfigType) => {
   const unit = customRelativeTime(date)
-  return unit.includes('second') || unit.includes('minute') || unit.includes('hour')
+  return (
+    unit.includes('second') ||
+    unit.includes('minute') ||
+    unit.includes('hour') ||
+    unit.includes('day')
+  )
 }
 
 /**
@@ -63,7 +67,7 @@ export const formattedRelativeDate = (
   options?: Partial<{ prefix: boolean; capitalize: boolean }>
 ): string => {
   if (options?.prefix) {
-    return isClockUnit(date)
+    return isTimeframe(date)
       ? customRelativeTime(date, options?.capitalize)
       : `on ${customRelativeTime(date)}`
   } else {


### PR DESCRIPTION
Small fix for the dateFormatter util, when rendering the prefix it would also show when the timeframe was 'days', resulting in an output of "on 5 days ago". This makes sure "day" is also excluded from using the prefix.