### PR TITLE
refactor(fe2): Replace IconConnectors with new version

### DIFF
--- a/packages/frontend-2/components/dashboard/Sidebar.vue
+++ b/packages/frontend-2/components/dashboard/Sidebar.vue
@@ -78,7 +78,7 @@
             <NuxtLink :to="connectorsPageUrl" target="_blank">
               <LayoutSidebarMenuGroupItem label="Connectors" external>
                 <template #icon>
-                  <IconConnectors class="h-4 w-4 text-foreground-2" />
+                  <IconConnectors class="h-4 w-4 ml-px text-foreground-2" />
                 </template>
               </LayoutSidebarMenuGroupItem>
             </NuxtLink>

--- a/packages/frontend-2/components/global/icon/Connectors.vue
+++ b/packages/frontend-2/components/global/icon/Connectors.vue
@@ -7,10 +7,32 @@
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
-      d="M5.72094 2.5L2.92094 6H7.25V2.5H5.72094ZM8.75 2.5V6H13.0791L10.2791 2.5H8.75ZM2.5 13.5V7.5H13.5V13.5H2.5ZM5.48062 1C5.17684 1 4.88953 1.13809 4.69976 1.3753L1.21913 5.72609C1.07728 5.9034 1 6.12371 1 6.35078V14C1 14.5523 1.44772 15 2 15H14C14.5523 15 15 14.5523 15 14V6.35078C15 6.12371 14.9227 5.9034 14.7809 5.72609L11.3002 1.3753C11.1105 1.13809 10.8232 1 10.5194 1H5.48062Z"
-      fill="currentColor"
+      d="M6.06301 2.75L13.2511 9.93813L11.4539 11.7354C10.9854 12.2227 10.4243 12.6116 9.80367 12.8795C9.183 13.1473 8.51514 13.2887 7.83918 13.2953C7.16321 13.302 6.49271 13.1737 5.86691 12.9181C5.2411 12.6625 4.67257 12.2846 4.19456 11.8066C3.71656 11.3286 3.33869 10.76 3.08306 10.1342C2.82743 9.50843 2.69918 8.83793 2.70581 8.16196C2.71244 7.486 2.85382 6.81814 3.12167 6.19747C3.38953 5.5768 3.77848 5.01579 4.26576 4.54725L6.06301 2.75Z"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M1 15L4.0625 11.9375"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M10.625 1L7.5625 4.0625"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M15 5.375L11.9375 8.4375"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
     />
   </svg>
 </template>


### PR DESCRIPTION
## Description & motivation
Michal has designed a new icon, more fitting with the new design system, but also something known to our users. 

I added a "ml-px". It's one of those where although it is perfectly aligned with the other icons, it still looks slightly off to the eye, due to the shape of the icon. The slight margin lessens this effect. 