### PR TITLE
fix(fe2): Update Chevron Rotation. Add Margin for items with icon

### DIFF
--- a/packages/ui-components/src/components/layout/sidebar/menu/group/Group.vue
+++ b/packages/ui-components/src/components/layout/sidebar/menu/group/Group.vue
@@ -6,7 +6,13 @@
         class="group flex space-x-1.5 items-center w-full hover:bg-foundation-3 rounded-md p-0.5"
         @click="isCollapsed = !isCollapsed"
       >
-        <ChevronDownIcon :class="isCollapsed ? 'rotate-180' : ''" class="h-2.5 w-2.5" />
+        <ChevronRightIcon
+          :class="[
+            isCollapsed ? '' : 'rotate-90',
+            collapsible && $slots['title-icon'] ? 'ml-6' : ''
+          ]"
+          class="h-2.5 w-2.5"
+        />
         <div
           v-if="$slots['title-icon']"
           class="h-5 w-5 flex items-center justify-center"
@@ -39,7 +45,7 @@
 </template>
 
 <script setup lang="ts">
-import { ChevronDownIcon } from '@heroicons/vue/24/outline'
+import { ChevronRightIcon } from '@heroicons/vue/24/outline'
 import { ref, onMounted } from 'vue'
 
 const props = defineProps<{


### PR DESCRIPTION
## Description & motivation
Fix the alignment issue in the settings sidebar. 
Fix the chevron so it rotates correctly