### PR TITLE
fix(workspaces): backend validation on workspace settings fields

### DIFF
--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -153,6 +153,13 @@ export = FF_WORKSPACES_MODULE_ENABLED
         update: async (_parent, args, context) => {
           const { id: workspaceId, ...workspaceInput } = args.input
 
+          await authorizeResolver(
+            context.userId!,
+            workspaceId,
+            Roles.Workspace.Admin,
+            context.resourceAccessRules
+          )
+
           const updateWorkspace = updateWorkspaceFactory({
             getWorkspace: getWorkspaceFactory({ db }),
             upsertWorkspace: upsertWorkspaceFactory({ db }),
@@ -161,9 +168,7 @@ export = FF_WORKSPACES_MODULE_ENABLED
 
           const workspace = await updateWorkspace({
             workspaceId,
-            workspaceInput,
-            workspaceUpdaterId: context.userId!,
-            updaterResourceAccessLimits: context.resourceAccessRules
+            workspaceInput
           })
 
           return workspace

--- a/packages/server/modules/workspaces/services/management.ts
+++ b/packages/server/modules/workspaces/services/management.ts
@@ -37,6 +37,7 @@ import {
 } from '@/modules/core/domain/tokens/types'
 import { ForbiddenError } from '@/modules/shared/errors'
 import { validateImageString } from '@/modules/workspaces/helpers/images'
+import { isEmpty } from 'lodash'
 
 type WorkspaceCreateArgs = {
   userId: string
@@ -138,6 +139,11 @@ export const updateWorkspaceFactory =
 
     if (!currentWorkspace) {
       throw new WorkspaceNotFoundError()
+    }
+
+    if (isEmpty(workspaceInput.name)) {
+      // Do not allow setting an empty name (empty descriptions allowed)
+      delete workspaceInput.name
     }
 
     const workspace = {

--- a/packages/server/modules/workspaces/services/management.ts
+++ b/packages/server/modules/workspaces/services/management.ts
@@ -29,7 +29,6 @@ import {
 import { queryAllWorkspaceProjectsFactory } from '@/modules/workspaces/services/projects'
 import { EventBus } from '@/modules/shared/services/eventBus'
 import { removeNullOrUndefinedKeys } from '@speckle/shared'
-import { authorizeResolver } from '@/modules/shared'
 import { isNewResourceAllowed } from '@/modules/core/helpers/token'
 import {
   TokenResourceIdentifier,
@@ -97,15 +96,12 @@ export const createWorkspaceFactory =
   }
 
 type WorkspaceUpdateArgs = {
-  /** Id of user performing the operation */
-  workspaceUpdaterId: string
   workspaceId: string
   workspaceInput: {
     name?: string | null
     description?: string | null
     logo?: string | null
   }
-  updaterResourceAccessLimits: MaybeNullOrUndefined<TokenResourceIdentifier[]>
 }
 
 export const updateWorkspaceFactory =
@@ -118,29 +114,17 @@ export const updateWorkspaceFactory =
     upsertWorkspace: UpsertWorkspace
     emitWorkspaceEvent: EventBus['emit']
   }) =>
-  async ({
-    workspaceUpdaterId,
-    workspaceId,
-    workspaceInput,
-    updaterResourceAccessLimits
-  }: WorkspaceUpdateArgs): Promise<Workspace> => {
-    await authorizeResolver(
-      workspaceUpdaterId,
-      workspaceId,
-      Roles.Workspace.Admin,
-      updaterResourceAccessLimits
-    )
-
-    if (!!workspaceInput.logo) {
-      validateImageString(workspaceInput.logo)
-    }
-
+  async ({ workspaceId, workspaceInput }: WorkspaceUpdateArgs): Promise<Workspace> => {
+    // Get existing workspace to merge with incoming changes
     const currentWorkspace = await getWorkspace({ workspaceId })
-
     if (!currentWorkspace) {
       throw new WorkspaceNotFoundError()
     }
 
+    // Validate incoming changes
+    if (!!workspaceInput.logo) {
+      validateImageString(workspaceInput.logo)
+    }
     if (isEmpty(workspaceInput.name)) {
       // Do not allow setting an empty name (empty descriptions allowed)
       delete workspaceInput.name


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Did not validate incoming changes to workspace name/desc
- But we should

## Changes:

- Validates
- Adds tests for these cases
- Moves authz to resolver level, since I'm here