### PR TITLE
chore(liveness): fail liveness if db conns saturated for 10min

### DIFF
--- a/packages/server/modules/core/rest/health.ts
+++ b/packages/server/modules/core/rest/health.ts
@@ -19,14 +19,14 @@ export default (app: express.Application) => {
   const knexFreeDbConnectionSamplerLiveness = knexFreeDbConnectionSamplerFactory({
     db,
     collectionPeriod: highFrequencyMetricsCollectionPeriodMs(),
-    sampledDuration: 120000 //number of ms over which to average the database connections, before declaring not alive
+    sampledDuration: 600000 //number of ms over which to average the database connections, before declaring not alive. 10 minutes.
   })
   knexFreeDbConnectionSamplerLiveness.start()
 
   const knexFreeDbConnectionSamplerReadiness = knexFreeDbConnectionSamplerFactory({
     db,
     collectionPeriod: highFrequencyMetricsCollectionPeriodMs(),
-    sampledDuration: 20000 //number of ms over which to average the database connections, before declaring unready
+    sampledDuration: 20000 //number of ms over which to average the database connections, before declaring unready. 20 seconds.
   })
   knexFreeDbConnectionSamplerReadiness.start()
 

--- a/packages/server/modules/core/rest/health.ts
+++ b/packages/server/modules/core/rest/health.ts
@@ -11,20 +11,32 @@ import { numberOfFreeConnections } from '@/modules/shared/helpers/dbHelper'
 import { db } from '@/db/knex'
 import type { Knex } from 'knex'
 
+type FreeConnectionsCalculator = {
+  mean: () => number
+}
+
 export default (app: express.Application) => {
-  const knexFreeDbConnectionSampler = knexFreeDbConnectionSamplerFactory({
+  const knexFreeDbConnectionSamplerLiveness = knexFreeDbConnectionSamplerFactory({
+    db,
+    collectionPeriod: highFrequencyMetricsCollectionPeriodMs(),
+    sampledDuration: 120000 //number of ms over which to average the database connections, before declaring not alive
+  })
+  knexFreeDbConnectionSamplerLiveness.start()
+
+  const knexFreeDbConnectionSamplerReadiness = knexFreeDbConnectionSamplerFactory({
     db,
     collectionPeriod: highFrequencyMetricsCollectionPeriodMs(),
     sampledDuration: 20000 //number of ms over which to average the database connections, before declaring unready
   })
-  knexFreeDbConnectionSampler.start()
+  knexFreeDbConnectionSamplerReadiness.start()
 
   app.options('/liveness')
   app.get(
     '/liveness',
     handleLivenessFactory({
       isRedisAlive,
-      isPostgresAlive
+      isPostgresAlive,
+      freeConnectionsCalculator: knexFreeDbConnectionSamplerLiveness
     })
   )
   app.options('/readiness')
@@ -33,7 +45,7 @@ export default (app: express.Application) => {
     handleReadinessFactory({
       isRedisAlive,
       isPostgresAlive,
-      freeConnectionsCalculator: knexFreeDbConnectionSampler
+      freeConnectionsCalculator: knexFreeDbConnectionSamplerReadiness
     })
   )
 }
@@ -42,6 +54,7 @@ const handleLivenessFactory =
   (deps: {
     isRedisAlive: RedisCheck
     isPostgresAlive: DBCheck
+    freeConnectionsCalculator: FreeConnectionsCalculator
   }): express.RequestHandler =>
   async (req, res) => {
     const postgres = await deps.isPostgresAlive()
@@ -69,13 +82,25 @@ const handleLivenessFactory =
       return
     }
 
+    const numFreeConnections = await deps.freeConnectionsCalculator.mean()
+    const percentageFreeConnections = Math.floor(
+      (numFreeConnections * 100) / postgresMaxConnections()
+    )
+    //unready if less than 10%
+    if (percentageFreeConnections < 10) {
+      const message =
+        'Liveness health check failed. Insufficient free database connections for a sustained duration.'
+      req.log.error(message)
+      res.status(500).json({
+        message
+      })
+      res.send()
+      return
+    }
+
     res.status(200)
     res.send()
   }
-
-type FreeConnectionsCalculator = {
-  mean: () => number
-}
 
 const handleReadinessFactory = (deps: {
   isRedisAlive: RedisCheck
@@ -112,7 +137,7 @@ const handleReadinessFactory = (deps: {
     const percentageFreeConnections = Math.floor(
       (numFreeConnections * 100) / postgresMaxConnections()
     )
-    //unready if less than 10% for 20s
+    //unready if less than 10%
     if (percentageFreeConnections < 10) {
       const message =
         'Readiness health check failed. Insufficient free database connections for a sustained duration.'


### PR DESCRIPTION
## Description & motivation

Pods are placed in an unready state if the database connections are saturated for >20 seconds.

We currently have a situation where there are some long-running database queries. These cause the database connections available to a pod to be saturated for extended periods of time. This in turn causes the pod to be in an unready state. Over time, as the long-running queries accumulate, the number of pods which are unready increases. This eventually causes the entire cluster to be unavailable.

Currently the only way to recover is to restart the pod.

Including a check of saturated database connections in the liveness probe is a short-term hack to ensure affected pods are restarted whenever the encounter this issue.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
