### PR TITLE
fix(helm chart): service account secrets only includes unique value

### DIFF
--- a/utils/helm/speckle-server/templates/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/_helpers.tpl
@@ -955,3 +955,40 @@ Generate the environment variables for Speckle server and Speckle objects deploy
   value: "{{ .Values.server.ratelimiting.burst_get_auth }}"
 {{- end }}
 {{- end }}
+
+{{/*
+Generate the secrets to which the service account should allow access for the Speckle server and Speckle objects deployments
+*/}}
+{{- define "server.serviceAccountSecrets" -}}
+{{- $secretNames := list ( default .Values.secretName .Values.db.connectionString.secretName ) }}
+{{- $secretNames := append $secretNames ( default .Values.secretName .Values.redis.connectionString.secretName ) }}
+{{- $secretNames := append $secretNames ( default .Values.secretName .Values.s3.secret_key.secretName ) }}
+{{- $secretNames := append $secretNames ( default .Values.secretName .Values.server.sessionSecret.secretName ) }}
+{{- if .Values.server.auth.google.enabled }}
+  {{- $secretNames := append $secretNames ( default .Values.secretName .Values.server.auth.google.clientSecret.secretName ) }}
+{{- end }}
+{{- if .Values.server.auth.github.enabled }}
+  {{- $secretNames := append $secretNames ( default .Values.secretName .Values.server.auth.github.clientSecret.secretName ) }}
+{{- end }}
+{{- if .Values.server.auth.azure_ad.enabled }}
+  {{- $secretNames := append $secretNames ( default .Values.secretName .Values.server.auth.azure_ad.clientSecret.secretName ) }}
+{{- end }}
+{{- if .Values.server.auth.oidc.enabled }}
+  {{- $secretNames := append $secretNames ( default .Values.secretName .Values.server.auth.oidc.clientSecret.secretName ) }}
+{{- end }}
+{{- if .Values.server.email.enabled }}
+  {{- $secretNames := append $secretNames ( default .Values.secretName .Values.server.email.password.secretName ) }}
+{{- end }}
+{{- if .Values.server.monitoring.apollo.enabled }}
+  {{- $secretNames := append $secretNames ( default .Values.secretName .Values.server.monitoring.apollo.key.secretName ) }}
+{{- end }}
+{{- if .Values.featureFlags.automateModuleEnabled }}
+  {{- $secretNames := append $secretNames "encryption-keys" }}
+{{- end }}
+{{- if .Values.featureFlags.workspaceModuleEnabled }}
+  {{- $secretNames := append $secretNames ( default .Values.secretName .Values.server.licenseTokenSecret.secretName ) }}
+{{- end }}
+{{- range $secretName := uniq $secretNames }}
+  - name: {{ $secretName }}
+{{- end }}
+{{- end }}

--- a/utils/helm/speckle-server/templates/objects/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/objects/serviceaccount.yml
@@ -10,33 +10,5 @@ metadata:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
 secrets:
-  - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
-  - name: {{ default .Values.secretName .Values.redis.connectionString.secretName }}
-  - name: {{ default .Values.secretName .Values.s3.secret_key.secretName }}
-  - name: {{ default .Values.secretName .Values.server.sessionSecret.secretName }}
-{{- if .Values.server.auth.google.enabled }}
-  - name: {{ default .Values.secretName .Values.server.auth.google.clientSecret.secretName }}
-{{- end }}
-{{- if .Values.server.auth.github.enabled }}
-  - name: {{ default .Values.secretName .Values.server.auth.github.clientSecret.secretName }}
-{{- end }}
-{{- if .Values.server.auth.azure_ad.enabled }}
-  - name: {{ default .Values.secretName .Values.server.auth.azure_ad.clientSecret.secretName }}
-{{- end }}
-{{- if .Values.server.auth.oidc.enabled }}
-  - name: {{ default .Values.secretName .Values.server.auth.oidc.clientSecret.secretName }}
-{{- end }}
-{{- if .Values.server.email.enabled }}
-  - name: {{ default .Values.secretName .Values.server.email.password.secretName }}
-{{- end }}
-{{- if .Values.server.monitoring.apollo.enabled }}
-  - name: {{ default .Values.secretName .Values.server.monitoring.apollo.key.secretName }}
-{{- end }}
-{{- if .Values.featureFlags.automateModuleEnabled }}
-  - name: encryption-keys
-{{- end }}
-{{- if .Values.featureFlags.workspaceModuleEnabled }}
-  - name: {{ default .Values.secretName .Values.server.licenseTokenSecret.secretName }}
-{{- end }}
-
+{{- include "server.serviceAccountSecrets" $ | indent 2 }}
 {{- end -}}

--- a/utils/helm/speckle-server/templates/server/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/server/serviceaccount.yml
@@ -10,33 +10,5 @@ metadata:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
 secrets:
-  - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
-  - name: {{ default .Values.secretName .Values.redis.connectionString.secretName }}
-  - name: {{ default .Values.secretName .Values.s3.secret_key.secretName }}
-  - name: {{ default .Values.secretName .Values.server.sessionSecret.secretName }}
-{{- if .Values.server.auth.google.enabled }}
-  - name: {{ default .Values.secretName .Values.server.auth.google.clientSecret.secretName }}
-{{- end }}
-{{- if .Values.server.auth.github.enabled }}
-  - name: {{ default .Values.secretName .Values.server.auth.github.clientSecret.secretName }}
-{{- end }}
-{{- if .Values.server.auth.azure_ad.enabled }}
-  - name: {{ default .Values.secretName .Values.server.auth.azure_ad.clientSecret.secretName }}
-{{- end }}
-{{- if .Values.server.auth.oidc.enabled }}
-  - name: {{ default .Values.secretName .Values.server.auth.oidc.clientSecret.secretName }}
-{{- end }}
-{{- if .Values.server.email.enabled }}
-  - name: {{ default .Values.secretName .Values.server.email.password.secretName }}
-{{- end }}
-{{- if .Values.server.monitoring.apollo.enabled }}
-  - name: {{ default .Values.secretName .Values.server.monitoring.apollo.key.secretName }}
-{{- end }}
-{{- if .Values.featureFlags.automateModuleEnabled }}
-  - name: encryption-keys
-{{- end }}
-{{- if .Values.featureFlags.workspaceModuleEnabled }}
-  - name: {{ default .Values.secretName .Values.server.licenseTokenSecret.secretName }}
-{{- end }}
-
+{{- include "server.serviceAccountSecrets" $ | indent 2 }}
 {{- end -}}


### PR DESCRIPTION
## Description & motivation

When deploying a change which amended the helm chart values to use the default secret instead of a custom secret name, the deployment broke.

It broke because the helm chart generated a list of secrets which was non-unique. In Kubernetes, the list was subsequently made unique. This amended the size of the list in Kubernetes compared to the Helm template.

When a patch was applied, the patch instructions could not work as the lists (in helm compared to kubernetes) did not match.

This change makes the chart more robust by ensuring the list is unique during Helm templating.  The behaviour can be determined at template time, and matches the situtation in Kubernetes.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

Passed Helm Chart deployment test:
<img width="832" alt="Screenshot 2024-10-15 at 09 54 37" src="https://github.com/user-attachments/assets/a22bab84-1928-4c37-b371-cbfa806cd253">


## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
