### PR TITLE
fix(workspaces): explain project role changes on workspace role change

### DIFF
--- a/packages/frontend-2/components/settings/shared/ChangeRoleDialog.vue
+++ b/packages/frontend-2/components/settings/shared/ChangeRoleDialog.vue
@@ -12,6 +12,14 @@
           <ArrowRightIcon class="h-4 w-4" />
           <span>{{ getRoleLabel(newRole).title }}</span>
         </div>
+        <div class="flex flex-col items-start gap-1 text-xs">
+          <div
+            v-for="(message, i) in getWorkspaceProjectRoleMessages(newRole)"
+            :key="`message-${i}`"
+          >
+            {{ message }}
+          </div>
+        </div>
       </div>
     </div>
   </LayoutDialog>
@@ -19,7 +27,7 @@
 
 <script setup lang="ts">
 import type { LayoutDialogButton } from '@speckle/ui-components'
-import type { WorkspaceRoles } from '@speckle/shared'
+import { Roles, type WorkspaceRoles } from '@speckle/shared'
 import { ArrowRightIcon } from '@heroicons/vue/24/outline'
 import { getRoleLabel } from '~~/lib/settings/helpers/utils'
 
@@ -49,4 +57,32 @@ const dialogButtons = computed((): LayoutDialogButton[] => [
     }
   }
 ])
+
+const getWorkspaceProjectRoleMessages = (workspaceRole: WorkspaceRoles): string[] => {
+  switch (workspaceRole) {
+    case Roles.Workspace.Admin: {
+      return [
+        'They will become a project owner for all existing workspace projects.',
+        'They will become a project owner for new projects created in the workspace.',
+        'Project owners will not be able to change their workspace project role.',
+        'Project owners will not be able to remove them from workspace projects.'
+      ]
+    }
+    case Roles.Workspace.Member: {
+      return [
+        'They will become a project viewer for all existing workspace projects.',
+        'They will become a project viewer for new projects created in the workspace.',
+        'Project owners will be able to grant them any role for workspace projects.',
+        'Project owners will be able to remove them from workspace projects.'
+      ]
+    }
+    case Roles.Workspace.Guest: {
+      return [
+        'They will lose access to all existing workspace projects.',
+        'Project owners will be able to grant them any role for workspace projects.',
+        'Project owners will be able to remove them from workspace projects.'
+      ]
+    }
+  }
+}
 </script>


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Workspace role changes have implications for the user's roles in existing and future workspace projects
- This should be explained before the change happens

## Changes:

Adds explanations (verbiage pending review):

![Screen Shot 2024-08-31 at 22 22 57](https://github.com/user-attachments/assets/584e20a7-8c10-4bef-b0cf-d123794cf5b6)

![Screen Shot 2024-08-31 at 22 22 48](https://github.com/user-attachments/assets/53fee6f0-5dd9-4fe3-b4a3-43bdc2558cb0)

![Screen Shot 2024-08-31 at 22 22 18](https://github.com/user-attachments/assets/92a4ce3e-5936-479b-a488-8d909c927fc7)