### PR TITLE
fix(workspaces): guests do not get workspace-wide project access

### DIFF
--- a/packages/server/modules/workspaces/events/eventListener.ts
+++ b/packages/server/modules/workspaces/events/eventListener.ts
@@ -41,13 +41,17 @@ export const onProjectCreatedFactory =
     const workspaceMembers = await getWorkspaceRoles({ workspaceId })
 
     await Promise.all(
-      workspaceMembers.map(({ userId, role: workspaceRole }) =>
+      workspaceMembers.map(({ userId, role: workspaceRole }) => {
+        if (workspaceRole === Roles.Workspace.Guest) {
+          // Guests do not get roles on project create
+          return
+        }
         grantStreamPermissions({
           streamId: projectId,
           userId,
           role: mapWorkspaceRoleToProjectRole(workspaceRole)
         })
-      )
+      })
     )
   }
 

--- a/packages/server/modules/workspaces/services/management.ts
+++ b/packages/server/modules/workspaces/services/management.ts
@@ -302,8 +302,18 @@ export const updateWorkspaceRoleFactory =
     // Perform upsert
     await upsertWorkspaceRole({ userId, workspaceId, role })
 
+    // Emit new role
+    await emitWorkspaceEvent({
+      eventName: WorkspaceEvents.RoleUpdated,
+      payload: { userId, workspaceId, role }
+    })
+
+    if (role === Roles.Workspace.Guest) {
+      // Guests do not get new roles for existing projects
+      return
+    }
+
     // Update user role in all workspace projects
-    // TODO: Should these be in a transaction with the workspace role change?
     const queryAllWorkspaceProjectsGenerator = queryAllWorkspaceProjectsFactory({
       getStreams
     })
@@ -321,10 +331,4 @@ export const updateWorkspaceRoleFactory =
         })
       )
     }
-
-    // Emit new role
-    await emitWorkspaceEvent({
-      eventName: WorkspaceEvents.RoleUpdated,
-      payload: { userId, workspaceId, role }
-    })
   }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- I incorrectly wrote some workspace role => project role logic that granted workspace-wide project roles to workspace guests
- We should no do this

## Changes:

- Do not do this anymore

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
