### PR TITLE
fix(ui-components): Update bounding on opening of LayoutMenu when mountMenuOnBody

### DIFF
--- a/packages/ui-components/src/components/layout/Menu.vue
+++ b/packages/ui-components/src/components/layout/Menu.vue
@@ -153,7 +153,12 @@ const chooseItem = (item: LayoutMenuItem, event: MouseEvent) => {
   emit('chosen', { item, event })
 }
 
-const toggle = () => menuButton.value?.el.click()
+const toggle = () => {
+  menuButton.value?.el.click()
+  if (props.mountMenuOnBody) {
+    menuButtonBounding.update()
+  }
+}
 
 // ok this is a bit hacky, but it's done because of headlessui's limited API
 // the point of this is 1) cast any to bool 2) store 'open' state locally


### PR DESCRIPTION
If the position of a LayoutMenu updates, the position for the dropdown did not update to reflect this. 

Now, when opening a LayoutMenu with mount-menu-on-body prop, we recalculate the bounding. 