### PR TITLE
Feat: Added server_id to workspace mixpanel profile

### DIFF
--- a/packages/frontend-2/lib/workspaces/composables/mixpanel.ts
+++ b/packages/frontend-2/lib/workspaces/composables/mixpanel.ts
@@ -41,11 +41,6 @@ graphql(`
 
 export const useWorkspacesMixpanel = () => {
   const mixpanel = useMixpanel()
-  const serverId = ref<string>()
-
-  if (import.meta.client) {
-    serverId.value = resolveMixpanelServerId(window.location.hostname)
-  }
 
   const workspaceMixpanelUpdateGroup = (
     workspace: WorkspaceMixpanelUpdateGroup_WorkspaceFragment
@@ -78,7 +73,7 @@ export const useWorkspacesMixpanel = () => {
       teamMemberCount: roleCount[Roles.Workspace.Member],
       teamGuestCount: roleCount[Roles.Workspace.Guest],
       // eslint-disable-next-line camelcase
-      server_id: serverId.value
+      server_id: resolveMixpanelServerId(window.location.hostname)
     })
   }
 

--- a/packages/frontend-2/lib/workspaces/composables/mixpanel.ts
+++ b/packages/frontend-2/lib/workspaces/composables/mixpanel.ts
@@ -59,21 +59,31 @@ export const useWorkspacesMixpanel = () => {
       }
     )
 
-    mixpanel.get_group('workspace_id', workspace.id).set({
+    const input = {
       name: workspace.name,
       description: workspace.description,
       domainBasedMembershipProtectionEnabled:
         workspace.domainBasedMembershipProtectionEnabled,
       discoverabilityEnabled: workspace.discoverabilityEnabled,
-      costTotal: workspace.billing?.cost.total,
-      versionsCountCurrent: workspace.billing?.versionsCount.current,
-      versionsCountMax: workspace.billing?.versionsCount.max,
       teamTotalCount: workspace.team.totalCount,
       teamAdminCount: roleCount[Roles.Workspace.Admin],
       teamMemberCount: roleCount[Roles.Workspace.Member],
       teamGuestCount: roleCount[Roles.Workspace.Guest],
       // eslint-disable-next-line camelcase
       server_id: resolveMixpanelServerId(window.location.hostname)
+    }
+
+    const billingInput = workspace.billing
+      ? {
+          costTotal: workspace.billing.cost.total,
+          versionsCountCurrent: workspace.billing.versionsCount.current,
+          versionsCountMax: workspace.billing.versionsCount.max
+        }
+      : {}
+
+    mixpanel.get_group('workspace_id', workspace.id).set({
+      ...input,
+      ...billingInput
     })
   }
 


### PR DESCRIPTION
- Add server_id to mixpanel workspace group
- Only include billing properties exist, this is done because when guests fetch this the value is `null` and this potentially overrides already existing values in Mixpanel with `null`