### PR TITLE
fix(fe2): Redirect to home on deletion of workspace if on the deleted workspace url

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/General/DeleteDialog.vue
+++ b/packages/frontend-2/components/settings/workspaces/General/DeleteDialog.vue
@@ -42,7 +42,7 @@ import { ToastNotificationType, useGlobalToast } from '~~/lib/common/composables
 import { useActiveUser } from '~~/lib/auth/composables/activeUser'
 import { isUndefined } from 'lodash-es'
 import { useMixpanel } from '~/lib/core/composables/mp'
-import { homeRoute, workspaceRoute } from '~/lib/common/helpers/route'
+import { homeRoute } from '~/lib/common/helpers/route'
 
 graphql(`
   fragment SettingsWorkspaceGeneralDeleteDialog_Workspace on Workspace {
@@ -60,12 +60,12 @@ const isOpen = defineModel<boolean>('open', { required: true })
 const { mutate: deleteWorkspace } = useMutation(deleteWorkspaceMutation)
 const { triggerNotification } = useGlobalToast()
 const { activeUser } = useActiveUser()
-const route = useRoute()
 const router = useRouter()
 const apollo = useApolloClient().client
 const mixpanel = useMixpanel()
 
 const onDelete = async () => {
+  router.push(homeRoute)
   isOpen.value = false
 
   const cache = apollo.cache
@@ -96,11 +96,6 @@ const onDelete = async () => {
         },
         { fieldNameWhitelist: ['workspaces'] }
       )
-    }
-
-    const currentWorkspaceUrl = workspaceRoute(props.workspace.id)
-    if (route.path === currentWorkspaceUrl) {
-      router.push(homeRoute)
     }
 
     triggerNotification({

--- a/packages/frontend-2/components/settings/workspaces/General/DeleteDialog.vue
+++ b/packages/frontend-2/components/settings/workspaces/General/DeleteDialog.vue
@@ -42,6 +42,7 @@ import { ToastNotificationType, useGlobalToast } from '~~/lib/common/composables
 import { useActiveUser } from '~~/lib/auth/composables/activeUser'
 import { isUndefined } from 'lodash-es'
 import { useMixpanel } from '~/lib/core/composables/mp'
+import { homeRoute, workspaceRoute } from '~/lib/common/helpers/route'
 
 graphql(`
   fragment SettingsWorkspaceGeneralDeleteDialog_Workspace on Workspace {
@@ -59,6 +60,8 @@ const isOpen = defineModel<boolean>('open', { required: true })
 const { mutate: deleteWorkspace } = useMutation(deleteWorkspaceMutation)
 const { triggerNotification } = useGlobalToast()
 const { activeUser } = useActiveUser()
+const route = useRoute()
+const router = useRouter()
 const apollo = useApolloClient().client
 const mixpanel = useMixpanel()
 
@@ -93,6 +96,11 @@ const onDelete = async () => {
         },
         { fieldNameWhitelist: ['workspaces'] }
       )
+    }
+
+    const currentWorkspaceUrl = workspaceRoute(props.workspace.id)
+    if (route.path === currentWorkspaceUrl) {
+      router.push(homeRoute)
     }
 
     triggerNotification({


### PR DESCRIPTION
We had a problem where when you deleted a workspace from the settings dialog, you would still be on the deleted workspace's url. 

This caused the breadcrumbs to break, and made no sense. 

Now, if you are on the url of the workspace you just deleted, you will be redirected to the homeRoute. 