### PR TITLE
Fix: Add close event to settings modal

### DIFF
--- a/packages/frontend-2/components/settings/Dialog.vue
+++ b/packages/frontend-2/components/settings/Dialog.vue
@@ -96,6 +96,7 @@
         ]"
         :user="user"
         :workspace-id="targetWorkspaceId"
+        @close="isOpen = false"
       />
     </div>
   </LayoutDialog>

--- a/packages/frontend-2/components/settings/server/Projects.vue
+++ b/packages/frontend-2/components/settings/server/Projects.vue
@@ -110,6 +110,10 @@ import { isProject } from '~~/lib/server-management/helpers/utils'
 import { useDebouncedTextInput } from '@speckle/ui-components'
 import { usePaginatedQuery } from '~/lib/common/composables/graphql'
 
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
 const { on, bind, value: search } = useDebouncedTextInput()
 const router = useRouter()
 
@@ -147,5 +151,6 @@ const openProjectDeleteDialog = (item: ItemType) => {
 
 const handleProjectClick = (item: ItemType) => {
   router.push(`/projects/${item.id}`)
+  emit('close')
 }
 </script>


### PR DESCRIPTION
Adds a event listener for close events, so the modal will be closed once a project is selected