### PR TITLE
Adds viewer receive events

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
@@ -836,5 +836,4 @@ export function useViewerPostSetup() {
   useViewerMeasurementIntegration()
   useDisableZoomOnEmbed()
   setupDebugMode()
-  // TODO: add here the use receive tracking
 }

--- a/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
@@ -155,10 +155,12 @@ function useViewerObjectAutoLoading() {
   })
 }
 
+/**
+ * Here we make the viewer pretend it's a connector and send out receive events. Note, this is important for us to track to be able to get a picture of how much data is consumed
+ * in our viewer.
+ */
 function useViewerReceiveTracking() {
-  // Here we make the viewer pretend it's a connector and send out receive events.
-  // Note, this is important for us to track to be able to get a picture of how much data is consumed
-  // in our viewer.
+  //
   const {
     resources: {
       response: { modelsAndVersionIds }


### PR DESCRIPTION
We make the viewer pretend it's a connector and send out receive events. Note, this is important for us to track to be able to get a picture of how much data is consumed in our viewer.

Thx to @fabis94 for the fast help this morning on this one.