### PR TITLE
Fix: z-index on project card

### DIFF
--- a/packages/frontend-2/components/project/page/models/Card.vue
+++ b/packages/frontend-2/components/project/page/models/Card.vue
@@ -170,7 +170,7 @@ const showActionsMenu = ref(false)
 
 const containerClasses = computed(() => {
   const classParts = [
-    'group rounded-xl bg-foundation border border-outline-3 hover:border-outline-5 w-full'
+    'group rounded-xl bg-foundation border border-outline-3 hover:border-outline-5 w-full z-[0]'
   ]
 
   if (versionCount.value > 0) {


### PR DESCRIPTION
This div has child elements that have a z-index set, but because it doesn't have a a z-index itself it was overflowing on other elements