### PR TITLE
fix(fe2): Cannot access 'isRevitProperty' before initialization

### DIFF
--- a/packages/frontend-2/components/viewer/explorer/Filters.vue
+++ b/packages/frontend-2/components/viewer/explorer/Filters.vue
@@ -122,6 +122,10 @@ const props = defineProps<{
   filters: PropertyInfo[]
 }>()
 
+const isRevitProperty = (key: string): boolean => {
+  return revitPropertyRegex.test(key)
+}
+
 const relevantFilters = computed(() => {
   return props.filters.filter((f) => {
     if (
@@ -236,10 +240,6 @@ const refreshColorsIfSetOrActiveFilterIsNumeric = () => {
 
   // removePropertyFilter()
   applyPropertyFilter()
-}
-
-const isRevitProperty = (key: string): boolean => {
-  return revitPropertyRegex.test(key)
 }
 
 const getPropertyName = (key: string): string => {


### PR DESCRIPTION
<img width="614" alt="image" src="https://github.com/user-attachments/assets/d9e2a9e7-1949-4ea4-9511-a89aa982e907">