### PR TITLE
fix(tailwind-theme) Update primary focus hex value

### DIFF
--- a/packages/tailwind-theme/src/plugin.ts
+++ b/packages/tailwind-theme/src/plugin.ts
@@ -26,7 +26,7 @@ export const lightThemeVariables = {
   /* primary color */
   '--primary': '#136CFF',
   /* focused primary color */
-  '--primary-focus': '#276FE5',
+  '--primary-focus': '#0057E5',
   /* muted primary color */
   '--primary-muted': '#EDEDED',
 


### PR DESCRIPTION
## Description & motivation
Jonathon noticed the lack of a hover state in the Button. This was down to the wrong hex value being applied to as the "primary-focus" class. 

This has been updated to the correct value