### PR TITLE
Fix(dui3): disable allow unset for settings dropdown

### DIFF
--- a/packages/dui3/components/form/json/EnumControlRenderer.vue
+++ b/packages/dui3/components/form/json/EnumControlRenderer.vue
@@ -7,6 +7,7 @@
     :items="control.options"
     :multiple="multiple"
     :help="control.description"
+    :allow-unset="false"
     show-label
     by="value"
     button-style="tinted"


### PR DESCRIPTION
It was unsetting it if we select the same item. Which we do not handle undefined behavior on any setting. So, disabled it for now.

Related to: https://linear.app/speckle/issue/CNX-380/revit-unset-settings-causes-dependency-error

![Revit_s8DyhXCw2K](https://github.com/user-attachments/assets/15093204-b652-46b9-bed8-49611348e981)
