### PR TITLE
Fix: Associate user with mixpanel group on creation and dashboard open

### DIFF
--- a/packages/frontend-2/lib/workspaces/composables/management.ts
+++ b/packages/frontend-2/lib/workspaces/composables/management.ts
@@ -394,6 +394,8 @@ export function useCreateWorkspace() {
         workspace_id: res.data?.workspaceMutations.create.id
       })
 
+      mixpanel.add_group('workspace_id', res.data?.workspaceMutations.create.id)
+
       triggerNotification({
         type: ToastNotificationType.Success,
         title: 'Workspace successfully created'

--- a/packages/frontend-2/lib/workspaces/composables/mixpanel.ts
+++ b/packages/frontend-2/lib/workspaces/composables/mixpanel.ts
@@ -80,7 +80,10 @@ export const useWorkspacesMixpanel = () => {
       })
     }
 
+    // Update all group properties
     mixpanel.get_group('workspace_id', workspace.id).set(input)
+    // Ensure the user is matched to the group
+    mixpanel.add_group('workspace_id', workspace.id)
   }
 
   return {


### PR DESCRIPTION
This will ensure every user is added to the mixpanel group