### PR TITLE
refactor(fe2): Changes to Move Projects button

### DIFF
--- a/packages/frontend-2/components/workspace/ProjectList.vue
+++ b/packages/frontend-2/components/workspace/ProjectList.vue
@@ -32,9 +32,23 @@
             v-bind="bind"
             v-on="on"
           />
-          <FormButton v-if="!isWorkspaceGuest" @click="openNewProject = true">
-            New project
-          </FormButton>
+          <div class="flex gap-2">
+            <div
+              v-tippy="isWorkspaceAdmin ? undefined : 'You must be a workspace admin'"
+            >
+              <FormButton
+                :disabled="!isWorkspaceAdmin"
+                class="hidden md:block"
+                color="outline"
+                @click="showMoveProjectsDialog = true"
+              >
+                Move projects
+              </FormButton>
+            </div>
+            <FormButton v-if="!isWorkspaceGuest" @click="openNewProject = true">
+              New project
+            </FormButton>
+          </div>
         </div>
       </div>
 
@@ -184,6 +198,7 @@ const projects = computed(() => query.result.value?.workspaceBySlug?.projects)
 const workspaceInvite = computed(() => initialQueryResult.value?.workspaceInvite)
 const workspace = computed(() => initialQueryResult.value?.workspaceBySlug)
 const isWorkspaceGuest = computed(() => workspace.value?.role === Roles.Workspace.Guest)
+const isWorkspaceAdmin = computed(() => workspace.value?.role === Roles.Workspace.Admin)
 const showEmptyState = computed(() => {
   if (search.value) return false
 

--- a/packages/frontend-2/components/workspace/ProjectList.vue
+++ b/packages/frontend-2/components/workspace/ProjectList.vue
@@ -33,9 +33,8 @@
             v-on="on"
           />
           <div class="flex gap-2">
-            <div
-              v-tippy="isWorkspaceAdmin ? undefined : 'You must be a workspace admin'"
-            >
+            <!--- Conditionally apply tooltip only for non-admins and avoid v-tippy reactivity bug -->
+            <div v-if="!isWorkspaceAdmin" v-tippy="'You must be a workspace admin'">
               <FormButton
                 :disabled="!isWorkspaceAdmin"
                 class="hidden md:block"
@@ -45,6 +44,14 @@
                 Move projects
               </FormButton>
             </div>
+            <FormButton
+              v-else
+              class="hidden md:block"
+              color="outline"
+              @click="showMoveProjectsDialog = true"
+            >
+              Move projects
+            </FormButton>
             <FormButton v-if="!isWorkspaceGuest" @click="openNewProject = true">
               New project
             </FormButton>

--- a/packages/frontend-2/components/workspace/ProjectList.vue
+++ b/packages/frontend-2/components/workspace/ProjectList.vue
@@ -243,6 +243,11 @@ const emptyStateItems = computed(() => [
       'Projects are the place where your models and their versions live. Add one and start creating.',
     buttons: [
       {
+        text: 'Move project',
+        onClick: () => (showMoveProjectsDialog.value = true),
+        disabled: !isWorkspaceAdmin.value
+      },
+      {
         text: 'New project',
         onClick: () => (openNewProject.value = true),
         disabled: isWorkspaceGuest.value

--- a/packages/frontend-2/components/workspace/header/Header.vue
+++ b/packages/frontend-2/components/workspace/header/Header.vue
@@ -83,14 +83,6 @@
           >
             Invite
           </FormButton>
-          <FormButton
-            v-if="isWorkspaceAdmin"
-            class="hidden md:block"
-            color="subtle"
-            @click="$emit('show-move-projects-dialog')"
-          >
-            Move projects
-          </FormButton>
           <LayoutMenu
             v-model:open="showActionsMenu"
             :items="actionsItems"

--- a/packages/frontend-2/components/workspace/header/Header.vue
+++ b/packages/frontend-2/components/workspace/header/Header.vue
@@ -181,12 +181,19 @@ const team = computed(() => props.workspaceInfo.team.items || [])
 const isWorkspaceAdmin = computed(
   () => props.workspaceInfo.role === Roles.Workspace.Admin
 )
+const isWorkspaceGuest = computed(
+  () => props.workspaceInfo.role === Roles.Workspace.Guest
+)
 const actionsItems = computed<LayoutMenuItem[][]>(() => [
   [
     ...(isMobile.value
       ? [
-          { title: 'Move projects', id: ActionTypes.MoveProjects },
-          { title: 'Invite', id: ActionTypes.Invite }
+          ...(isWorkspaceAdmin.value
+            ? [{ title: 'Move projects', id: ActionTypes.MoveProjects }]
+            : []),
+          ...(!isWorkspaceGuest.value
+            ? [{ title: 'Invite', id: ActionTypes.Invite }]
+            : [])
         ]
       : []),
     { title: 'Copy link', id: ActionTypes.CopyLink }


### PR DESCRIPTION
- Moved the `Move projects` button down next to the `New projects` button and turned it into an actual button (white, similar to the invite button).
  - The button still becomes hidden in <md breakpoint, and instead is added to the ... menu
- Kept it visible to Members and Guests but disabled. On hover show tooltip with: "Only admins can move projects into the workspace".
  - Tooltips don't consistently work on buttons, so i wrapped the button in a div.
- Add "Move projects" button to Quickstart card