### PR TITLE
Fix: Disable removing of last domain if policy is on

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/Security.vue
+++ b/packages/frontend-2/components/settings/workspaces/Security.vue
@@ -305,4 +305,13 @@ const openRemoveDialog = (
   removeDialogDomain.value = domain
   showRemoveDomainDialog.value = true
 }
+
+watch(
+  () => workspaceDomains.value,
+  () => {
+    if (!hasWorkspaceDomains.value) {
+      isDomainDiscoverabilityEnabled.value = false
+    }
+  }
+)
 </script>

--- a/packages/frontend-2/components/settings/workspaces/Security.vue
+++ b/packages/frontend-2/components/settings/workspaces/Security.vue
@@ -7,14 +7,19 @@
       />
       <section>
         <SettingsSectionHeader title="Your domains" class="pb-4 md:pb-6" subheading />
-        <ul v-if="workspaceDomains.length > 0">
+        <ul v-if="hasWorkspaceDomains">
           <li
             v-for="domain in workspaceDomains"
             :key="domain.id"
             class="border-x border-b first:border-t first:rounded-t-lg last:rounded-b-lg p-6 py-4 flex items-center"
           >
             <p class="text-body-xs font-medium flex-1">@{{ domain.domain }}</p>
-            <FormButton color="outline" size="sm" @click="openRemoveDialog(domain)">
+            <FormButton
+              :disabled="workspaceDomains.length === 1 && isDomainProtectionEnabled"
+              color="outline"
+              size="sm"
+              @click="openRemoveDialog(domain)"
+            >
               Delete
             </FormButton>
           </li>
@@ -67,6 +72,7 @@
             <FormSwitch
               v-model="isDomainProtectionEnabled"
               :show-label="false"
+              :disabled="!hasWorkspaceDomains"
               name="domain-protection"
             />
           </div>
@@ -83,6 +89,7 @@
             <FormSwitch
               v-model="isDomainDiscoverabilityEnabled"
               name="domain-discoverability"
+              :disabled="!hasWorkspaceDomains"
               :show-label="false"
             />
           </div>
@@ -155,6 +162,7 @@ const { result } = useQuery(settingsWorkspacesSecurityQuery, {
 const workspaceDomains = computed(() => {
   return result.value?.workspace.domains || []
 })
+const hasWorkspaceDomains = computed(() => workspaceDomains.value.length > 0)
 
 const verifiedUserDomains = computed(() => {
   const workspaceDomainSet = new Set(workspaceDomains.value.map((item) => item.domain))


### PR DESCRIPTION
Following https://linear.app/speckle/issue/WEB-1744/turning-on-domain-based-membership-policy-when-the-workspace-has-no

- Disable toggles when domainlist is empty
- Dont allow removal of last domain if policy is enabled
- Make sure domain discovery is turned off when the last domain is removed