### PR TITLE
Add stream destroy where db streams are used on download

### DIFF
--- a/packages/preview-service/src/server/routes/api.ts
+++ b/packages/preview-service/src/server/routes/api.ts
@@ -35,13 +35,14 @@ const apiRouterFactory = (deps: { db: Knex }) => {
         streamId: req.params.streamId,
         objectIds: getObjectsRequestBody.objects
       })
+      // https://knexjs.org/faq/recipes.html#manually-closing-streams
+      // https://github.com/knex/knex/issues/2324
+      req.on('close', () => {
+        dbStream.end.bind(dbStream)
+        dbStream.destroy.bind(dbStream)
+      })
 
       const speckleObjStream = new SpeckleObjectsStream(isSimpleTextRequested(req))
-      const speckleObjStreamCloseHandler = () => {
-        // https://knexjs.org/faq/recipes.html#manually-closing-streams
-        dbStream.end.bind(dbStream)
-      }
-      speckleObjStream.once('close', speckleObjStreamCloseHandler)
 
       const gzipStream = zlib.createGzip()
 

--- a/packages/preview-service/src/server/routes/objects.ts
+++ b/packages/preview-service/src/server/routes/objects.ts
@@ -40,14 +40,14 @@ const objectsRouterFactory = (deps: { db: Knex }) => {
         streamId: req.params.streamId,
         objectId: req.params.objectId
       })
+      // https://knexjs.org/faq/recipes.html#manually-closing-streams
+      // https://github.com/knex/knex/issues/2324
+      req.on('close', () => {
+        dbStream.end.bind(dbStream)
+        dbStream.destroy.bind(dbStream)
+      })
 
       const speckleObjStream = new SpeckleObjectsStream(isSimpleTextRequested(req))
-      const speckleObjStreamCloseHandler = () => {
-        // https://knexjs.org/faq/recipes.html#manually-closing-streams
-        dbStream.end.bind(dbStream)
-      }
-      speckleObjStream.once('close', speckleObjStreamCloseHandler)
-
       const gzipStream = zlib.createGzip()
 
       speckleObjStream.write(obj)

--- a/packages/server/modules/core/rest/download.js
+++ b/packages/server/modules/core/rest/download.js
@@ -47,6 +47,12 @@ module.exports = (app) => {
       streamId: req.params.streamId,
       objectId: req.params.objectId
     })
+    // https://knexjs.org/faq/recipes.html#manually-closing-streams
+    // https://github.com/knex/knex/issues/2324
+    req.on('close', () => {
+      dbStream.end.bind(dbStream)
+      dbStream.destroy.bind(dbStream)
+    })
     const speckleObjStream = new SpeckleObjectsStream(simpleText)
     const gzipStream = zlib.createGzip()
 


### PR DESCRIPTION
I think the force closing of a DB is slightly wrong.

From my understanding, request close event is only called when a connection is forcefully closed.  Also, it seems the destroy needs to be called to ensure the DB connection goes back to the pool.  The found docs is slightly wrong

https://knexjs.org/faq/recipes.html#manually-closing-streams
https://github.com/knex/knex/issues/2324