### PR TITLE
Feat(dui3): CNX-548 card settings backward and forward compatible

### DIFF
--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -523,7 +523,6 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     await refreshDocumentModelStore()
     await refreshSendFilters()
     await getSendSettings()
-
     await getHostAppName()
     await getHostAppVersion()
     await getConnectorVersion()

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -448,10 +448,11 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
 
   const getSendSettings = async () => {
     sendSettings.value = await app.$sendBinding.getSendSettings()
-    tryToUpgradeSendSettings()
+    // TODO: tryToUpgradeSendSettings()
   }
 
-  const tryToUpgradeSendSettings = () => {
+  const tryToUpgradeSendSettings = async () => {
+    await refreshDocumentModelStore() // if we do it without awaiting this, we are getting empty array here at first. TODO: TBD tmr
     if (documentModelStore.value.models.length === 0) return
     const senderModelCards = documentModelStore.value.models.filter(
       (m) => m.typeDiscriminator === 'SenderModelCard'
@@ -514,7 +515,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         void refreshDocumentInfo()
         void refreshDocumentModelStore()
         void refreshSendFilters()
-        tryToUpgradeSendSettings()
+        void tryToUpgradeSendSettings()
       }, 500) // timeout exists because of rhino
   )
 
@@ -523,6 +524,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   void refreshDocumentModelStore()
   void refreshSendFilters()
   void getSendSettings()
+  void tryToUpgradeSendSettings()
   void getHostAppName()
   void getHostAppVersion()
   void getConnectorVersion()

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -450,7 +450,10 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     sendSettings.value = await app.$sendBinding.getSendSettings()
   }
 
-  const tryToUpgradeSettings = (settings: CardSetting[], typeDiscriminator: string) => {
+  const tryToUpgradeModelCardSettings = (
+    settings: CardSetting[],
+    typeDiscriminator: string
+  ) => {
     if (documentModelStore.value.models.length === 0) return
     const modelCards = documentModelStore.value.models.filter(
       (m) => m.typeDiscriminator === typeDiscriminator
@@ -513,7 +516,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         void refreshDocumentInfo()
         await refreshDocumentModelStore() // need to awaited since upgrading the card settings need documentModelStore in place
         void refreshSendFilters()
-        void tryToUpgradeSettings(sendSettings.value || [], 'SenderModelCard')
+        void tryToUpgradeModelCardSettings(sendSettings.value || [], 'SenderModelCard')
       }, 500) // timeout exists because of rhino
   )
 
@@ -525,7 +528,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     await refreshDocumentModelStore()
     await refreshSendFilters()
     await getSendSettings()
-    tryToUpgradeSettings(sendSettings.value || [], 'SenderModelCard')
+    tryToUpgradeModelCardSettings(sendSettings.value || [], 'SenderModelCard')
   }
 
   initializeApp()

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -453,18 +453,18 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
 
   const tryToUpgradeSettings = (typeDiscriminator: string) => {
     if (documentModelStore.value.models.length === 0) return
-    const senderModelCards = documentModelStore.value.models.filter(
+    const modelCards = documentModelStore.value.models.filter(
       (m) => m.typeDiscriminator === typeDiscriminator
     )
-    if (senderModelCards.length === 0) return
+    if (modelCards.length === 0) return
 
     const sendSettingIds = sendSettings.value?.map((s) => s.id) || []
-    senderModelCards.forEach(async (senderModelCard) => {
+    modelCards.forEach(async (modelCard) => {
       const idsToUpgrade = [] as string[]
       const idsToDrop = [] as string[]
 
       sendSettingIds?.forEach((id) => {
-        const existingSetting = senderModelCard.settings?.find((s) => s.id === id)
+        const existingSetting = modelCard.settings?.find((s) => s.id === id)
 
         if (!existingSetting) {
           // If the setting does not exist, it's a new one to upgrade
@@ -479,7 +479,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
       })
 
       // Identify settings to drop (if they no longer exist in sendSettingIds)
-      senderModelCard.settings?.forEach((setting) => {
+      modelCard.settings?.forEach((setting) => {
         if (!sendSettingIds.includes(setting.id)) {
           idsToDrop.push(setting.id)
         }
@@ -487,7 +487,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
 
       if (idsToUpgrade.length !== 0 || idsToDrop.length !== 0) {
         // Prepare new settings by filtering the old ones and adding upgraded ones
-        const newSettings = senderModelCard.settings?.filter(
+        const newSettings = modelCard.settings?.filter(
           (setting) => !idsToDrop.includes(setting.id)
         )
 
@@ -499,7 +499,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         })
 
         // Patch the model with the new settings
-        await patchModel(senderModelCard.modelCardId, {
+        await patchModel(modelCard.modelCardId, {
           settings: newSettings
         })
       }
@@ -527,6 +527,8 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     await getHostAppVersion()
     await getConnectorVersion()
   }
+
+  void getConnectorVersion()
 
   initializeApp()
 

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -450,19 +450,19 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     sendSettings.value = await app.$sendBinding.getSendSettings()
   }
 
-  const tryToUpgradeSettings = (typeDiscriminator: string) => {
+  const tryToUpgradeSettings = (settings: CardSetting[], typeDiscriminator: string) => {
     if (documentModelStore.value.models.length === 0) return
     const modelCards = documentModelStore.value.models.filter(
       (m) => m.typeDiscriminator === typeDiscriminator
     )
     if (modelCards.length === 0) return
 
-    const sendSettingIds = sendSettings.value?.map((s) => s.id) || []
+    const settingIds = settings?.map((s) => s.id) || []
     modelCards.forEach(async (modelCard) => {
       const idsToUpgrade = [] as string[]
       const idsToDrop = [] as string[]
 
-      sendSettingIds?.forEach((id) => {
+      settingIds?.forEach((id) => {
         const existingSetting = modelCard.settings?.find((s) => s.id === id)
 
         if (!existingSetting) {
@@ -479,7 +479,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
 
       // Identify settings to drop (if they no longer exist in sendSettingIds)
       modelCard.settings?.forEach((setting) => {
-        if (!sendSettingIds.includes(setting.id)) {
+        if (!settingIds.includes(setting.id)) {
           idsToDrop.push(setting.id)
         }
       })
@@ -513,7 +513,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         void refreshDocumentInfo()
         await refreshDocumentModelStore() // need to awaited since upgrading the card settings need documentModelStore in place
         void refreshSendFilters()
-        void tryToUpgradeSettings('SenderModelCard')
+        void tryToUpgradeSettings(sendSettings.value || [], 'SenderModelCard')
       }, 500) // timeout exists because of rhino
   )
 
@@ -525,7 +525,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     await refreshDocumentModelStore()
     await refreshSendFilters()
     await getSendSettings()
-    tryToUpgradeSettings('SenderModelCard')
+    tryToUpgradeSettings(sendSettings.value || [], 'SenderModelCard')
   }
 
   initializeApp()

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -512,7 +512,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
       setTimeout(async () => {
         void trackEvent('DUI3 Action', { name: 'Document changed' })
         void refreshDocumentInfo()
-        await refreshDocumentModelStore()
+        await refreshDocumentModelStore() // need to awaited since upgradings settings need documentModelStore in place
         void refreshSendFilters()
         void tryToUpgradeSettings('SenderModelCard')
       }, 500) // timeout exists because of rhino

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -451,11 +451,11 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     // TODO: tryToUpgradeSendSettings()
   }
 
-  const tryToUpgradeSendSettings = async () => {
+  const tryToUpgradeSettings = async (typeDiscriminator: string) => {
     await refreshDocumentModelStore() // if we do it without awaiting this, we are getting empty array here at first. TODO: TBD tmr
     if (documentModelStore.value.models.length === 0) return
     const senderModelCards = documentModelStore.value.models.filter(
-      (m) => m.typeDiscriminator === 'SenderModelCard'
+      (m) => m.typeDiscriminator === typeDiscriminator // 'SenderModelCard'
     )
     if (senderModelCards.length === 0) return
 
@@ -515,7 +515,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         void refreshDocumentInfo()
         void refreshDocumentModelStore()
         void refreshSendFilters()
-        void tryToUpgradeSendSettings()
+        void tryToUpgradeSettings('SenderModelCard')
       }, 500) // timeout exists because of rhino
   )
 
@@ -524,7 +524,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   void refreshDocumentModelStore()
   void refreshSendFilters()
   void getSendSettings()
-  void tryToUpgradeSendSettings()
+  void tryToUpgradeSettings('SenderModelCard')
   void getHostAppName()
   void getHostAppVersion()
   void getConnectorVersion()

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -528,8 +528,6 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     await getConnectorVersion()
   }
 
-  void getConnectorVersion()
-
   initializeApp()
 
   return {

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -448,7 +448,6 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
 
   const getSendSettings = async () => {
     sendSettings.value = await app.$sendBinding.getSendSettings()
-    tryToUpgradeSettings('SenderModelCard')
   }
 
   const tryToUpgradeSettings = (typeDiscriminator: string) => {
@@ -512,20 +511,21 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
       setTimeout(async () => {
         void trackEvent('DUI3 Action', { name: 'Document changed' })
         void refreshDocumentInfo()
-        await refreshDocumentModelStore() // need to awaited since upgradings settings need documentModelStore in place
+        await refreshDocumentModelStore() // need to awaited since upgrading the card settings need documentModelStore in place
         void refreshSendFilters()
         void tryToUpgradeSettings('SenderModelCard')
       }, 500) // timeout exists because of rhino
   )
 
   const initializeApp = async () => {
+    await getHostAppName()
+    await getHostAppVersion()
+    await getConnectorVersion()
     await refreshDocumentInfo()
     await refreshDocumentModelStore()
     await refreshSendFilters()
     await getSendSettings()
-    await getHostAppName()
-    await getHostAppVersion()
-    await getConnectorVersion()
+    tryToUpgradeSettings('SenderModelCard')
   }
 
   initializeApp()


### PR DESCRIPTION
We upgrade the sender card settings on the init.

Another issue was, we were not awaiting the init functions like `void refreshDocumentModelStore()` in the `hostAppStore` and it was causing empty `documentModelStore` whenever we call `tryToUpgradeSettings()`. I have wrapped them into `async` init function and await them all.