### PR TITLE
fix(fe2): Update cache after removing workspace members

### DIFF
--- a/packages/frontend-2/lib/workspaces/composables/management.ts
+++ b/packages/frontend-2/lib/workspaces/composables/management.ts
@@ -414,7 +414,22 @@ export const useWorkspaceUpdateRole = () => {
   const { triggerNotification } = useGlobalToast()
 
   return async (input: WorkspaceRoleUpdateInput) => {
-    const result = await mutate({ input }).catch(convertThrowIntoFetchResult)
+    const result = await mutate(
+      { input },
+      {
+        update: (cache) => {
+          if (!input.role) {
+            // If role is null, we're removing the user
+            modifyObjectField(
+              cache,
+              getCacheId('Workspace', input.workspaceId),
+              'team',
+              ({ helpers: { evict } }) => evict()
+            )
+          }
+        }
+      }
+    ).catch(convertThrowIntoFetchResult)
 
     if (result?.data) {
       triggerNotification({

--- a/packages/frontend-2/lib/workspaces/composables/management.ts
+++ b/packages/frontend-2/lib/workspaces/composables/management.ts
@@ -419,10 +419,26 @@ export const useWorkspaceUpdateRole = () => {
       {
         update: (cache) => {
           if (!input.role) {
-            // If role is null, we're removing the user
             cache.evict({
               id: getCacheId('WorkspaceCollaborator', input.userId)
             })
+
+            modifyObjectField(
+              cache,
+              getCacheId('Workspace', input.workspaceId),
+              'team',
+              ({ value }) => {
+                if (value.totalCount) {
+                  return {
+                    ...value,
+                    totalCount: value.totalCount - 1
+                  }
+                }
+              },
+              {
+                autoEvictFiltered: true
+              }
+            )
           }
         }
       }

--- a/packages/frontend-2/lib/workspaces/composables/management.ts
+++ b/packages/frontend-2/lib/workspaces/composables/management.ts
@@ -419,12 +419,15 @@ export const useWorkspaceUpdateRole = () => {
       {
         update: (cache) => {
           if (!input.role) {
-            // If role is null, we're removing the user
             modifyObjectField(
               cache,
               getCacheId('Workspace', input.workspaceId),
               'team',
-              ({ helpers: { evict } }) => evict()
+              () => {
+                cache.evict({
+                  id: getCacheId('WorkspaceCollaborator', input.userId)
+                })
+              }
             )
           }
         }

--- a/packages/frontend-2/lib/workspaces/composables/management.ts
+++ b/packages/frontend-2/lib/workspaces/composables/management.ts
@@ -427,13 +427,10 @@ export const useWorkspaceUpdateRole = () => {
               cache,
               getCacheId('Workspace', input.workspaceId),
               'team',
-              ({ value }) => {
-                if (value.totalCount) {
-                  return {
-                    ...value,
-                    totalCount: value.totalCount - 1
-                  }
-                }
+              ({ helpers: { createUpdatedValue } }) => {
+                return createUpdatedValue(({ update }) => {
+                  update('totalCount', (totalCount) => totalCount - 1)
+                })
               },
               {
                 autoEvictFiltered: true

--- a/packages/frontend-2/lib/workspaces/composables/management.ts
+++ b/packages/frontend-2/lib/workspaces/composables/management.ts
@@ -419,16 +419,10 @@ export const useWorkspaceUpdateRole = () => {
       {
         update: (cache) => {
           if (!input.role) {
-            modifyObjectField(
-              cache,
-              getCacheId('Workspace', input.workspaceId),
-              'team',
-              () => {
-                cache.evict({
-                  id: getCacheId('WorkspaceCollaborator', input.userId)
-                })
-              }
-            )
+            // If role is null, we're removing the user
+            cache.evict({
+              id: getCacheId('WorkspaceCollaborator', input.userId)
+            })
           }
         }
       }


### PR DESCRIPTION
Use the new modifyObjectField to update the cache, when a user has had their role set to null (removed). 