### PR TITLE
fix(helm chart): remove confusing duplicate max_object_size_mb property

### DIFF
--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -554,7 +554,7 @@
         "max_object_size_mb": {
           "type": "number",
           "description": "The maximum size of an individual object which can be uploaded to the server",
-          "default": 10
+          "default": 100
         },
         "max_object_upload_file_size_mb": {
           "type": "number",
@@ -1309,11 +1309,6 @@
               "default": "7000"
             }
           }
-        },
-        "max_object_size_mb": {
-          "type": "number",
-          "description": "The maximum size of an individual object which can be uploaded to the server",
-          "default": 100
         },
         "requests": {
           "type": "object",

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -424,7 +424,7 @@ server:
   weeklyDigestEnabled: false
 
   ## @param server.max_object_size_mb The maximum size of an individual object which can be uploaded to the server
-  max_object_size_mb: 10
+  max_object_size_mb: 100
   ## @param server.max_object_upload_file_size_mb Objects are batched together and uploaded to the /objects endpoint as http POST form data. This determines the maximum size of that form data which can be uploaded to the server
   max_object_upload_file_size_mb: 50
   ## @param server.max_project_models_per_page The maximum number of models that can be returned in a single page of a query for all models of a project
@@ -812,9 +812,6 @@ objects:
     enabled: false
     ## @param objects.inspect.port The port on which the nodejs inspect feature should be exposed
     port: '7000'
-
-  ## @param objects.max_object_size_mb The maximum size of an individual object which can be uploaded to the server
-  max_object_size_mb: 100
 
   requests:
     ## @param objects.requests.cpu The CPU that should be available on a node when scheduling this pod.


### PR DESCRIPTION
## Description & motivation

The deprecated helm chart property `objects.max_object_size_mb` was still present and caused confusion. It has been replaced with `server.max_object_size_mb`.4

The default is now correctly applied to `server.max_object_size_mb`.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
