### PR TITLE
hotfix(fe2): Add truncation to prevent long names overflowing

### DIFF
--- a/packages/frontend-2/components/project/page/models/Card.vue
+++ b/packages/frontend-2/components/project/page/models/Card.vue
@@ -4,7 +4,7 @@
   <div v-keyboard-clickable :class="containerClasses" @click="onCardClick">
     <div class="relative">
       <div class="flex justify-between items-center h-10">
-        <div class="px-2 select-none">
+        <div class="px-2 select-none w-full max-w-[80%]">
           <div
             v-if="nameParts[0]"
             class="text-body-2xs text-foreground-2 relative truncate"


### PR DESCRIPTION
To fix this:
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/d5424d25-2f65-4eb6-a311-d2c1d17177f9">


Added width classes to fix. 