### PR TITLE
fix(sso): revoke all sso sessions on logout

### DIFF
--- a/packages/frontend-2/lib/auth/composables/auth.ts
+++ b/packages/frontend-2/lib/auth/composables/auth.ts
@@ -190,6 +190,7 @@ export const useAuthManager = (
   const getMixpanel = useDeferredMixpanel()
   const postAuthRedirect = usePostAuthRedirect()
   const { markLoggedOut } = useJustLoggedOutTracking()
+  const isSsoEnabled = useIsWorkspacesSsoEnabled()
 
   /**
    * Invite token, if any
@@ -396,6 +397,17 @@ export const useAuthManager = (
       forceFullReload: boolean
     }>
   ) => {
+    if (isSsoEnabled.value) {
+      await fetch(new URL('/api/v1/auth/logout', apiOrigin).toString(), {
+        method: 'POST',
+        headers: authToken.value
+          ? {
+              Authorization: authToken.value
+            }
+          : undefined
+      })
+    }
+
     await saveNewToken(undefined, { skipRedirect: true })
 
     if (!options?.skipToast) {

--- a/packages/server/modules/workspaces/domain/sso.ts
+++ b/packages/server/modules/workspaces/domain/sso.ts
@@ -48,6 +48,8 @@ export type StoreUserSsoSession = (args: {
   userSsoSession: UserSsoSession
 }) => Promise<void>
 
+export type RevokeUserSsoSessions = (args: { userId: string }) => Promise<void>
+
 export const oidcProviderValidationRequest = z.object({
   token: z.string(),
   provider: oidcProvider

--- a/packages/server/modules/workspaces/repositories/sso.ts
+++ b/packages/server/modules/workspaces/repositories/sso.ts
@@ -7,7 +7,8 @@ import {
   AssociateSsoProviderWithWorkspace,
   StoreUserSsoSession,
   UserSsoSession,
-  GetWorkspaceSsoProvider
+  GetWorkspaceSsoProvider,
+  RevokeUserSsoSessions
 } from '@/modules/workspaces/domain/sso'
 import Redis from 'ioredis'
 import { Knex } from 'knex'
@@ -96,4 +97,10 @@ export const storeUserSsoSessionFactory =
   ({ db }: { db: Knex }): StoreUserSsoSession =>
   async ({ userSsoSession }) => {
     await tables.userSsoSessions(db).insert(userSsoSession)
+  }
+
+export const revokeUserSsoSessionsFactory =
+  ({ db }: { db: Knex }): RevokeUserSsoSessions =>
+  async ({ userId }) => {
+    await tables.userSsoSessions(db).where({ userId }).delete()
   }

--- a/packages/server/modules/workspaces/rest/sso.ts
+++ b/packages/server/modules/workspaces/rest/sso.ts
@@ -18,7 +18,8 @@ import {
   associateSsoProviderWithWorkspaceFactory,
   storeProviderRecordFactory,
   storeUserSsoSessionFactory,
-  getWorkspaceSsoProviderFactory
+  getWorkspaceSsoProviderFactory,
+  revokeUserSsoSessionsFactory
 } from '@/modules/workspaces/repositories/sso'
 import { buildDecryptor, buildEncryptor } from '@/modules/shared/utils/libsodium'
 import { getEncryptionKeyPair } from '@/modules/automate/services/encryption'
@@ -118,6 +119,18 @@ router.get(
     res?.json(limitedWorkspace)
   }
 )
+
+router.post('/api/v1/auth/logout', async ({ context, res }) => {
+  const { userId } = context
+
+  if (!userId) {
+    return res?.status(200).send()
+  }
+
+  await revokeUserSsoSessionsFactory({ db })({ userId })
+
+  return res?.status(200).send()
+})
 
 router.get(
   '/api/v1/workspaces/:workspaceSlug/sso/oidc/validate',


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- SSO sessions are currently too sticky - they should be revoked when the user signs out

## Changes:

- Add `RevokeUserSsoSessions`
- Add workspace sso rest endpoint `/api/v1/auth/logout`, which calls the above repo function
- Makes request during logout, if Sso is enabled
