### PR TITLE
feat(scene explorer): filters out noise from scene explorer (CNX-326)

### DIFF
--- a/packages/frontend-2/components/viewer/explorer/TreeItem.vue
+++ b/packages/frontend-2/components/viewer/explorer/TreeItem.vue
@@ -308,8 +308,13 @@ const isObject = (x: unknown) =>
   typeof x === 'object' && !Array.isArray(x) && x !== null
 
 const hiddenSpeckleTypes = [
-  'Objects.Other.DisplayStyle',
-  'Objects.Other.Revit.RevitMaterial',
+  'Objects.Other', // From a fast look at the current object model, and the new one, all of this can be safely ignored (partially be ready for complaints)
+  // 'Objects.Other.DisplayStyle',
+  // 'Objects.Other.Revit.RevitMaterial',
+  'ColorProxy',
+  'InstanceDefinitionProxy', // Note, but not InstanceProxy - wish we could just go for "*Proxy*" but...
+  'GroupProxy',
+  'RenderMaterialProxy', // It's now partially included in the objects.other namespace, but we might move the class around, so... better safe than sorry!
   'Objects.BuiltElements.Revit.ProjectInfo',
   'Objects.BuiltElements.View',
   'Objects.BuiltElements.View3D'


### PR DESCRIPTION
Closes (for now!) [CNX-326: Frontend: clean the scene explorer](https://linear.app/speckle/issue/CNX-326/frontend-clean-the-scene-explorer).

tl;dr: we've been adding stuff to the object model, and the current filtering was not cutting it and made the whole scene explorer unusable in quite a few instances. 