### PR TITLE
feat(fe2): adds a quick check for window focus before sending viewer events out

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/activity.ts
+++ b/packages/frontend-2/lib/viewer/composables/activity.ts
@@ -21,7 +21,7 @@ import { broadcastViewerUserActivityMutation } from '~~/lib/viewer/graphql/mutat
 import { convertThrowIntoFetchResult } from '~~/lib/common/helpers/graphql'
 import type { Dayjs } from 'dayjs'
 import dayjs from 'dayjs'
-import { useIntervalFn } from '@vueuse/core'
+import { useIntervalFn, useWindowFocus } from '@vueuse/core'
 import type { MaybeRef } from '@vueuse/core'
 import type { CSSProperties, Ref } from 'vue'
 import { useViewerAnchoredPoints } from '~~/lib/viewer/composables/anchorPoints'
@@ -294,7 +294,17 @@ export function useViewerUserActivityTracking(params: {
     }
   }
 
+  const focused = useWindowFocus()
+
+  watch(focused, async (newVal) => {
+    if (!newVal) {
+      await sendUpdate.emitDisconnected()
+    } else {
+      await sendUpdate.emitViewing()
+    }
+  })
   const sendUpdateAndHideStaleUsers = () => {
+    if (!focused.value) return
     hideStaleUsers()
     sendUpdate.emitViewing()
   }


### PR DESCRIPTION
Rather simple hotfix to take into account window focus. It was annoying in DUI3, as out of focus tabs would still send viewing events. 