### PR TITLE
refactor(fe2): Update viewer page title to include model name

### DIFF
--- a/packages/frontend-2/app.vue
+++ b/packages/frontend-2/app.vue
@@ -17,7 +17,7 @@ const { isDarkTheme } = useTheme()
 
 useHead({
   // Title suffix
-  titleTemplate: (titleChunk) => (titleChunk ? `${titleChunk} - Speckle` : 'Speckle'),
+  titleTemplate: (titleChunk) => (titleChunk ? `${titleChunk} | Speckle` : 'Speckle'),
   htmlAttrs: {
     class: computed(() => (isDarkTheme.value ? `dark` : ``)),
     lang: 'en'

--- a/packages/frontend-2/components/viewer/PreSetupWrapper.vue
+++ b/packages/frontend-2/components/viewer/PreSetupWrapper.vue
@@ -137,9 +137,20 @@ graphql(`
   }
 `)
 
-const title = computed(() =>
-  project.value?.name.length ? `Viewer - ${project.value.name}` : ''
-)
+const title = computed(() => {
+  if (project.value?.models?.items) {
+    const modelCount = project.value.models.items.length
+    const projectName = project.value.name || ''
+
+    if (modelCount > 1) {
+      return projectName ? `Multiple models - ${projectName}` : 'Multiple models'
+    } else if (modelCount === 1) {
+      const modelName = project.value.models.items[0].name || ''
+      return projectName ? `${modelName} - ${projectName}` : modelName
+    }
+  }
+  return ''
+})
 
 const modelName = computed(() => {
   if (project.value?.models?.items && project.value.models.items.length > 0) {


### PR DESCRIPTION
## Description & motivation
Bilal requested this in discord. When you have multiple tabs from the same project open, it's hard to know which tab is which. 

This change adds the Model Name to the page title. If multiple models, it will say "Multiple models". 

This change also involved changing the trailing `- Speckle` to `| Speckle`.