### PR TITLE
fix(fe2): Fix layout shift from workspace description read mroe

### DIFF
--- a/packages/frontend-2/components/workspace/header/Header.vue
+++ b/packages/frontend-2/components/workspace/header/Header.vue
@@ -26,7 +26,7 @@
             v-if="hasOverflow"
             color="subtle"
             size="sm"
-            class="md:opacity-0 group-hover:opacity-100 md:pointer-events-none group-hover:pointer-events-auto items-center text-foreground text-body-2xs"
+            class="md:invisible group-hover:visible items-center text-foreground text-body-2xs"
             @click="showDescriptionDialog"
           >
             Read more


### PR DESCRIPTION
On smaller screens, the "read more" button in the Workspace header would cause layout shifts as it appeared/disappeared on hover of the description. 

I updated this to use visibility to avoid the layout shift. 