### PR TITLE
Fix(dui3): z index of footer buttons

### DIFF
--- a/packages/dui3/pages/index.vue
+++ b/packages/dui3/pages/index.vue
@@ -58,7 +58,7 @@
     </div>
     <div
       v-if="!hasNoModelCards"
-      class="fixed bottom-0 left-0 w-full bg-blue-500/50 rounded-t-md p-2 z-100 flex space-x-2 max-[275px]:flex-col max-[275px]:space-y-2 max-[275px]:space-x-0"
+      class="z-20 fixed bottom-0 left-0 w-full bg-blue-500/50 rounded-t-md p-2 z-100 flex space-x-2 max-[275px]:flex-col max-[275px]:space-y-2 max-[275px]:space-x-0"
     >
       <div v-if="app.$sendBinding" class="grow">
         <FormButton :icon-left="CloudArrowUpIcon" full-width @click="handleSendClick">


### PR DESCRIPTION
CTA buttons in card had `z-10` index for a purpose. I have put footer buttons to `z-20`.

![acad_Q9zpZeBPB8](https://github.com/user-attachments/assets/e75935af-bec9-449d-8c6f-f28f4c1e14a0)
