### PR TITLE
Fix(dui3): Use existing cards for latter operations

### DIFF
--- a/packages/dui3/components/send/Wizard.vue
+++ b/packages/dui3/components/send/Wizard.vue
@@ -120,6 +120,27 @@ watch(step, (newVal, oldVal) => {
 const hostAppStore = useHostAppStore()
 
 const addModel = async () => {
+  void trackEvent('DUI3 Action', {
+    name: 'Publish Wizard',
+    step: 'objects selected',
+    filter: filter.value?.typeDiscriminator
+  })
+
+  const existingModel = hostAppStore.models.find(
+    (m) =>
+      m.modelId === selectedModel.value?.id && m.typeDiscriminator === 'SenderModelCard'
+  ) as SenderModelCard
+  if (existingModel) {
+    emit('close')
+    // Patch the existing model card with new send filter and non-expired state!
+    await hostAppStore.patchModel(existingModel.modelCardId, {
+      sendFilter: filter.value as ISendFilter,
+      expired: false
+    })
+    void hostAppStore.sendModel(existingModel.modelCardId)
+    return
+  }
+
   const model = new SenderModelCard()
   model.accountId = selectedAccountId.value
   model.projectId = selectedProject.value?.id as string
@@ -127,12 +148,6 @@ const addModel = async () => {
   model.modelId = selectedModel.value?.id as string
   model.sendFilter = filter.value as ISendFilter
   model.expired = false
-
-  void trackEvent('DUI3 Action', {
-    name: 'Publish Wizard',
-    step: 'objects selected',
-    filter: filter.value?.typeDiscriminator
-  })
 
   emit('close')
   await hostAppStore.addModel(model)

--- a/packages/dui3/components/wizard/ModelSelector.vue
+++ b/packages/dui3/components/wizard/ModelSelector.vue
@@ -49,6 +49,7 @@
               <ExclamationTriangleIcon class="w-4 in inline text-orange-500" />
               The model you selected
               <b>already exists in the file.</b>
+              Your existing model will be used for operation.
             </p>
             <p class="mb-2 text-sm">Are you sure you want to proceed?</p>
           </div>


### PR DESCRIPTION
Instead of creating new model cards, finds the existing one and patch it with important data before running send/receive operation.

Patching on send:
- `sendFilter`
- `isExpired`

Patching on receive:
- `selectedVersionId`
- `latestVersion`

SEND
![SketchUp_CF9YQK47Yr-ezgif com-resize](https://github.com/user-attachments/assets/8188ed2f-baf5-4080-8ab1-e3cc84816061)

RECEIVE
![0iqTfHlSrB](https://github.com/user-attachments/assets/7955c66c-221c-4bf7-a97b-495939d10106)
