### PR TITLE
fix(fe2): Always show workspace description read more on mobile

### DIFF
--- a/packages/frontend-2/components/workspace/header/Header.vue
+++ b/packages/frontend-2/components/workspace/header/Header.vue
@@ -26,7 +26,7 @@
             v-if="hasOverflow"
             color="subtle"
             size="sm"
-            class="hidden group-hover:flex items-center text-foreground text-body-2xs"
+            class="md:hidden group-hover:flex items-center text-foreground text-body-2xs"
             @click="showDescriptionDialog"
           >
             Read more


### PR DESCRIPTION
<img width="381" alt="image" src="https://github.com/user-attachments/assets/02eca4bd-1755-4ed4-9cd9-418715246cef">
<img width="406" alt="image" src="https://github.com/user-attachments/assets/43f8ec8b-79f1-4643-809c-04d81d8585a5">