### PR TITLE
fix(fe2): Project page - only show role tag if you have a role

### DIFF
--- a/packages/frontend-2/pages/projects/[id]/index.vue
+++ b/packages/frontend-2/pages/projects/[id]/index.vue
@@ -18,7 +18,11 @@
                 project.modelCount.totalCount === 1 ? '' : 's'
               }}
             </CommonBadge>
-            <CommonBadge rounded :color-classes="'text-foreground-2 bg-primary-muted'">
+            <CommonBadge
+              v-if="project.role"
+              rounded
+              :color-classes="'text-foreground-2 bg-primary-muted'"
+            >
               <span class="capitalize">
                 {{ project.role?.split(':').reverse()[0] }}
               </span>


### PR DESCRIPTION
Bug noticed on a call with Michal. When you are on a discoverable project, with no role, it displays an empty tag.
<img width="616" alt="image" src="https://github.com/user-attachments/assets/7a7773d0-53ab-4de3-9e12-eb0cbea64dc9">