### PR TITLE
fix(fe2): Remove spacing in invite banners

### DIFF
--- a/packages/frontend-2/components/projects/DashboardHeader.vue
+++ b/packages/frontend-2/components/projects/DashboardHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="hasBanners" class="space-y-3 mb-8 empty:mb-0">
+    <div v-if="hasBanners" class="mb-8 empty:mb-0">
       <ProjectsInviteBanners
         v-if="projectsInvites?.projectInvites?.length"
         :invites="projectsInvites"


### PR DESCRIPTION
@benjaminvo I think there was a merge conflict in your papercuts branch. There was a slight change to the invite banners yesterday, which now makes the `space-y-3` class add spacing between each banner, rather than banner groups. 

<img width="678" alt="image" src="https://github.com/user-attachments/assets/c2aeb7ea-3113-49bc-aadf-b8532f136808">
