### PR TITLE
fix(fe2): Don't show survicate NPS on authorize application page

### DIFF
--- a/packages/frontend-2/plugins/survicate.client.ts
+++ b/packages/frontend-2/plugins/survicate.client.ts
@@ -4,12 +4,17 @@ import { useSynchronizedCookie } from '~/lib/common/composables/reactiveCookie'
 import dayjs from 'dayjs'
 import type { Survicate } from '@survicate/survicate-web-surveys-wrapper'
 import type { Nullable } from '@speckle/shared'
+import { useRoute } from 'vue-router'
 
 export default defineNuxtPlugin(async () => {
   const { isLoggedIn } = useActiveUser()
+  const route = useRoute()
   let survicateInstance = null as Nullable<Survicate>
 
-  if (!isLoggedIn.value) {
+  // Check if the current route is the auth verify application page
+  const isAuthVerifyPage = computed(() => route.name === 'authorize-app')
+
+  if (!isLoggedIn.value || isAuthVerifyPage.value) {
     return {
       provide: {
         survicate: survicateInstance


### PR DESCRIPTION
The `/authn/verify/index` page is the only one in `/authn/` that needs the user to be logged in.

Right now, we show the Survicate NPS survey to logged-in users, but we don’t want it appearing on the verify page.

Regular page:
<img width="1523" alt="image" src="https://github.com/user-attachments/assets/36facba1-df19-49cd-9514-84d9dec1899c">

Authorize page:
<img width="1523" alt="image" src="https://github.com/user-attachments/assets/a823191a-c075-43b2-9bde-727a7b2571c0">