### PR TITLE
fix(fe2): Only show Workspace breadcrumb when workspace is loaded

### DIFF
--- a/packages/frontend-2/components/workspace/ProjectList.vue
+++ b/packages/frontend-2/components/workspace/ProjectList.vue
@@ -4,7 +4,7 @@
       <WorkspaceInviteBlock :invite="workspaceInvite" />
     </div>
     <template v-else>
-      <Portal to="navigation">
+      <Portal v-if="workspace?.name" to="navigation">
         <HeaderNavLink
           :to="workspaceRoute(workspaceSlug)"
           :name="workspace?.name"


### PR DESCRIPTION
This is to prevent the flash from the url in breadcrumbs, when you first load a workspace page. 