### PR TITLE
Add Plus CTA to SidebarGroup

### DIFF
--- a/packages/frontend-2/components/dashboard/Sidebar.vue
+++ b/packages/frontend-2/components/dashboard/Sidebar.vue
@@ -64,7 +64,7 @@
                     }
                   : undefined
               "
-              plus-text="Add workspace"
+              plus-text="Create workspace"
             >
               <NuxtLink :to="workspacesRoute">
                 <LayoutSidebarMenuGroupItem

--- a/packages/frontend-2/components/dashboard/Sidebar.vue
+++ b/packages/frontend-2/components/dashboard/Sidebar.vue
@@ -57,6 +57,14 @@
               v-if="isWorkspacesEnabled && workspacesItems.length"
               collapsible
               title="Workspaces"
+              :plus-click="
+                isUserAdmin
+                  ? () => {
+                      showWorkspaceCreateDialog = true
+                    }
+                  : undefined
+              "
+              plus-text="Add workspace"
             >
               <NuxtLink :to="workspacesRoute">
                 <LayoutSidebarMenuGroupItem
@@ -88,15 +96,6 @@
                   </template>
                 </LayoutSidebarMenuGroupItem>
               </NuxtLink>
-              <LayoutSidebarMenuGroupItem
-                v-if="isUserAdmin"
-                label="Add workspace"
-                @click="showWorkspaceCreateDialog = true"
-              >
-                <template #icon>
-                  <PlusIcon class="h-4 w-4 text-foreground-2" />
-                </template>
-              </LayoutSidebarMenuGroupItem>
             </LayoutSidebarMenuGroup>
 
             <LayoutSidebarMenuGroup title="Resources">
@@ -165,8 +164,7 @@ import {
   GlobeAltIcon,
   ClockIcon,
   Squares2X2Icon,
-  HomeIcon,
-  PlusIcon
+  HomeIcon
 } from '@heroicons/vue/24/outline'
 import {
   FormButton,
@@ -204,6 +202,7 @@ const isActive = (...routes: string[]): boolean => {
 }
 
 const isUserAdmin = computed(() => user.value?.role === 'server:admin')
+
 const workspacesItems = computed(() =>
   workspaceResult.value?.activeUser
     ? workspaceResult.value.activeUser.workspaces.items.map((workspace) => ({

--- a/packages/ui-components/src/components/layout/sidebar/menu/group/Group.vue
+++ b/packages/ui-components/src/components/layout/sidebar/menu/group/Group.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flex flex-col">
-    <div v-if="title" class="select-none mb-1">
+    <div v-if="title" class="flex items-center justify-between select-none mb-1">
       <button
         v-if="collapsible"
-        class="group flex space-x-1.5 items-center w-full hover:bg-foundation-3 rounded-md p-0.5"
+        class="group flex space-x-1.5 items-center w-full rounded-md p-0.5"
         @click="isCollapsed = !isCollapsed"
       >
         <ChevronRightIcon
@@ -36,6 +36,17 @@
           {{ title }}
         </h6>
       </div>
+      <FormButton
+        v-if="plusClick"
+        v-tippy="plusText ? plusText : undefined"
+        color="subtle"
+        size="sm"
+        hide-text
+        :icon-left="PlusIcon"
+        @click="plusClick"
+      >
+        {{ plusText }}
+      </FormButton>
     </div>
 
     <div
@@ -49,13 +60,16 @@
 </template>
 
 <script setup lang="ts">
-import { ChevronRightIcon } from '@heroicons/vue/24/outline'
+import { ChevronRightIcon, PlusIcon } from '@heroicons/vue/24/outline'
 import { ref, onMounted } from 'vue'
+import FormButton from '~~/src/components/form/Button.vue'
 
 const props = defineProps<{
   title?: string
   collapsible?: boolean
   collapsed?: boolean
+  plusText?: string
+  plusClick?: () => void
 }>()
 
 const isCollapsed = ref(true)


### PR DESCRIPTION
## Description & motivation
Move the "Add Workspace" button to the LayoutSidebarGroup, as per the designs. 

<img width="467" alt="image" src="https://github.com/user-attachments/assets/9baefdea-56cf-43f2-b519-ccee18c088b3">
