### PR TITLE
Feat(dui3): CNX-401 bad ux settings vs selection and minors

### DIFF
--- a/packages/dui3/components/filter/Selection.vue
+++ b/packages/dui3/components/filter/Selection.vue
@@ -3,7 +3,7 @@
     <div v-if="selectionStore.selectionInfo.selectedObjectIds?.length === 0">
       No objects selected, go ahead and select some!
     </div>
-    <div v-else>{{ selectionStore.selectionInfo.summary }}.</div>
+    <div v-else>{{ selectionStore.selectionInfo.summary }}</div>
   </div>
 </template>
 <script setup lang="ts">

--- a/packages/dui3/components/model/ActionsDialog.vue
+++ b/packages/dui3/components/model/ActionsDialog.vue
@@ -13,7 +13,7 @@
     >
       <div class="-mx-1">
         <SendSettingsDialog
-          v-if="isSender"
+          v-if="hasSettings"
           :model-card-id="props.modelCard.modelCardId"
           :settings="props.modelCard.settings"
         >
@@ -68,8 +68,8 @@ const props = defineProps<{
   modelCard: IModelCard
 }>()
 
-const isSender = computed(() => {
-  return props.modelCard.typeDiscriminator === 'SenderModelCard'
+const hasSettings = computed(() => {
+  return !!props.modelCard.settings
 })
 
 const app = useNuxtApp()

--- a/packages/dui3/components/model/ActionsDialog.vue
+++ b/packages/dui3/components/model/ActionsDialog.vue
@@ -12,6 +12,18 @@
       fullscreen="none"
     >
       <div class="-mx-1">
+        <SendSettingsDialog
+          v-if="isSender"
+          :model-card-id="props.modelCard.modelCardId"
+          :settings="props.modelCard.settings"
+        >
+          <template #activator="{ toggle }">
+            <button class="action action-normal" @click="toggle()">
+              <div class="truncate max-[275px]:text-xs">Settings</div>
+              <div><Cog6ToothIcon class="w-5 h-5" /></div>
+            </button>
+          </template>
+        </SendSettingsDialog>
         <ReportBase v-if="modelCard.report" :report="modelCard.report">
           <template #activator="{ toggle }">
             <button class="action action-normal" @click="toggle()">
@@ -51,10 +63,14 @@ const { trackEvent } = useMixpanel()
 const openModelCardActionsDialog = ref(false)
 const emit = defineEmits(['view', 'view-versions', 'copy-model-link', 'remove'])
 
-defineProps<{
+const props = defineProps<{
   modelName: string
   modelCard: IModelCard
 }>()
+
+const isSender = computed(() => {
+  return props.modelCard.typeDiscriminator === 'SenderModelCard'
+})
 
 const app = useNuxtApp()
 app.$baseBinding.on('documentChanged', () => {

--- a/packages/dui3/components/model/Sender.vue
+++ b/packages/dui3/components/model/Sender.vue
@@ -57,11 +57,11 @@
       fullscreen="none"
     >
       <FilterListSelect :filter="modelCard.sendFilter" @update:filter="updateFilter" />
-      <SendSettings
+      <!-- <SendSettings
         v-if="hasSendSettings"
         :settings="modelCard.settings"
         @update:settings="updateSettings"
-      ></SendSettings>
+      ></SendSettings> -->
       <div class="mt-2 flex">
         <!-- TODO: Ux wise, users might want to just save the selection and publish it later. -->
         <!-- <FormButton text @click.stop=";(openFilterDialog = false), saveFilter()">
@@ -108,7 +108,6 @@ import type { ISendFilter, ISenderModelCard } from '~/lib/models/card/send'
 import type { ProjectModelGroup } from '~/store/hostApp'
 import { useHostAppStore } from '~/store/hostApp'
 import { useMixpanel } from '~/lib/core/composables/mixpanel'
-import type { CardSetting } from '~/lib/models/card/setting'
 
 const { trackEvent } = useMixpanel()
 const app = useNuxtApp()
@@ -139,14 +138,6 @@ const updateFilter = (filter: ISendFilter) => {
   newFilter = filter
 }
 
-let newSettings: CardSetting[]
-const updateSettings = (settings: CardSetting[]) => {
-  newSettings = settings
-}
-
-const hasSendSettings = computed(
-  () => store.sendSettings && store.sendSettings?.length > 0
-)
 const saveFilter = async () => {
   void trackEvent('DUI3 Action', {
     name: 'Publish Card Filter Change',
@@ -154,7 +145,6 @@ const saveFilter = async () => {
   })
   await store.patchModel(props.modelCard.modelCardId, {
     sendFilter: newFilter,
-    settings: newSettings,
     expired: true
   })
 }

--- a/packages/dui3/components/model/Sender.vue
+++ b/packages/dui3/components/model/Sender.vue
@@ -64,13 +64,8 @@
       ></SendSettings> -->
       <div class="mt-4 flex justify-center items-center space-x-2">
         <!-- TODO: Ux wise, users might want to just save the selection and publish it later. -->
-        <FormButton size="sm" @click.stop=";(openFilterDialog = false), saveFilter()">
-          Save
-        </FormButton>
-        <FormButton
-          size="sm"
-          @click.stop=";(openFilterDialog = false), saveFilterAndSend()"
-        >
+        <FormButton size="sm" @click.stop="saveFilter()">Save</FormButton>
+        <FormButton size="sm" @click.stop="saveFilterAndSend()">
           Save & Publish
         </FormButton>
       </div>
@@ -147,6 +142,7 @@ const saveFilter = async () => {
     sendFilter: newFilter,
     expired: true
   })
+  openFilterDialog.value = false
 }
 
 const hover = ref(false)

--- a/packages/dui3/components/model/Sender.vue
+++ b/packages/dui3/components/model/Sender.vue
@@ -62,13 +62,13 @@
         :settings="modelCard.settings"
         @update:settings="updateSettings"
       ></SendSettings> -->
-      <div class="mt-2 flex">
+      <div class="mt-4 flex justify-center items-center space-x-2">
         <!-- TODO: Ux wise, users might want to just save the selection and publish it later. -->
-        <!-- <FormButton text @click.stop=";(openFilterDialog = false), saveFilter()">
-              Save
-            </FormButton> -->
+        <FormButton size="sm" @click.stop=";(openFilterDialog = false), saveFilter()">
+          Save
+        </FormButton>
         <FormButton
-          full-width
+          size="sm"
           @click.stop=";(openFilterDialog = false), saveFilterAndSend()"
         >
           Save & Publish

--- a/packages/dui3/components/model/Sender.vue
+++ b/packages/dui3/components/model/Sender.vue
@@ -160,7 +160,7 @@ const expiredNotification = computed(() => {
   notification.level = props.modelCard.progress ? 'warning' : 'info'
   notification.text = props.modelCard.progress
     ? 'Model was changed while publishing'
-    : 'Model is out of sync with application.'
+    : 'Out of sync with application'
 
   const ctaType = props.modelCard.progress ? 'Restart' : 'Update'
   notification.cta = {

--- a/packages/dui3/components/model/Sender.vue
+++ b/packages/dui3/components/model/Sender.vue
@@ -62,9 +62,11 @@
         :settings="modelCard.settings"
         @update:settings="updateSettings"
       ></SendSettings> -->
-      <div class="mt-4 flex justify-center items-center space-x-2">
+      <div class="mt-4 flex justify-end items-center space-x-2">
         <!-- TODO: Ux wise, users might want to just save the selection and publish it later. -->
-        <FormButton size="sm" @click.stop="saveFilter()">Save</FormButton>
+        <FormButton size="sm" color="outline" @click.stop="saveFilter()">
+          Save
+        </FormButton>
         <FormButton size="sm" @click.stop="saveFilterAndSend()">
           Save & Publish
         </FormButton>

--- a/packages/dui3/components/send/FiltersAndSettings.vue
+++ b/packages/dui3/components/send/FiltersAndSettings.vue
@@ -3,6 +3,7 @@
     <FilterListSelect @update:filter="updateFilter" />
     <SendSettings
       v-if="hasSendSettings"
+      expandable
       @update:settings="updateSettings"
     ></SendSettings>
   </div>

--- a/packages/dui3/components/send/Settings.vue
+++ b/packages/dui3/components/send/Settings.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="p-0">
     <button
+      v-if="expandable"
       class="flex w-full items-center text-foreground-2 justify-between hover:bg-blue-500/10 rounded-md transition group"
       @click="showSettings = !showSettings"
     >
@@ -31,6 +32,7 @@ import { useHostAppStore } from '~/store/hostApp'
 
 const props = defineProps<{
   settings?: CardSetting[]
+  expandable: boolean
 }>()
 
 const emit = defineEmits<{ (e: 'update:settings', value: CardSetting[]): void }>()
@@ -42,7 +44,7 @@ const sendSettings = ref<CardSetting[] | undefined>(
   cloneDeep(props.settings ?? defaultSendSettings.value) // need to prevent mutation!
 )
 
-const showSettings = ref(false)
+const showSettings = ref(!props.expandable)
 
 const settingsJsonForms = computed(() => {
   if (sendSettings.value === undefined) return {}

--- a/packages/dui3/components/send/SettingsDialog.vue
+++ b/packages/dui3/components/send/SettingsDialog.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="p-0">
+    <slot name="activator" :toggle="toggleDialog"></slot>
+    <LayoutDialog
+      v-model:open="showSettingsDialog"
+      :title="`Settings`"
+      fullscreen="none"
+    >
+      <SendSettings
+        :expandable="false"
+        :settings="props.settings"
+        @update:settings="updateSettings"
+      ></SendSettings>
+      <div class="mt-4 flex justify-center items-center space-x-2">
+        <FormButton size="sm" text @click="showSettingsDialog = false">
+          Cancel
+        </FormButton>
+        <FormButton size="sm" @click="saveSettings()">Save</FormButton>
+      </div>
+    </LayoutDialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useHostAppStore } from '~/store/hostApp'
+import type { CardSetting } from '~/lib/models/card/setting'
+
+const { trackEvent } = useMixpanel()
+
+const props = defineProps<{
+  settings?: CardSetting[]
+  modelCardId: string
+}>()
+
+const store = useHostAppStore()
+
+const showSettingsDialog = ref(false)
+
+const toggleDialog = () => {
+  showSettingsDialog.value = !showSettingsDialog.value
+}
+
+let newSettings: CardSetting[]
+const updateSettings = (settings: CardSetting[]) => {
+  newSettings = settings
+}
+
+const saveSettings = async () => {
+  void trackEvent('DUI3 Action', {
+    name: 'Send Settings Updated'
+  })
+  await store.patchModel(props.modelCardId, {
+    settings: newSettings,
+    expired: true
+  })
+  showSettingsDialog.value = false
+}
+</script>

--- a/packages/dui3/components/send/SettingsDialog.vue
+++ b/packages/dui3/components/send/SettingsDialog.vue
@@ -11,8 +11,8 @@
         :settings="props.settings"
         @update:settings="updateSettings"
       ></SendSettings>
-      <div class="mt-4 flex justify-center items-center space-x-2">
-        <FormButton size="sm" text @click="showSettingsDialog = false">
+      <div class="mt-4 flex justify-end items-center space-x-2">
+        <FormButton size="sm" color="outline" @click="showSettingsDialog = false">
           Cancel
         </FormButton>
         <FormButton size="sm" @click="saveSettings()">Save</FormButton>

--- a/packages/dui3/components/wizard/ModelSelector.vue
+++ b/packages/dui3/components/wizard/ModelSelector.vue
@@ -78,7 +78,7 @@
         </FormButton>
         <FormButton
           v-else
-          color="card"
+          color="outline"
           full-width
           :disabled="hasReachedEnd"
           @click="loadMore"

--- a/packages/dui3/components/wizard/ProjectSelector.vue
+++ b/packages/dui3/components/wizard/ProjectSelector.vue
@@ -45,7 +45,13 @@
           Create&nbsp;
           <div class="truncate">"{{ searchText }}"</div>
         </FormButton>
-        <FormButton v-else full-width :disabled="hasReachedEnd" @click="loadMore">
+        <FormButton
+          v-else
+          full-width
+          :disabled="hasReachedEnd"
+          color="outline"
+          @click="loadMore"
+        >
           {{ hasReachedEnd ? 'No more projects found' : 'Load older projects' }}
         </FormButton>
       </div>

--- a/packages/dui3/components/wizard/list/ModelCard.vue
+++ b/packages/dui3/components/wizard/list/ModelCard.vue
@@ -3,7 +3,7 @@
     class="group text-left relative bg-foundation-2 rounded p-2 hover:text-primary hover:bg-primary-muted transition cursor-pointer hover:shadow-md"
   >
     <div class="flex items-center space-x-4">
-      <div>
+      <div class="max-[275px]:hidden">
         <div v-if="model.previewUrl" class="h-12 w-12">
           <img
             :src="model.previewUrl"

--- a/packages/dui3/lib/core/composables/updateConnector.ts
+++ b/packages/dui3/lib/core/composables/updateConnector.ts
@@ -1,5 +1,6 @@
 import type { ToastNotification } from '@speckle/ui-components'
 import { ToastNotificationType } from '@speckle/ui-components'
+import { useConfigStore } from '~/store/config'
 import { useHostAppStore } from '~/store/hostApp'
 
 type Versions = {
@@ -17,6 +18,7 @@ export type Version = {
 
 export function useUpdateConnector() {
   const hostApp = useHostAppStore()
+  const config = useConfigStore()
   const { $openUrl } = useNuxtApp()
 
   const versions = ref<Version[]>([])
@@ -28,7 +30,7 @@ export function useUpdateConnector() {
 
   async function checkUpdate() {
     await getVersions()
-    if (!isUpToDate.value) {
+    if (!isUpToDate.value && !config.isDevMode) {
       const notification: ToastNotification = {
         type: ToastNotificationType.Success,
         title: `Update available`,


### PR DESCRIPTION
1. Change Filter Dialog
- Bring save button back
- "Settings" accordion only available on first send. Not available after model card created.

![Revit_bDKzVEy4zJ](https://github.com/user-attachments/assets/ade16440-772b-4691-bb2c-4ed8687b4f5b)

2. Settings Dialog on model card actions

![Revit_fmJNDhasjK](https://github.com/user-attachments/assets/dafa4e61-0e52-4b35-8ede-e08125634c76)
![Revit_3wEQW23WUK](https://github.com/user-attachments/assets/53e470d9-92e3-43fb-8ace-3d6e1799d257)

3. Toast Notification on "Update available" not triggerred on dev mode