### PR TITLE
fix(fe2): Border issues around invite banners

### DIFF
--- a/packages/frontend-2/components/projects/DashboardHeader.vue
+++ b/packages/frontend-2/components/projects/DashboardHeader.vue
@@ -1,9 +1,6 @@
 <template>
   <div>
-    <div
-      v-if="hasBanners"
-      class="bg-foundation divide-y divide-outline-3 mb-8 empty:mb-0"
-    >
+    <div v-if="hasBanners" class="space-y-2 mb-8 empty:mb-0">
       <ProjectsInviteBanners
         v-if="projectsInvites?.projectInvites?.length"
         :invites="projectsInvites"


### PR DESCRIPTION
- Removed divide-y which was causing the unnecessary line between invites
- ProjectInviteBanner and WorkspaceInvitesBanner are 2 separate components. This causes a weird visual bug, where both have rounded borders, but there is no gap. I added a small gap to make this seem more intentional.
<img width="1093" alt="image" src="https://github.com/user-attachments/assets/0fb8f1ff-9608-4045-9092-4214743b67d1">
@benjaminvo The second part was out of scope of this ticket, so just want to run this past you before merging. 