### PR TITLE
fix(workspacs): workspace soft delete

### DIFF
--- a/packages/server/modules/shared/test/unit/eventBus.spec.ts
+++ b/packages/server/modules/shared/test/unit/eventBus.spec.ts
@@ -17,7 +17,8 @@ const createFakeWorkspace = (): Omit<Workspace, 'domains'> => {
     createdAt: new Date(),
     defaultProjectRole: Roles.Stream.Contributor,
     domainBasedMembershipProtectionEnabled: false,
-    discoverabilityEnabled: false
+    discoverabilityEnabled: false,
+    deleteAfter: null
   }
 }
 

--- a/packages/server/modules/workspaces/domain/operations.ts
+++ b/packages/server/modules/workspaces/domain/operations.ts
@@ -23,7 +23,7 @@ import { TokenResourceIdentifier } from '@/modules/core/domain/tokens/types'
 /** Workspace */
 
 type UpsertWorkspaceArgs = {
-  workspace: Omit<Workspace, 'domains'>
+  workspace: Omit<Workspace, 'domains' | 'deleteAfter'>
 }
 
 export type UpsertWorkspace = (args: UpsertWorkspaceArgs) => Promise<void>

--- a/packages/server/modules/workspaces/repositories/workspaces.ts
+++ b/packages/server/modules/workspaces/repositories/workspaces.ts
@@ -110,7 +110,6 @@ const workspaceWithRoleBaseQuery = ({
         // Getting first role from grouped results
         knex.raw(`(array_agg("workspace_acl"."role"))[1] as role`)
       ])
-      .whereNull(Workspaces.col.deleteAfter)
       .leftJoin(DbWorkspaceAcl.name, function () {
         this.on(DbWorkspaceAcl.col.workspaceId, Workspaces.col.id).andOnVal(
           DbWorkspaceAcl.col.userId,
@@ -119,6 +118,7 @@ const workspaceWithRoleBaseQuery = ({
       })
       .groupBy(Workspaces.col.id)
   }
+  q.whereNull(Workspaces.col.deleteAfter)
   return q
 }
 

--- a/packages/server/modules/workspaces/services/management.ts
+++ b/packages/server/modules/workspaces/services/management.ts
@@ -160,7 +160,8 @@ export const createWorkspaceFactory =
       updatedAt: new Date(),
       defaultProjectRole: Roles.Stream.Contributor,
       domainBasedMembershipProtectionEnabled: false,
-      discoverabilityEnabled: false
+      discoverabilityEnabled: false,
+      deleteAfter: null
     }
     await upsertWorkspace({ workspace })
     // assign the creator as workspace administrator

--- a/packages/server/modules/workspaces/tests/integration/repositories.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/repositories.spec.ts
@@ -82,17 +82,6 @@ const createAndStoreTestUser = async (): Promise<BasicTestUser> => {
 }
 
 describe('Workspace repositories', () => {
-  const testServerAdmin: BasicTestUser = {
-    id: '',
-    name: 'John A Speckle',
-    email: 'john@example.speckle',
-    role: Roles.Server.Admin
-  }
-
-  before(async () => {
-    await createTestUsers([testServerAdmin])
-  })
-
   describe('getWorkspaceFactory creates a function, that', () => {
     it('returns null if the workspace is not found', async () => {
       const workspace = await getWorkspace({
@@ -101,12 +90,19 @@ describe('Workspace repositories', () => {
       expect(workspace).to.be.null
     })
     it('returns null if workspace is marked as deleted', async () => {
+      const testServerAdmin: BasicTestUser = {
+        id: '',
+        name: 'John A Speckle',
+        email: 'john@example.speckle',
+        role: Roles.Server.Admin
+      }
       const testWorkspace: BasicTestWorkspace = {
         id: '',
         ownerId: '',
         slug: cryptoRandomString({ length: 10 }),
         name: 'Test Workspace'
       }
+      await createTestUsers([testServerAdmin])
       await createTestWorkspace(testWorkspace, testServerAdmin)
       await deleteWorkspace({ workspaceId: testWorkspace.id })
 
@@ -126,12 +122,19 @@ describe('Workspace repositories', () => {
       expect(workspace).to.be.null
     })
     it('returns the workspace if it exists', async () => {
+      const testServerAdmin: BasicTestUser = {
+        id: '',
+        name: 'John A Speckle',
+        email: 'john@example.speckle',
+        role: Roles.Server.Admin
+      }
       const testWorkspace: BasicTestWorkspace = {
         id: '',
         ownerId: '',
         slug: cryptoRandomString({ length: 10 }),
         name: 'Test Workspace'
       }
+      await createTestUsers([testServerAdmin])
       await createTestWorkspace(testWorkspace, testServerAdmin)
 
       const workspace = await getWorkspaceBySlug({
@@ -141,12 +144,19 @@ describe('Workspace repositories', () => {
       expect(workspace?.id).to.be.equal(testWorkspace.id)
     })
     it('returns null if the workspace is marked as deleted', async () => {
+      const testServerAdmin: BasicTestUser = {
+        id: '',
+        name: 'John A Speckle',
+        email: 'john@example.speckle',
+        role: Roles.Server.Admin
+      }
       const testWorkspace: BasicTestWorkspace = {
         id: '',
         ownerId: '',
         slug: cryptoRandomString({ length: 10 }),
         name: 'Test Workspace'
       }
+      await createTestUsers([testServerAdmin])
       await createTestWorkspace(testWorkspace, testServerAdmin)
       await deleteWorkspace({ workspaceId: testWorkspace.id })
 

--- a/packages/server/modules/workspaces/tests/integration/workspaces.graph.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/workspaces.graph.spec.ts
@@ -836,9 +836,9 @@ describe('Workspaces GQL CRUD', () => {
         const memberApollo: TestApolloServer = (apollo = await testApolloServer({
           context: createTestContext({
             auth: true,
-            userId: testAdminUser.id,
+            userId: testMemberUser.id,
             token: '',
-            role: testAdminUser.role,
+            role: testMemberUser.role,
             scopes: AllScopes
           })
         }))

--- a/packages/server/modules/workspaces/tests/unit/services/domains.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/services/domains.spec.ts
@@ -32,7 +32,8 @@ describe('workspace domain services', () => {
           domainBasedMembershipProtectionEnabled: false,
           defaultProjectRole: 'stream:contributor',
           domains: [],
-          id: cryptoRandomString({ length: 10 })
+          id: cryptoRandomString({ length: 10 }),
+          deleteAfter: null
         }),
         findEmailsByUserId: async () => []
       })({
@@ -66,7 +67,8 @@ describe('workspace domain services', () => {
               workspaceId: cryptoRandomString({ length: 10 })
             }
           ],
-          id: cryptoRandomString({ length: 10 })
+          id: cryptoRandomString({ length: 10 }),
+          deleteAfter: null
         }),
         findEmailsByUserId: async () => [
           {

--- a/packages/server/modules/workspaces/tests/unit/services/join.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/services/join.spec.ts
@@ -32,7 +32,8 @@ const createTestWorkspaceWithDomains = (
     discoverabilityEnabled: false,
     domainBasedMembershipProtectionEnabled: false,
     defaultProjectRole: Roles.Stream.Contributor,
-    defaultLogoIndex: 0
+    defaultLogoIndex: 0,
+    deleteAfter: null
   }
   if (arg) assign(workspace, arg)
   return workspace

--- a/packages/server/modules/workspaces/tests/unit/services/management.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/services/management.spec.ts
@@ -40,7 +40,7 @@ import { FindVerifiedEmailsByUserId } from '@/modules/core/domain/userEmails/ope
 import { EventNames } from '@/modules/shared/services/eventBus'
 
 type WorkspaceTestContext = {
-  storedWorkspaces: Omit<Workspace, 'domains'>[]
+  storedWorkspaces: Omit<Workspace, 'domains' | 'deleteAfter'>[]
   storedRoles: WorkspaceAcl[]
   eventData: {
     isCalled: boolean
@@ -66,7 +66,7 @@ const buildCreateWorkspaceWithTestContext = (
     upsertWorkspace: async ({
       workspace
     }: {
-      workspace: Omit<Workspace, 'domains'>
+      workspace: Omit<Workspace, 'domains' | 'deleteAfter'>
     }) => {
       context.storedWorkspaces.push(workspace)
     },
@@ -265,7 +265,8 @@ describe('Workspace services', () => {
         discoverabilityEnabled: false,
         domainBasedMembershipProtectionEnabled: false,
         defaultProjectRole: 'stream:contributor',
-        domains: []
+        domains: [],
+        deleteAfter: null
       }
       return merge(workspace, input)
     }
@@ -1083,7 +1084,8 @@ describe('Workspace role services', () => {
                   discoverabilityEnabled: false,
                   domainBasedMembershipProtectionEnabled: false,
                   defaultProjectRole: 'stream:contributor',
-                  defaultLogoIndex: 0
+                  defaultLogoIndex: 0,
+                  deleteAfter: null
                 }
               },
               getDomains: async () => {
@@ -1127,7 +1129,8 @@ describe('Workspace role services', () => {
           discoverabilityEnabled: false,
           domainBasedMembershipProtectionEnabled: false,
           defaultProjectRole: 'stream:contributor',
-          defaultLogoIndex: 0
+          defaultLogoIndex: 0,
+          deleteAfter: null
         }
 
         await addDomainToWorkspaceFactory({
@@ -1169,7 +1172,8 @@ describe('Workspace role services', () => {
         }
 
         let storedDomains: WorkspaceDomain | undefined = undefined
-        let storedWorkspace: Omit<Workspace, 'domains'> | undefined = undefined
+        let storedWorkspace: Omit<Workspace, 'domains' | 'deleteAfter'> | undefined =
+          undefined
         let omittedEventName: EventNames | undefined = undefined
 
         const workspace: Workspace = {
@@ -1183,7 +1187,8 @@ describe('Workspace role services', () => {
           discoverabilityEnabled: false,
           domainBasedMembershipProtectionEnabled: false,
           defaultProjectRole: 'stream:contributor',
-          defaultLogoIndex: 0
+          defaultLogoIndex: 0,
+          deleteAfter: null
         }
 
         await addDomainToWorkspaceFactory({
@@ -1246,7 +1251,8 @@ describe('Workspace role services', () => {
           domainBasedMembershipProtectionEnabled: false,
           domains: [],
           defaultProjectRole: Roles.Stream.Contributor,
-          defaultLogoIndex: 0
+          defaultLogoIndex: 0,
+          deleteAfter: null
         }
 
         let workspaceData: Workspace = {

--- a/packages/server/modules/workspacesCore/domain/types.ts
+++ b/packages/server/modules/workspacesCore/domain/types.ts
@@ -31,6 +31,7 @@ export type Workspace = {
   defaultProjectRole: WorkspaceDefaultProjectRole
   domainBasedMembershipProtectionEnabled: boolean
   discoverabilityEnabled: boolean
+  deleteAfter: Date | null
 }
 
 export type WorkspaceWithDomains = Workspace & { domains: WorkspaceDomain[] }

--- a/packages/server/modules/workspacesCore/helpers/db.ts
+++ b/packages/server/modules/workspacesCore/helpers/db.ts
@@ -11,7 +11,8 @@ export const Workspaces = buildTableHelper('workspaces', [
   'defaultLogoIndex',
   'defaultProjectRole',
   'domainBasedMembershipProtectionEnabled',
-  'discoverabilityEnabled'
+  'discoverabilityEnabled',
+  'deleteAfter'
 ])
 
 export const WorkspaceAcl = buildTableHelper('workspace_acl', [

--- a/packages/server/modules/workspacesCore/migrations/20241021220137_workspace_soft_delete.ts
+++ b/packages/server/modules/workspacesCore/migrations/20241021220137_workspace_soft_delete.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('workspaces', (table) => {
+    table
+      .timestamp('deleteAfter', { precision: 3, useTz: true })
+      .nullable()
+      .defaultTo(null)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('workspaces', (table) => {
+    table.dropColumn('deleteAfter')
+  })
+}

--- a/packages/server/test/speckle-helpers/workspaces.ts
+++ b/packages/server/test/speckle-helpers/workspaces.ts
@@ -18,6 +18,7 @@ export const createAndStoreTestWorkspaceFactory =
       discoverabilityEnabled: false,
       defaultLogoIndex: 0,
       defaultProjectRole: Roles.Stream.Contributor,
+      deleteAfter: null,
       ...workspaceOverrides
     }
 


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Raised some flags that it's somewhat dangerous to immediately delete everything associated with a workspace.
- A user-facing way to message and manage this is high-investment
- We can still do the soft delete (for recovery reasons) and handle the other bits later

## Changes:

- Introduces `deleteAfter` on workspace records, set to 30 days after `deleteWorkspace` is called
- Filters out workspaces with `deleteAfter` from all workspace query repo functions

Lots to discuss, fronted and backend, with how we want to surface these soft deleted workspaces...