### PR TITLE
fix(fe2): no click on empty model

### DIFF
--- a/packages/frontend-2/components/project/page/models/StructureItem.vue
+++ b/packages/frontend-2/components/project/page/models/StructureItem.vue
@@ -5,8 +5,8 @@
   <div
     v-keyboard-clickable
     class="space-y-4 relative"
-    :class="model ? 'cursor-pointer' : undefined"
-    @click="onCardClick"
+    :class="model && !isEmptyModel ? 'cursor-pointer' : undefined"
+    @click="isEmptyModel ? undefined : onCardClick"
     @mouseleave="showActionsMenu = false"
   >
     <div
@@ -404,6 +404,10 @@ const {
 )
 
 const children = computed(() => childrenResult.value?.project?.modelChildrenTree || [])
+
+const isEmptyModel = computed(() => {
+  return itemType.value === StructureItemType.EmptyModel
+})
 
 const onModelUpdated = () => {
   emit('model-updated')

--- a/packages/frontend-2/components/settings/server/PendingInvitations.vue
+++ b/packages/frontend-2/components/settings/server/PendingInvitations.vue
@@ -53,6 +53,7 @@
         <template #resend="{ item }">
           <FormButton
             :link="true"
+            text
             :class="{
               'font-medium': true,
               'text-primary': !successfullyResentInvites.includes(item.id),


### PR DESCRIPTION
Made resend button text link to remove shadows:
<img width="1069" alt="image" src="https://github.com/user-attachments/assets/ccb98a10-7176-458f-8182-07639ed0a148">


Can no longer click an empty model here:
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/6110c653-2da4-4590-a209-78a2c9c456e7">
