### PR TITLE
fix(workspaces): prohibit workspace guests from being project owners

### DIFF
--- a/packages/frontend-2/components/project/page/settings/collaborators/Row.vue
+++ b/packages/frontend-2/components/project/page/settings/collaborators/Row.vue
@@ -118,7 +118,7 @@ const roleTooltip = computed(() => {
 })
 
 const isTargettingWorkspaceGuest = computed(
-  () => props.collaborator.role === Roles.Workspace.Guest
+  () => props.collaborator.workspaceRole === Roles.Workspace.Guest
 )
 
 const onActionChosen = (

--- a/packages/server/modules/workspaces/domain/operations.ts
+++ b/packages/server/modules/workspaces/domain/operations.ts
@@ -8,9 +8,17 @@ import {
   WorkspaceWithOptionalRole
 } from '@/modules/workspacesCore/domain/types'
 import { EventBusPayloads } from '@/modules/shared/services/eventBus'
-import { PartialNullable, StreamRoles, WorkspaceRoles } from '@speckle/shared'
+import {
+  MaybeNullOrUndefined,
+  Nullable,
+  PartialNullable,
+  StreamRoles,
+  WorkspaceRoles
+} from '@speckle/shared'
 import { WorkspaceRoleToDefaultProjectRoleMapping } from '@/modules/workspaces/domain/types'
 import { WorkspaceTeam } from '@/modules/workspaces/domain/types'
+import { Stream } from '@/modules/core/domain/streams/types'
+import { TokenResourceIdentifier } from '@/modules/core/domain/tokens/types'
 
 /** Workspace */
 
@@ -183,6 +191,23 @@ type GrantWorkspaceProjectRolesArgs = {
 export type GrantWorkspaceProjectRoles = (
   args: GrantWorkspaceProjectRolesArgs
 ) => Promise<void>
+
+type UpdateWorkspaceProjectRoleArgs = {
+  role: {
+    projectId: string
+    userId: string
+    // Undefined or null role means delete role
+    role?: Nullable<string>
+  }
+  updater: {
+    userId: string
+    resourceAccessRules: MaybeNullOrUndefined<TokenResourceIdentifier[]>
+  }
+}
+
+export type UpdateWorkspaceProjectRole = (
+  args: UpdateWorkspaceProjectRoleArgs
+) => Promise<Stream | undefined>
 
 /** Events */
 

--- a/packages/server/modules/workspaces/services/projects.ts
+++ b/packages/server/modules/workspaces/services/projects.ts
@@ -2,13 +2,17 @@ import { StreamRecord } from '@/modules/core/helpers/types'
 import { getUserStreams } from '@/modules/core/repositories/streams'
 import {
   GetWorkspace,
+  GetWorkspaceRoleForUser,
   GetWorkspaceRoles,
   GetWorkspaceRoleToDefaultProjectRoleMapping,
   QueryAllWorkspaceProjects,
+  UpdateWorkspaceProjectRole,
   UpdateWorkspaceRole
 } from '@/modules/workspaces/domain/operations'
 import {
+  WorkspaceAdminError,
   WorkspaceInvalidProjectError,
+  WorkspaceInvalidRoleError,
   WorkspaceNotFoundError,
   WorkspaceQueryError
 } from '@/modules/workspaces/errors/workspace'
@@ -22,7 +26,11 @@ import { chunk } from 'lodash'
 import { Roles, StreamRoles } from '@speckle/shared'
 import { orderByWeight } from '@/modules/shared/domain/rolesAndScopes/logic'
 import coreUserRoles from '@/modules/core/roles'
-import { LegacyGetStreams } from '@/modules/core/domain/streams/operations'
+import {
+  GetStream,
+  LegacyGetStreams,
+  UpdateStreamRole
+} from '@/modules/core/domain/streams/operations'
 
 export const queryAllWorkspaceProjectsFactory = ({
   getStreams
@@ -194,4 +202,43 @@ export const getWorkspaceRoleToDefaultProjectRoleMappingFactory =
       [Roles.Workspace.Member]: workspace.defaultProjectRole,
       [Roles.Workspace.Admin]: Roles.Stream.Owner
     }
+  }
+
+export const updateWorkspaceProjectRoleFactory =
+  ({
+    getStream,
+    getWorkspaceRoleForUser,
+    updateStreamRoleAndNotify
+  }: {
+    getStream: GetStream
+    getWorkspaceRoleForUser: GetWorkspaceRoleForUser
+    updateStreamRoleAndNotify: UpdateStreamRole
+  }): UpdateWorkspaceProjectRole =>
+  async ({ role, updater }) => {
+    const { workspaceId } = (await getStream({ streamId: role.projectId })) ?? {}
+    if (!workspaceId) throw new WorkspaceInvalidProjectError()
+
+    const currentWorkspaceRole = await getWorkspaceRoleForUser({
+      workspaceId,
+      userId: role.userId
+    })
+
+    if (currentWorkspaceRole?.role === Roles.Workspace.Admin) {
+      // User is workspace admin and cannot have their project roles changed
+      throw new WorkspaceAdminError()
+    }
+
+    if (
+      currentWorkspaceRole?.role === Roles.Workspace.Guest &&
+      role.role === Roles.Stream.Owner
+    ) {
+      // Workspace guests cannot be project owners
+      throw new WorkspaceInvalidRoleError('Workspace guests cannot be project owners.')
+    }
+
+    return await updateStreamRoleAndNotify(
+      role,
+      updater.userId!,
+      updater.resourceAccessRules
+    )
   }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- We do not want to allow workspace guests to be project owners. Reviewers and editors only.

## Changes:

- Adds this protection in backend (new service function)
- Adds this protection to frontend
