### PR TITLE
feat(fe2): Add workspace to breadcrumbs

### DIFF
--- a/packages/frontend-2/components/project/page/Header.vue
+++ b/packages/frontend-2/components/project/page/Header.vue
@@ -1,11 +1,24 @@
 <template>
   <div>
     <Portal to="navigation">
+      <template v-if="project.workspace && isWorkspacesEnabled">
+        <HeaderNavLink
+          :to="workspacesRoute"
+          name="Workspaces"
+          :separator="false"
+        ></HeaderNavLink>
+        <HeaderNavLink
+          :to="workspaceRoute(project.workspace.id)"
+          :name="project.workspace.name"
+        ></HeaderNavLink>
+      </template>
       <HeaderNavLink
+        v-else
         :to="projectsRoute"
         name="Projects"
         :separator="false"
       ></HeaderNavLink>
+
       <HeaderNavLink
         :to="projectRoute(project.id)"
         :name="project.name"
@@ -34,7 +47,7 @@
 import { graphql } from '~~/lib/common/generated/gql'
 import type { ProjectPageProjectHeaderFragment } from '~~/lib/common/generated/gql/graphql'
 import { projectRoute, projectsRoute } from '~~/lib/common/helpers/route'
-import { workspaceRoute } from '~/lib/common/helpers/route'
+import { workspaceRoute, workspacesRoute } from '~/lib/common/helpers/route'
 
 graphql(`
   fragment ProjectPageProjectHeader on Project {


### PR DESCRIPTION
If a project is in a workspace, we should show the breadcrumbs as:
/workspaces/WorkspaceName/ProjectName

If it's not in a workspace, it should be:
/projects/ProjectName

<img width="1120" alt="image" src="https://github.com/user-attachments/assets/8f626474-44ba-4f12-bcb0-29b6a97122f1">