### PR TITLE
fix(fe2): Add 'just now' to isTimeframe check to prevent "Created on just now"

### DIFF
--- a/packages/frontend-2/utils/dateFormatter.ts
+++ b/packages/frontend-2/utils/dateFormatter.ts
@@ -41,7 +41,8 @@ const isTimeframe = (date: ConfigType) => {
     unit.includes('second') ||
     unit.includes('minute') ||
     unit.includes('hour') ||
-    unit.includes('day')
+    unit.includes('day') ||
+    unit.includes('just now')
   )
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ce7aac62-1f07-4b47-8aa4-e70ab5bf9ca0)