### PR TITLE
fix(workspaces): fix leaky search

### DIFF
--- a/packages/server/modules/workspaces/repositories/workspaces.ts
+++ b/packages/server/modules/workspaces/repositories/workspaces.ts
@@ -248,9 +248,11 @@ export const getWorkspaceCollaboratorsFactory =
     const { search, role } = filter || {}
 
     if (search) {
-      query
-        .where(Users.col.name, 'ILIKE', `%${search}%`)
-        .orWhere(Users.col.email, 'ILIKE', `%${search}%`)
+      query.andWhere((builder) => {
+        builder
+          .where(Users.col.name, 'ILIKE', `%${search}%`)
+          .orWhere(Users.col.email, 'ILIKE', `%${search}%`)
+      })
     }
 
     if (role) {


### PR DESCRIPTION
## Changes:

- Fix `orWhere()` clause to limit workspace team searches to intended limit
