### PR TITLE
fix(ui-components): Add border to LayoutMenu

### DIFF
--- a/packages/ui-components/src/components/layout/Menu.vue
+++ b/packages/ui-components/src/components/layout/Menu.vue
@@ -12,7 +12,7 @@
         v-if="isMenuOpen"
         ref="menuItems"
         :class="[
-          'absolute mt-1 w-44 origin-top-right divide-y divide-outline-3 rounded-md bg-foundation shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-50',
+          'absolute mt-1 w-44 origin-top-right divide-y divide-outline-3 rounded-md bg-foundation shadow-lg border border-outline-2 z-50',
           menuDirection === HorizontalDirection.Left ? 'right-0' : ''
         ]"
         :style="menuItemsStyles"


### PR DESCRIPTION
I also removed the ring classes. Not sure that they were actually doing anything, but it's not in designs. 

<img width="322" alt="image" src="https://github.com/user-attachments/assets/1129210e-6431-490e-a0a9-1b8502a18047">
