### PR TITLE
Fix: Adjust SSO button styling

### DIFF
--- a/packages/frontend-2/components/auth/third-party/LoginButtonBase.vue
+++ b/packages/frontend-2/components/auth/third-party/LoginButtonBase.vue
@@ -3,8 +3,8 @@
     :to="to"
     :class="[
       'transition grow px-3 inline-flex justify-center items-center outline-none h6 font-medium leading-7',
-      'rounded shadow hover:shadow-lg bg-foundation-2 text-foreground dark:text-foreground-on-primary',
-      'ring-outline-2 focus:ring-2 hover:ring-2',
+      'rounded shadow bg-foundation- text-foreground dark:text-foreground-on-primary',
+      'border border-1 border-outline-2 hover:border-outline-3',
       noVerticalPadding ? '' : 'py-2'
     ]"
   >


### PR DESCRIPTION
Looked a bit off, fixed it to look like this (like the design):

<img width="485" alt="Screenshot 2024-07-30 at 17 50 43" src="https://github.com/user-attachments/assets/8a9e56b9-c859-4a5d-b958-efb13ad8499d">
