### PR TITLE
fix(fe2): Don't trigger shortcuts while typing comments

### DIFF
--- a/packages/frontend-2/components/viewer/Controls.vue
+++ b/packages/frontend-2/components/viewer/Controls.vue
@@ -422,10 +422,14 @@ const measureShortcut = ref(
   `Measure mode ${getShortcutTitle(ViewerKeyboardActions.ToggleMeasurements)}`
 )
 
-const isTyping = computed(() => ui.threads.openThread.isTyping.value)
+const isTypingComment = computed(() => {
+  const isNewThreadEditorOpen = ui.threads.openThread.newThreadEditor.value
+  const isExistingThreadEditorOpen = !!ui.threads.openThread.thread.value
+  return isNewThreadEditorOpen || isExistingThreadEditorOpen
+})
 
 const handleKeyboardAction = (action: ViewerKeyboardActions) => {
-  if (isTyping.value) {
+  if (isTypingComment.value) {
     return
   }
   switch (action) {

--- a/packages/frontend-2/components/viewer/Controls.vue
+++ b/packages/frontend-2/components/viewer/Controls.vue
@@ -264,7 +264,8 @@ import {
 } from '@speckle/ui-components'
 import {
   useInjectedViewerLoadedResources,
-  useInjectedViewerInterfaceState
+  useInjectedViewerInterfaceState,
+  useInjectedViewerState
 } from '~~/lib/viewer/composables/setup'
 import { useMixpanel } from '~~/lib/core/composables/mp'
 
@@ -356,6 +357,8 @@ const {
   camera: { isOrthoProjection }
 } = useCameraUtilities()
 
+const { ui } = useInjectedViewerState()
+
 const breakpoints = useBreakpoints(TailwindBreakpoints)
 const isMobile = breakpoints.smaller('sm')
 
@@ -419,7 +422,12 @@ const measureShortcut = ref(
   `Measure mode ${getShortcutTitle(ViewerKeyboardActions.ToggleMeasurements)}`
 )
 
+const isTyping = computed(() => ui.threads.openThread.isTyping.value)
+
 const handleKeyboardAction = (action: ViewerKeyboardActions) => {
+  if (isTyping.value) {
+    return
+  }
   switch (action) {
     case ViewerKeyboardActions.ToggleModels:
       toggleActiveControl('models')


### PR DESCRIPTION
## Description & motivation
Currently, when typing a comment, you can accidentally trigger the sidebar shortcuts. 

Now, we check if the user is typing a comment before we execute the shortcut action. 