### PR TITLE
feat(fe2): Add change role dialog to guests table

### DIFF
--- a/packages/frontend-2/components/form/select/WorkspaceRoles.vue
+++ b/packages/frontend-2/components/form/select/WorkspaceRoles.vue
@@ -13,6 +13,7 @@
     :fully-control-value="fullyControlValue"
     :disabled="disabled"
     :disabled-item-predicate="disabledItemPredicate"
+    :disabled-item-tooltip="disabledItemTooltip"
     :clearable="clearable"
   >
     <template #nothing-selected>
@@ -82,6 +83,10 @@ const props = defineProps({
     required: false,
     type: Array as PropType<WorkspaceRoles[]>
   },
+  currentRole: {
+    type: String as PropType<WorkspaceRoles>,
+    required: false
+  },
   showLabel: Boolean,
   clearable: Boolean,
   hideItems: {
@@ -115,8 +120,15 @@ const roles = computed(() => {
   return Object.values(Roles.Workspace)
 })
 
+const disabledItemTooltip = computed(() =>
+  props.currentRole
+    ? `User is already a ${RoleInfo.Workspace[props.currentRole].title}`
+    : undefined
+)
+
 const disabledItemPredicate = (item: WorkspaceRoles) =>
-  props.disabledItems && props.disabledItems.length > 0
-    ? props.disabledItems.includes(item)
-    : false
+  (props.disabledItems &&
+    props.disabledItems.length > 0 &&
+    props.disabledItems.includes(item)) ||
+  item === props.currentRole
 </script>

--- a/packages/frontend-2/components/settings/shared/ChangeRoleDialog.vue
+++ b/packages/frontend-2/components/settings/shared/ChangeRoleDialog.vue
@@ -6,8 +6,8 @@
         v-model="newRole"
         label="New role"
         fully-control-value
-        :hide-items="hideItems"
         :disabled-items="disabledItems"
+        :current-role="currentRole"
         show-label
         show-description
       />
@@ -45,7 +45,7 @@ const emit = defineEmits<{
 
 const props = defineProps<{
   workspaceDomainPolicyCompliant?: boolean | null
-  hideItems?: WorkspaceRoles[]
+  currentRole?: WorkspaceRoles
 }>()
 
 const open = defineModel<boolean>('open', { required: true })

--- a/packages/frontend-2/components/settings/shared/ChangeRoleDialog.vue
+++ b/packages/frontend-2/components/settings/shared/ChangeRoleDialog.vue
@@ -44,7 +44,6 @@ const emit = defineEmits<{
 }>()
 
 const props = defineProps<{
-  name: string
   workspaceDomainPolicyCompliant?: boolean | null
   hideItems?: WorkspaceRoles[]
 }>()

--- a/packages/frontend-2/components/settings/shared/ChangeRoleDialog.vue
+++ b/packages/frontend-2/components/settings/shared/ChangeRoleDialog.vue
@@ -6,6 +6,7 @@
         v-model="newRole"
         label="New role"
         fully-control-value
+        :hide-items="hideItems"
         :disabled-items="disabledItems"
         show-label
         show-description
@@ -45,6 +46,7 @@ const emit = defineEmits<{
 const props = defineProps<{
   name: string
   workspaceDomainPolicyCompliant?: boolean | null
+  hideItems?: WorkspaceRoles[]
 }>()
 
 const open = defineModel<boolean>('open', { required: true })

--- a/packages/frontend-2/components/settings/workspaces/members/GuestsTable.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/GuestsTable.vue
@@ -87,8 +87,6 @@
 
     <SettingsSharedChangeRoleDialog
       v-model:open="showChangeUserRoleDialog"
-      :name="userToModify?.user.name ?? ''"
-      :is-workspace-admin="isWorkspaceAdmin"
       :workspace-domain-policy-compliant="
         userToModify?.user.workspaceDomainPolicyCompliant
       "
@@ -107,7 +105,6 @@ import { graphql } from '~/lib/common/generated/gql'
 import { Roles, type WorkspaceRoles } from '@speckle/shared'
 import { settingsWorkspacesMembersSearchQuery } from '~~/lib/settings/graphql/queries'
 import { useQuery } from '@vue/apollo-composable'
-import { useMixpanel } from '~/lib/core/composables/mp'
 import { useWorkspaceUpdateRole } from '~/lib/workspaces/composables/management'
 import { HorizontalDirection } from '~~/lib/common/composables/window'
 import type { LayoutMenuItem } from '~~/lib/layout/helpers/components'
@@ -169,7 +166,6 @@ const userToModify = computed(
   () => guests.value.find((guest) => guest.id === userIdToModify.value) || null
 )
 
-const mixpanel = useMixpanel()
 const updateUserRole = useWorkspaceUpdateRole()
 
 const { result: searchResult, loading: searchResultLoading } = useQuery(
@@ -241,11 +237,6 @@ const onRemoveUser = async () => {
     role: null,
     workspaceId: props.workspaceId
   })
-
-  mixpanel.track('Workspace User Removed', {
-    // eslint-disable-next-line camelcase
-    workspace_id: props.workspaceId
-  })
 }
 
 const toggleMenu = (itemId: string) => {
@@ -259,12 +250,6 @@ const onUpdateRole = async (newRoleValue: WorkspaceRoles) => {
     userId: userToModify.value.id,
     role: newRoleValue,
     workspaceId: props.workspaceId
-  })
-
-  mixpanel.track('Workspace User Role Updated', {
-    newRole: newRoleValue,
-    // eslint-disable-next-line camelcase
-    workspace_id: props.workspaceId
   })
 }
 </script>

--- a/packages/frontend-2/components/settings/workspaces/members/GuestsTable.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/GuestsTable.vue
@@ -90,7 +90,7 @@
       :workspace-domain-policy-compliant="
         userToModify?.user.workspaceDomainPolicyCompliant
       "
-      :hide-items="[Roles.Workspace.Guest]"
+      :current-role="Roles.Workspace.Guest"
       @update-role="onUpdateRole"
     />
   </div>

--- a/packages/frontend-2/components/settings/workspaces/members/MembersTable.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/MembersTable.vue
@@ -82,8 +82,6 @@
     </LayoutTable>
     <SettingsSharedChangeRoleDialog
       v-model:open="showChangeUserRoleDialog"
-      :name="userToModify?.name ?? ''"
-      :is-workspace-admin="isWorkspaceAdmin"
       :workspace-domain-policy-compliant="userToModify?.workspaceDomainPolicyCompliant"
       @update-role="onUpdateRole"
     />
@@ -117,7 +115,6 @@ import {
 import { useWorkspaceUpdateRole } from '~/lib/workspaces/composables/management'
 import type { LayoutMenuItem } from '~~/lib/layout/helpers/components'
 import { HorizontalDirection } from '~~/lib/common/composables/window'
-import { useMixpanel } from '~/lib/core/composables/mp'
 import { getRoleLabel } from '~~/lib/settings/helpers/utils'
 
 type UserItem = (typeof members)['value'][0]
@@ -182,7 +179,6 @@ const { result: searchResult, loading: searchResultLoading } = useQuery(
 )
 
 const updateUserRole = useWorkspaceUpdateRole()
-const mixpanel = useMixpanel()
 const { activeUser } = useActiveUser()
 
 const showChangeUserRoleDialog = ref(false)
@@ -262,12 +258,6 @@ const onUpdateRole = async (newRoleValue: WorkspaceRoles) => {
     role: newRoleValue,
     workspaceId: props.workspaceId
   })
-
-  mixpanel.track('Workspace User Role Updated', {
-    newRole: newRoleValue,
-    // eslint-disable-next-line camelcase
-    workspace_id: props.workspaceId
-  })
 }
 
 const onRemoveUser = async () => {
@@ -277,11 +267,6 @@ const onRemoveUser = async () => {
     userId: userToModify.value.id,
     role: null,
     workspaceId: props.workspaceId
-  })
-
-  mixpanel.track('Workspace User Removed', {
-    // eslint-disable-next-line camelcase
-    workspace_id: props.workspaceId
   })
 }
 

--- a/packages/frontend-2/components/settings/workspaces/members/MembersTable.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/MembersTable.vue
@@ -83,6 +83,7 @@
     <SettingsSharedChangeRoleDialog
       v-model:open="showChangeUserRoleDialog"
       :workspace-domain-policy-compliant="userToModify?.workspaceDomainPolicyCompliant"
+      :current-role="userToModify?.role"
       @update-role="onUpdateRole"
     />
     <SettingsSharedDeleteUserDialog

--- a/packages/frontend-2/components/settings/workspaces/members/MembersTable.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/MembersTable.vue
@@ -83,7 +83,7 @@
     <SettingsSharedChangeRoleDialog
       v-model:open="showChangeUserRoleDialog"
       :workspace-domain-policy-compliant="userToModify?.workspaceDomainPolicyCompliant"
-      :current-role="userToModify?.role"
+      :current-role="currentUserRole"
       @update-role="onUpdateRole"
     />
     <SettingsSharedDeleteUserDialog
@@ -215,6 +215,14 @@ const hasNoResults = computed(
     (search.value.length || roleFilter.value) &&
     searchResult.value?.workspace.team.items.length === 0
 )
+
+const currentUserRole = computed<WorkspaceRoles | undefined>(() => {
+  if (userToModify.value?.role && isWorkspaceRole(userToModify.value.role)) {
+    return userToModify.value.role
+  }
+  return undefined
+})
+
 const filteredActionsItems = (user: UserItem) => {
   const baseItems: LayoutMenuItem[][] = []
 

--- a/packages/frontend-2/lib/workspaces/composables/management.ts
+++ b/packages/frontend-2/lib/workspaces/composables/management.ts
@@ -419,6 +419,7 @@ export function useCreateWorkspace() {
 export const useWorkspaceUpdateRole = () => {
   const { mutate } = useMutation(workspaceUpdateRoleMutation)
   const { triggerNotification } = useGlobalToast()
+  const mixpanel = useMixpanel()
 
   return async (input: WorkspaceRoleUpdateInput) => {
     const result = await mutate(
@@ -456,6 +457,19 @@ export const useWorkspaceUpdateRole = () => {
           ? 'The user role has been updated'
           : 'The user has been removed from the workspace'
       })
+
+      if (input.role) {
+        mixpanel.track('Workspace User Role Updated', {
+          newRole: input.role,
+          // eslint-disable-next-line camelcase
+          workspace_id: input.workspaceId
+        })
+      } else {
+        mixpanel.track('Workspace User Removed', {
+          // eslint-disable-next-line camelcase
+          workspace_id: input.workspaceId
+        })
+      }
     } else {
       const errorMessage = getFirstErrorMessage(result?.errors)
       triggerNotification({


### PR DESCRIPTION
Adding SettingsSharedChangeRoleDialog to guests table, triggered by the actions menu. 

Also adding a prop to this, to allow us to hide items from the role select, in this case, hide guests role when editing a guest. 