### PR TITLE
refactor(fe2): Output disabled invite button to non-admins

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/members/TableHeader.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/TableHeader.vue
@@ -23,10 +23,10 @@
         :hide-items="[Roles.Workspace.Guest]"
       />
     </div>
-    <FormButton
-      v-if="isWorkspaceAdmin"
-      @click="() => (isInviteDialogOpen = !isInviteDialogOpen)"
-    >
+    <div v-if="!isWorkspaceAdmin" v-tippy="'You must be a workspace admin'">
+      <FormButton :disabled="!isWorkspaceAdmin">Invite</FormButton>
+    </div>
+    <FormButton v-else @click="() => (isInviteDialogOpen = !isInviteDialogOpen)">
       Invite
     </FormButton>
     <WorkspaceInviteDialog


### PR DESCRIPTION
Instead of hiding the invite button to non workspace admins, we now show a disabled button, with a tooltip warning the user. 

I had to do this with a v-if, and the isAdmin state is initially false for all users on loading the dialog. The caching issue with tooltips meant the tooltip was always visible, even when the button was not disabled. The v-if pattern fixed this. 