### PR TITLE
fix(fe2): Update WorkspaceProtectedError

### DIFF
--- a/packages/server/modules/workspaces/services/invites.ts
+++ b/packages/server/modules/workspaces/services/invites.ts
@@ -216,7 +216,7 @@ export const collectAndValidateWorkspaceTargetsFactory =
           })
         )
           throw new WorkspaceProtectedError(
-            'The target email is not matching the domain policies'
+            'The invited email does not match the domain policies'
           )
       }
     }


### PR DESCRIPTION
Slight copy change, based on feedback from Iain
https://linear.app/speckle/issue/WEB-1757/error-copy-the-target-email-is-not-matching-the-domain-policies