### PR TITLE
fix(server): more resilient sign up tracking

### DIFF
--- a/packages/server/modules/auth/index.ts
+++ b/packages/server/modules/auth/index.ts
@@ -1,7 +1,7 @@
 import { SpeckleModule } from '@/modules/shared/helpers/typeHelper'
 
 import { registerOrUpdateScopeFactory } from '@/modules/shared/repositories/scopes'
-import { moduleLogger } from '@/logging/logging'
+import { authLogger, moduleLogger } from '@/logging/logging'
 import db from '@/db/knex'
 import { initializeDefaultAppsFactory } from '@/modules/auth/services/serverApps'
 import {
@@ -59,6 +59,7 @@ import { deleteOldAndInsertNewVerificationFactory } from '@/modules/emails/repos
 import { renderEmail } from '@/modules/emails/services/emailRendering'
 import { sendEmail } from '@/modules/emails/services/sending'
 import { getServerInfoFactory } from '@/modules/core/repositories/server'
+import { initializeEventListenerFactory } from '@/modules/auth/services/postAuth'
 
 const findEmail = findEmailFactory({ db })
 const requestNewEmailVerification = requestNewEmailVerificationFactory({
@@ -139,7 +140,7 @@ const setupStrategies = setupStrategiesFactory({
 
 let authStrategies: AuthStrategyMetadata[]
 
-export const init: SpeckleModule['init'] = async (app) => {
+export const init: SpeckleModule['init'] = async (app, isInitial) => {
   moduleLogger.info('🔑 Init auth module')
 
   // Initialize authn strategies
@@ -152,6 +153,15 @@ export const init: SpeckleModule['init'] = async (app) => {
   const registerFunc = registerOrUpdateScopeFactory({ db })
   for (const scope of authScopes) {
     await registerFunc({ scope })
+  }
+
+  // Listen to event emitters
+  if (isInitial) {
+    const initializeEventListener = initializeEventListenerFactory({
+      usersEventsListener: UsersEmitter.listen,
+      logger: authLogger
+    })
+    initializeEventListener()
   }
 }
 

--- a/packages/server/modules/auth/services/postAuth.ts
+++ b/packages/server/modules/auth/services/postAuth.ts
@@ -1,0 +1,68 @@
+import { Logger } from '@/logging/logging'
+import {
+  addToMailchimpAudience,
+  triggerMailchimpCustomerJourney
+} from '@/modules/auth/services/mailchimp'
+import {
+  UsersEvents,
+  UsersEventsListener,
+  UsersEventsPayloads
+} from '@/modules/core/events/usersEmitter'
+import {
+  enableMixpanel,
+  getMailchimpNewsletterIds,
+  getMailchimpOnboardingIds,
+  getMailchimpStatus
+} from '@/modules/shared/helpers/envHelper'
+import { mixpanel } from '@/modules/shared/utils/mixpanel'
+
+const onUserCreatedFactory =
+  (deps: { logger: Logger }) =>
+  async (payload: UsersEventsPayloads[UsersEvents.Created]) => {
+    const { user, signUpCtx } = payload
+
+    try {
+      // Send event to MP
+      const userEmail = user.email
+      const newsletterConsent = signUpCtx?.newsletterConsent
+
+      if (userEmail && enableMixpanel()) {
+        const isInvite = !!signUpCtx?.isInvite
+        await mixpanel({ userEmail, req: signUpCtx?.req }).track('Sign Up', {
+          isInvite
+        })
+      }
+
+      // Set up mailchimp
+      if (getMailchimpStatus()) {
+        try {
+          const onboardingIds = getMailchimpOnboardingIds()
+          await triggerMailchimpCustomerJourney(user, onboardingIds)
+
+          if (newsletterConsent) {
+            const { listId } = getMailchimpNewsletterIds()
+            await addToMailchimpAudience(user, listId)
+          }
+        } catch (error) {
+          deps.logger.warn(error, 'Failed to sign up user to mailchimp lists')
+        }
+      }
+    } catch (e) {
+      deps.logger.error(
+        {
+          error: e,
+          userId: user.id
+        },
+        'Post sign up tracking failed'
+      )
+    }
+  }
+
+export const initializeEventListenerFactory =
+  (deps: { usersEventsListener: UsersEventsListener; logger: Logger }) => () => {
+    const onUserCreated = onUserCreatedFactory(deps)
+
+    const cbs = [deps.usersEventsListener(UsersEvents.Created, onUserCreated)]
+
+    return () => cbs.forEach((cb) => cb())
+  }

--- a/packages/server/modules/auth/strategies/azureAd.ts
+++ b/packages/server/modules/auth/strategies/azureAd.ts
@@ -158,7 +158,12 @@ const azureAdStrategyBuilderFactory =
               role: invite
                 ? getResourceTypeRole(invite.resource, ServerInviteResourceType)
                 : undefined,
-              verified: !!invite
+              verified: !!invite,
+              signUpContext: {
+                req,
+                isInvite: !!invite,
+                newsletterConsent: !!req.session.newsletterConsent
+              }
             }
           })
 

--- a/packages/server/modules/auth/strategies/github.ts
+++ b/packages/server/modules/auth/strategies/github.ts
@@ -132,7 +132,12 @@ const githubStrategyBuilderFactory =
               role: invite
                 ? getResourceTypeRole(invite.resource, ServerInviteResourceType)
                 : undefined,
-              verified: !!invite
+              verified: !!invite,
+              signUpContext: {
+                req,
+                isInvite: !!invite,
+                newsletterConsent: !!req.session.newsletterConsent
+              }
             }
           })
 

--- a/packages/server/modules/auth/strategies/google.ts
+++ b/packages/server/modules/auth/strategies/google.ts
@@ -115,7 +115,12 @@ const googleStrategyBuilderFactory =
               role: invite
                 ? getResourceTypeRole(invite.resource, ServerInviteResourceType)
                 : undefined,
-              verified: !!invite
+              verified: !!invite,
+              signUpContext: {
+                req,
+                isInvite: !!invite,
+                newsletterConsent: !!req.session.newsletterConsent
+              }
             }
           })
 

--- a/packages/server/modules/auth/strategies/local.ts
+++ b/packages/server/modules/auth/strategies/local.ts
@@ -117,7 +117,12 @@ const localStrategyBuilderFactory =
             role: invite
               ? getResourceTypeRole(invite.resource, ServerInviteResourceType)
               : undefined,
-            verified: !!invite
+            verified: !!invite,
+            signUpContext: {
+              req,
+              isInvite: !!invite,
+              newsletterConsent: !!req.session.newsletterConsent
+            }
           })
           req.user = {
             id: userId,

--- a/packages/server/modules/auth/strategies/oidc.ts
+++ b/packages/server/modules/auth/strategies/oidc.ts
@@ -126,7 +126,12 @@ const oidcStrategyBuilderFactory =
                 role: invite
                   ? getResourceTypeRole(invite.resource, ServerInviteResourceType)
                   : undefined,
-                verified: !!invite
+                verified: !!invite,
+                signUpContext: {
+                  req,
+                  isInvite: !!invite,
+                  newsletterConsent: !!req.session.newsletterConsent
+                }
               }
             })
 

--- a/packages/server/modules/core/domain/users/operations.ts
+++ b/packages/server/modules/core/domain/users/operations.ts
@@ -1,6 +1,7 @@
 import {
   LimitedUser,
   User,
+  UserSignUpContext,
   UserWithOptionalRole
 } from '@/modules/core/domain/users/types'
 import { UserUpdateInput } from '@/modules/core/graph/generated/graphql'
@@ -113,6 +114,10 @@ export type CreateValidatedUser = (
     verified?: boolean
     password?: string
     role?: ServerRoles
+    /**
+     * Only OK to leave unset in fake/simulated scenarios such as tests
+     */
+    signUpContext?: Optional<UserSignUpContext>
   },
   options?: Partial<{
     skipPropertyValidation: boolean
@@ -126,6 +131,10 @@ export type FindOrCreateValidatedUser = (params: {
     role?: ServerRoles
     bio?: string
     verified?: boolean
+    /**
+     * Only OK to leave unset in fake/simulated scenarios such as tests
+     */
+    signUpContext?: Optional<UserSignUpContext>
   }
 }) => Promise<{
   id: string

--- a/packages/server/modules/core/domain/users/types.ts
+++ b/packages/server/modules/core/domain/users/types.ts
@@ -1,5 +1,7 @@
 import { LimitedUserRecord, UserRecord } from '@/modules/core/helpers/userHelper'
 import { ServerRoles } from '@speckle/shared'
+import type express from 'express'
+import type http from 'http'
 
 export type User = UserRecord
 export type LimitedUser = LimitedUserRecord
@@ -12,3 +14,18 @@ export type UserWithOptionalRole<UserType extends LimitedUserRecord = UserRecord
      */
     role?: ServerRoles
   }
+
+export type UserSignUpContext = {
+  /**
+   * Set when the user creation is happening in the context of a Web request and is triggered by the user making the request.
+   */
+  req: express.Request | http.IncomingMessage
+  /**
+   * Set to true, if user is created because of an invite. Important for tracking.
+   */
+  isInvite: boolean
+  /**
+   * Whether user agrees to sign up to newsletter
+   */
+  newsletterConsent: boolean
+}

--- a/packages/server/modules/core/events/usersEmitter.ts
+++ b/packages/server/modules/core/events/usersEmitter.ts
@@ -1,12 +1,20 @@
+import { UserSignUpContext } from '@/modules/core/domain/users/types'
 import { UserRecord } from '@/modules/core/helpers/types'
 import { initializeModuleEventEmitter } from '@/modules/shared/services/moduleEventEmitterSetup'
+import { Optional } from '@speckle/shared'
 
 export enum UsersEvents {
   Created = 'created'
 }
 
 export type UsersEventsPayloads = {
-  [UsersEvents.Created]: { user: UserRecord }
+  [UsersEvents.Created]: {
+    user: UserRecord
+    /**
+     * Should be set in all real non-simulated sign up sessions
+     */
+    signUpCtx: Optional<UserSignUpContext>
+  }
 }
 
 const { emit, listen } = initializeModuleEventEmitter<UsersEventsPayloads>({

--- a/packages/server/modules/core/services/users/management.ts
+++ b/packages/server/modules/core/services/users/management.ts
@@ -144,12 +144,15 @@ export const createUserFactory =
     // ONLY ALLOW SKIPPING WHEN CREATING USERS FOR TESTS, IT'S UNSAFE OTHERWISE
     const { skipPropertyValidation = false } = options || {}
 
+    const signUpCtx = user.signUpContext
+
     let finalUser: typeof user &
       Omit<NullableKeysToOptional<UserRecord>, 'suuid' | 'createdAt'> = {
       ...user,
       id: crs({ length: 10 }),
       verified: user.verified || false
     }
+    delete finalUser.signUpContext
 
     if (!finalUser.email?.length) throw new UserInputError('E-mail address is required')
 
@@ -220,7 +223,7 @@ export const createUserFactory =
       }
     })
 
-    await deps.usersEventsEmitter(UsersEvents.Created, { user: newUser })
+    await deps.usersEventsEmitter(UsersEvents.Created, { user: newUser, signUpCtx })
 
     return newUser.id
   }

--- a/packages/server/modules/shared/utils/mixpanel.ts
+++ b/packages/server/modules/shared/utils/mixpanel.ts
@@ -8,6 +8,7 @@ import {
 import Mixpanel from 'mixpanel'
 import { mixpanelLogger } from '@/logging/logging'
 import type express from 'express'
+import type http from 'http'
 
 let client: Optional<Mixpanel.Mixpanel> = undefined
 let baseTrackingProperties: Optional<Record<string, string>> = undefined
@@ -45,7 +46,7 @@ export function getClient() {
  */
 export function mixpanel(params: {
   userEmail: Optional<string>
-  req: Optional<express.Request>
+  req: Optional<express.Request | http.IncomingMessage>
 }) {
   const { userEmail, req } = params
   const mixpanelUserId = userEmail?.length
@@ -57,7 +58,7 @@ export function mixpanel(params: {
       const payload = {
         ...MixpanelUtils.buildPropertiesPayload({
           distinctId: mixpanelUserId,
-          query: req?.query || {},
+          query: (req && 'query' in req ? req?.query : {}) || {},
           headers: req?.headers || {},
           remoteAddress: req?.socket?.remoteAddress
         }),


### PR DESCRIPTION
Matteo noticed that Sign Up MP events don't always fire: https://discord.com/channels/726756379083145269/1296758480606330880/1296853364251824200

Ultimately this seems to happen because the auth flow fails near the very end, but after the new user is already created. It's not clear to me why it fails (the one scenario happened because of a mismatched challenge, but how did that happen especially in the Google SSO flow?), but it is a problem that an authentication failure prevents post-sign up activities from firing.

So I refactored the logic to be more resilient - post-sign up tracking is now done pretty much right after user creation and it occurs independently from the actual sign in flow, so if the very last step fails - if a user was created, the event should be fired.