### PR TITLE
fix: objectloader totalChildrenCount

### DIFF
--- a/packages/objectloader/src/index.js
+++ b/packages/objectloader/src/index.js
@@ -150,7 +150,7 @@ class ObjectLoader {
 
     for await (const obj of this.getObjectIterator()) {
       if (first) {
-        this.totalChildrenCount = obj.totalChildrenCount
+        this.totalChildrenCount = Object.keys(obj?.__closure || {}).length
         first = false
         this.isLoading = true
       }


### PR DESCRIPTION
one liner for the object loader to use a more reliable way of getting the total children count. the actual `totalChildrenCount` property is not really properly set anymore by the .NET sdk. 