### PR TITLE
fix(logging): graphql errors are logged at the appropriate level

### DIFF
--- a/packages/server/logging/graphqlError.ts
+++ b/packages/server/logging/graphqlError.ts
@@ -1,0 +1,22 @@
+import { BaseError } from '@/modules/shared/errors'
+import { isUserGraphqlError } from '@/modules/shared/helpers/graphqlHelper'
+import { ApolloError } from '@apollo/client/core'
+import { GraphQLError } from 'graphql'
+
+export const shouldLogAsInfoLevel = (err: unknown): boolean => {
+  if (err instanceof GraphQLError) {
+    if (isUserGraphqlError(err)) return true
+    if (!!err.cause && shouldLogAsInfoLevel(err.cause)) return true
+    if (!!err.originalError && shouldLogAsInfoLevel(err.originalError)) return true
+  }
+
+  if (
+    err instanceof BaseError &&
+    !!err.info().statusCode &&
+    typeof err.info().statusCode === 'number' &&
+    err.info().statusCode < 500
+  )
+    return true
+
+  return err instanceof ApolloError
+}

--- a/packages/server/modules/core/graph/plugins/logging.ts
+++ b/packages/server/modules/core/graph/plugins/logging.ts
@@ -2,10 +2,10 @@
 import prometheusClient from 'prom-client'
 import { graphqlLogger } from '@/logging/logging'
 import { redactSensitiveVariables } from '@/logging/loggingHelper'
-import { FieldNode, GraphQLError, SelectionNode } from 'graphql'
+import { FieldNode, SelectionNode } from 'graphql'
 import { ApolloServerPlugin } from '@apollo/server'
 import { GraphQLContext } from '@/modules/shared/helpers/typeHelper'
-import { isUserGraphqlError } from '@/modules/shared/helpers/graphqlHelper'
+import { shouldLogAsInfoLevel } from '@/logging/graphqlError'
 
 type ApolloLoggingPluginTransaction = {
   start: number
@@ -110,7 +110,7 @@ export const loggingPlugin: ApolloServerPlugin<GraphQLContext> = {
               graphql_variables: variables
             })
           }
-          if (err instanceof GraphQLError && isUserGraphqlError(err)) {
+          if (shouldLogAsInfoLevel(err)) {
             logger.info(
               { err },
               '{graphql_operation_value} failed after {apollo_query_duration_ms} ms'


### PR DESCRIPTION
## Description & motivation

Previously, almost all errors incurred in a graphql request were being logged as `error` level even if they were user-input problems.

This PR ensures that the graphql logger (for both graphql and subscriptions) logs based on the underlying error, using the error status code to determine if an error should be logged as `error` or `info` level.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

These errors are due to user input and are now logged at `info` level:

<img width="1853" alt="Screenshot 2024-09-25 at 12 47 47" src="https://github.com/user-attachments/assets/e2e56e70-4d01-4daa-b53d-3c90cd0982be">
<img width="1844" alt="Screenshot 2024-09-25 at 12 48 21" src="https://github.com/user-attachments/assets/d58fca51-20e4-4cdd-a1a8-11385e8eca98">


## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
