### PR TITLE
fix(fe2): dont build sourcemaps unnecessarily

### DIFF
--- a/packages/frontend-2/Dockerfile
+++ b/packages/frontend-2/Dockerfile
@@ -2,9 +2,6 @@ FROM node:18-bookworm-slim@sha256:408f8cbbb7b33a5bb94bdb8862795a94d2b64c2d516856
 ARG NODE_ENV=production
 ARG SPECKLE_SERVER_VERSION=custom
 
-# have to build w/ sourcemaps and then delete them, cause otherwise the file hashes are different (absurd, i know...)
-ENV BUILD_SOURCEMAPS=true
-
 WORKDIR /speckle-server
 
 COPY .yarnrc.yml .


### PR DESCRIPTION
We enabled building sourcemaps even when not using them cause we were running into issues w/ sourcemaps not working, and thought that maybe the built file hashes are different if sourcemaps are enabled/disabled.

Sourcemaps did start working, but from a seemingly unrelated fix. Additionally, building sourcemaps and then deleting them still causes browsers to request them sometimes (cause they're referenced in the .js files) and the requests fail w/ a 500 not 404 error, probably because of the manual build output manipulation.

![image](https://github.com/user-attachments/assets/dfce4859-f626-4a9d-a0f9-e6497630d6ab)

So lets try disabling them in the build again and hope that sourcemap collection in the separate CI job still works

