### PR TITLE
fix(automate): corrected naming convention for `visualOverrides`: an as yet unused property on object result case

### DIFF
--- a/packages/shared/src/automate/helpers/types.ts
+++ b/packages/shared/src/automate/helpers/types.ts
@@ -36,7 +36,7 @@ export type ResultsSchema = {
           gradientValues?: Record<string, { gradientValue: number }>
         }
       >
-      visualoverrides: Nullable<Record<string, unknown>>
+      visualOverrides: Nullable<Record<string, unknown>>
     }>
     blobIds?: string[]
   }
@@ -157,7 +157,7 @@ export const formatResultsSchema = (state: UnformattedResultsSchema): ResultsSch
             throwInvalidError(`values.[${i}].objectResults.objectIds`),
           message: value.message || null,
           metadata: value.metadata || null,
-          visualoverrides: value.visualoverrides || null
+          visualOverrides: value.visualOverrides || null
         }
       }),
       blobIds: values.blobIds || undefined


### PR DESCRIPTION
Change `visualoverrrides` to `visualOverrides` for consistency.

`gradientValues` and `objectResults` are correct by convention. This removes potential confusion.
