### PR TITLE
fix(fe2): Make toasts clickable when dialogs are open

### DIFF
--- a/packages/frontend-2/components/singleton/Managers.vue
+++ b/packages/frontend-2/components/singleton/Managers.vue
@@ -1,6 +1,8 @@
 <template>
   <div v-if="hasLock">
-    <SingletonToastManager />
+    <ClientOnly>
+      <SingletonToastManager />
+    </ClientOnly>
     <SingletonAppErrorStateManager />
   </div>
   <div v-else />

--- a/packages/frontend-2/components/singleton/ToastManager.vue
+++ b/packages/frontend-2/components/singleton/ToastManager.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport :to="portalTarget">
+  <Teleport to="#toast-portal">
     <GlobalToastRenderer v-model:notification="notification" />
   </Teleport>
 </template>
@@ -17,18 +17,5 @@ const notification = computed({
       dismiss()
     }
   }
-})
-
-const portalTarget = ref('body')
-
-const checkForToastTarget = () => {
-  const toastTarget = document.getElementById('toast-target')
-  if (toastTarget) {
-    portalTarget.value = '#toast-target'
-  }
-}
-
-onMounted(() => {
-  checkForToastTarget()
 })
 </script>

--- a/packages/frontend-2/components/singleton/ToastManager.vue
+++ b/packages/frontend-2/components/singleton/ToastManager.vue
@@ -1,6 +1,9 @@
 <template>
-  <GlobalToastRenderer v-model:notification="notification" />
+  <Teleport :to="portalTarget">
+    <GlobalToastRenderer v-model:notification="notification" />
+  </Teleport>
 </template>
+
 <script setup lang="ts">
 import { useGlobalToastManager } from '~~/lib/common/composables/toast'
 import { GlobalToastRenderer } from '@speckle/ui-components'
@@ -14,5 +17,18 @@ const notification = computed({
       dismiss()
     }
   }
+})
+
+const portalTarget = ref('body')
+
+const checkForToastTarget = () => {
+  const toastTarget = document.getElementById('toast-target')
+  if (toastTarget) {
+    portalTarget.value = '#toast-target'
+  }
+}
+
+onMounted(() => {
+  checkForToastTarget()
 })
 </script>

--- a/packages/frontend-2/plugins/portal.ts
+++ b/packages/frontend-2/plugins/portal.ts
@@ -2,4 +2,10 @@ import PortalVue from 'portal-vue'
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(PortalVue)
+
+  if (import.meta.client) {
+    const div = document.createElement('div')
+    div.id = 'toast-portal'
+    document.body.appendChild(div)
+  }
 })

--- a/packages/ui-components/src/components/layout/Dialog.vue
+++ b/packages/ui-components/src/components/layout/Dialog.vue
@@ -47,7 +47,6 @@
               :as="isForm ? 'form' : 'div'"
               @submit.prevent="onFormSubmit"
             >
-              <div id="toast-target" />
               <div
                 v-if="hasTitle"
                 class="border-b border-outline-3"

--- a/packages/ui-components/src/components/layout/Dialog.vue
+++ b/packages/ui-components/src/components/layout/Dialog.vue
@@ -47,6 +47,7 @@
               :as="isForm ? 'form' : 'div'"
               @submit.prevent="onFormSubmit"
             >
+              <div id="toast-target" />
               <div
                 v-if="hasTitle"
                 class="border-b border-outline-3"


### PR DESCRIPTION
Bit of a strange one.

Our toasts were not clickable when a dialog was open due to headless ui adding an inert attribute to the nuxt root. 

There also is a function in HeadlessUI which closes the dialog on click of any element outside the DialogPanel. 

My solution was:

- Added a `<div id="toast-target" />` inside DialogPanel in Dialog.vue.
- Updated ToastManager.vue to use Vue's Teleport:
  - Renders toast inside #toast-target if it exists (when dialog is open).
  - Otherwise, renders in the default location (body).
  - This ensures toasts are always clickable and maintains consistent appearance/behaviour.
  - This solution solves the issue without significantly altering existing dialog or toast logic.