### PR TITLE
fix(fe2): Update button style in onboarding flow

### DIFF
--- a/packages/frontend-2/components/tour/content/OverlayModel.vue
+++ b/packages/frontend-2/components/tour/content/OverlayModel.vue
@@ -8,6 +8,7 @@
         <span v-show="!hasAddedOverlay">
           <FormButton
             link
+            text
             :icon-right="hasAddedOverlay ? CheckIcon : null"
             :disabled="hasAddedOverlay"
             @click="addOverlay()"


### PR DESCRIPTION
This is to remove the shadow from the button in the onboarding flow:
<img width="462" alt="image" src="https://github.com/user-attachments/assets/4a9397a3-ad4a-4960-af75-1ccd242af40c">
