### PR TITLE
fix(ui-components) Update LayoutMenu disabled states

### DIFF
--- a/packages/frontend-2/components/project/page/models/Actions.vue
+++ b/packages/frontend-2/components/project/page/models/Actions.vue
@@ -104,12 +104,14 @@ const actionsItems = computed<LayoutMenuItem[][]>(() => [
           {
             title: 'Edit...',
             id: ActionTypes.Rename,
-            disabled: !props.canEdit
+            disabled: !props.canEdit,
+            disabledTooltip: 'Insufficient permissions'
           },
           {
             title: 'Upload new version...',
             id: ActionTypes.UploadVersion,
-            disabled: !props.canEdit
+            disabled: !props.canEdit,
+            disabledTooltip: 'Insufficient permissions'
           }
         ]
       ]
@@ -125,7 +127,8 @@ const actionsItems = computed<LayoutMenuItem[][]>(() => [
           {
             title: 'Delete...',
             id: ActionTypes.Delete,
-            disabled: isMain.value || !props.canEdit
+            disabled: isMain.value || !props.canEdit,
+            disabledTooltip: 'Insufficient permissions'
           }
         ]
       ]

--- a/packages/ui-components/src/components/layout/Menu.vue
+++ b/packages/ui-components/src/components/layout/Menu.vue
@@ -126,7 +126,7 @@ const buildButtonClassses = (params: {
   if (active && !color) {
     classParts.push('bg-primary-muted text-foreground')
   } else if (disabled) {
-    classParts.push('text-foreground-disabled')
+    classParts.push('opacity-50')
   } else if (color === 'danger' && active) {
     classParts.push('text-foreground-on-primary bg-danger')
   } else if (color === 'danger' && !active) {

--- a/packages/ui-components/src/components/layout/Menu.vue
+++ b/packages/ui-components/src/components/layout/Menu.vue
@@ -126,7 +126,7 @@ const buildButtonClassses = (params: {
   if (active && !color) {
     classParts.push('bg-primary-muted text-foreground')
   } else if (disabled) {
-    classParts.push('opacity-50')
+    classParts.push('opacity-40')
   } else if (color === 'danger' && active) {
     classParts.push('text-foreground-on-primary bg-danger')
   } else if (color === 'danger' && !active) {


### PR DESCRIPTION
When an item in the Model card actions is disabled, we do not give an indication of this in the UI. 

We should also add tooltip text explaining why it is disabled.

![image](https://github.com/user-attachments/assets/09244c03-401b-41ba-81ec-8123dc7f2a88)
