### PR TITLE
refactor(fe2): Survicate improvements

### DIFF
--- a/packages/frontend-2/plugins/survicate.client.ts
+++ b/packages/frontend-2/plugins/survicate.client.ts
@@ -1,26 +1,9 @@
-import { useOnAuthStateChange } from '~/lib/auth/composables/auth'
-import { useActiveUser } from '~~/lib/auth/composables/activeUser'
-import { useSynchronizedCookie } from '~/lib/common/composables/reactiveCookie'
-import dayjs from 'dayjs'
 import type { Survicate } from '@survicate/survicate-web-surveys-wrapper'
 import type { Nullable } from '@speckle/shared'
-import { useRoute } from 'vue-router'
+import { useOnAuthStateChange } from '~/lib/auth/composables/auth'
 
 export default defineNuxtPlugin(async () => {
-  const { isLoggedIn } = useActiveUser()
-  const route = useRoute()
   let survicateInstance = null as Nullable<Survicate>
-
-  // Check if the current route is the auth verify application page
-  const isAuthVerifyPage = computed(() => route.name === 'authorize-app')
-
-  if (!isLoggedIn.value || isAuthVerifyPage.value) {
-    return {
-      provide: {
-        survicate: survicateInstance
-      }
-    }
-  }
 
   const {
     public: { survicateWorkspaceKey }
@@ -28,10 +11,12 @@ export default defineNuxtPlugin(async () => {
 
   const logger = useLogger()
   const onAuthStateChange = useOnAuthStateChange()
-  const prepareSurvey = useInitMainSurvey()
+  const { isLoggedIn } = useActiveUser()
+  const route = useRoute()
 
-  // Skip initialization if the survicateWorkspaceKey is empty or undefined
-  if (!survicateWorkspaceKey?.length) {
+  const isAuthVerifyPage = computed(() => route.name === 'authorize-app')
+
+  if (!survicateWorkspaceKey?.length || !isLoggedIn.value || isAuthVerifyPage.value) {
     return {
       provide: {
         survicate: survicateInstance
@@ -67,7 +52,8 @@ export default defineNuxtPlugin(async () => {
           { immediate: true }
         )
 
-        prepareSurvey(survicateInstance)
+        //Send NPS event
+        survicateInstance.invokeEvent('nps-survey')
       })
       .catch(logger.error)
   } catch (error) {
@@ -80,40 +66,3 @@ export default defineNuxtPlugin(async () => {
     }
   }
 })
-
-function useInitMainSurvey() {
-  const onboardingOrFeedbackDateString = useSynchronizedCookie<string | undefined>(
-    'onboardingOrFeedbackDate',
-    {
-      default: () => dayjs().startOf('day').format('YYYY-MM-DD')
-    }
-  )
-  const { projectVersionCount } = useActiveUser()
-
-  return (survicateInstance: Survicate) => {
-    const onboardingOrFeedbackDate = onboardingOrFeedbackDateString.value
-      ? new Date(onboardingOrFeedbackDateString.value)
-      : new Date()
-
-    const shouldShowSurvey = checkSurveyDisplayConditions(
-      onboardingOrFeedbackDate,
-      projectVersionCount
-    )
-
-    if (shouldShowSurvey) {
-      survicateInstance.invokeEvent('nps-survey')
-    }
-  }
-}
-
-function checkSurveyDisplayConditions(
-  onboardingOrFeedbackDate: Date,
-  projectVersionCount: ComputedRef<number | undefined>
-): boolean {
-  const threeDaysAfterOnboarding = dayjs(onboardingOrFeedbackDate).add(7, 'day')
-  const isAfterOnboardingPeriod = dayjs().isAfter(threeDaysAfterOnboarding)
-
-  const minimumThreeVersions = (projectVersionCount?.value ?? 0) > 9
-
-  return isAfterOnboardingPeriod && minimumThreeVersions
-}


### PR DESCRIPTION
Survicate now allow a delay in the triggering of the first survey, so a lot of the complications in this can be removed. We now don't need to track the onboarding date as a cookie. 

This would require the following changes to the NPS survey in survicate:
<img width="624" alt="image" src="https://github.com/user-attachments/assets/f5c39339-8b8f-47de-9599-ca76ffa080c3">
