### PR TITLE
Fix(dui3): Autocad escape issue

### DIFF
--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -214,8 +214,16 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     model.progress = { status: 'Starting to send...' }
     model.expired = false
     model.report = undefined
-
-    void app.$sendBinding.send(modelCardId)
+    // You should stop asking why if you saw anything related autocad..
+    // It solves the press "escape" issue.
+    // Because probably we don't give enough time to acad complete it's previos task and it stucks.
+    if (hostAppName.value === 'autocad') {
+      setTimeout(() => {
+        void app.$sendBinding.send(modelCardId)
+      }, 500) // I prefer to sacrifice 500ms
+    } else {
+      void app.$sendBinding.send(modelCardId)
+    }
   }
 
   /**


### PR DESCRIPTION
We were looking solution on wrong garden.
It was sneaky.. (No escape press needed anymore)
The delay on the seeing first card at the beginning lead me to think on potential async/await issue with `await sendBinding.send` function. Sometimes we hit the send function too early and AutoCAD API doesn't like it as we doesn't like him. It was random. By sacrificing 500ms delay on acad send operation fixing the problem. 🤷‍♂️
Also there is no more delay at the begining. We see the card immediately.

![acad_MiNlEzIP3M](https://github.com/user-attachments/assets/3ce123a4-d1c6-433f-9bfc-a6433010d07a)
