### PR TITLE
feat(fe2): Temporary Ghost URL replacement until we swap to WebFlow API

### DIFF
--- a/packages/frontend-2/pages/index.vue
+++ b/packages/frontend-2/pages/index.vue
@@ -183,7 +183,8 @@ async function fetchTutorials() {
       id: post.id,
       readingTime: post.reading_time,
       publishedAt: post.published_at,
-      url: post.url,
+      // Temporary replacement until we swap to WebFlow API
+      url: post.url?.replace('https://v1.speckle.systems', 'https://speckle.systems'),
       title: post.title,
       featureImage: getResizedGhostImage({ url: post.feature_image, width: 600 })
     }))


### PR DESCRIPTION
Ghost(old) site is now at v1.speckle.systems.

The tutorial cards in FE2 are using the Ghost API and is sending users to the old site. 

This is a temp change to replace the url given by the Ghost API, to the new Webflow site at speckle.systems.

It is important that permalinks match on both sites, and that any new articles are added to Ghost as well (even if its an empty story)