### PR TITLE
Feat(dui3): CNX-589 handle graphql and network errors as toast notification

### DIFF
--- a/packages/dui3/store/accounts.ts
+++ b/packages/dui3/store/accounts.ts
@@ -1,11 +1,22 @@
 import { defineStore } from 'pinia'
 import type { ApolloLink } from '@apollo/client/core'
-import { ApolloClient, InMemoryCache, gql, HttpLink, split } from '@apollo/client/core'
+import {
+  ApolloClient,
+  InMemoryCache,
+  gql,
+  HttpLink,
+  split,
+  from
+} from '@apollo/client/core'
 import { ApolloClients, provideApolloClients } from '@vue/apollo-composable'
 import type { Account } from '~/lib/bindings/definitions/IAccountBinding'
 import { WebSocketLink } from '@apollo/client/link/ws'
+import { onError, type ErrorResponse } from '@apollo/client/link/error'
 import { getMainDefinition } from '@apollo/client/utilities'
 import { setContext } from '@apollo/client/link/context'
+import { useHostAppStore } from '~/store/hostApp'
+import type { ToastNotification } from '@speckle/ui-components'
+import { ToastNotificationType } from '@speckle/ui-components'
 
 export type DUIAccount = {
   /** account info coming from the host app */
@@ -29,6 +40,8 @@ const accountTestQuery = gql`
 export const useAccountStore = defineStore('accountStore', () => {
   const app = useNuxtApp()
   const { $accountBinding } = app
+
+  const hostAppStore = useHostAppStore()
 
   const apolloClients = {} as Record<string, ApolloClient<unknown>>
   const accounts = ref<DUIAccount[]>([])
@@ -81,12 +94,43 @@ export const useAccountStore = defineStore('accountStore', () => {
         continue
       }
 
+      // Handle apollo client errors as top level
+      const errorLink = onError((res: ErrorResponse) => {
+        console.log('hit the onError', res)
+
+        if (res.graphQLErrors) {
+          const messages: string[] = []
+          res.graphQLErrors.forEach(({ message, locations, path }) => {
+            messages.push(
+              `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`
+            )
+          })
+
+          const notification: ToastNotification = {
+            type: ToastNotificationType.Danger,
+            title: 'Graphql Error',
+            description: messages.join('\n')
+          }
+          hostAppStore.setNotification(notification)
+        }
+
+        if (res.networkError) {
+          console.error(`[Network error]: ${res.networkError}`)
+          const notification: ToastNotification = {
+            type: ToastNotificationType.Danger,
+            title: 'Network Error',
+            description: res.networkError.message
+          }
+          hostAppStore.setNotification(notification)
+        }
+      })
+
       const link = splitLink(
         getLinks(new URL('/graphql', acc.serverInfo.url).href, 'Bearer ' + acc.token)
       )
       const client = new ApolloClient({
         cache: new InMemoryCache(),
-        link,
+        link: from([errorLink, link]),
         headers: {
           Authorization: 'Bearer ' + acc.token
         }


### PR DESCRIPTION
Graphql Error (faked it to be able to reproduce)

![Screenshot 2024-10-01 144445](https://github.com/user-attachments/assets/6568be11-f369-4e57-9d57-1dc03e4619e5)

Network Error (i.e. internet connection is dropped etc)

![image](https://github.com/user-attachments/assets/8547556f-0d49-4c9a-a997-7628a60f5209)
