### PR TITLE
fix(fe2): Redirect to workspace when joined through discoverable banner

### DIFF
--- a/packages/frontend-2/components/workspace/invite/DiscoverableWorkspaceBanner.vue
+++ b/packages/frontend-2/components/workspace/invite/DiscoverableWorkspaceBanner.vue
@@ -22,6 +22,7 @@ import {
   getFirstErrorMessage,
   modifyObjectField
 } from '~/lib/common/helpers/graphql'
+import { workspaceRoute } from '~/lib/common/helpers/route'
 import { useMixpanel } from '~~/lib/core/composables/mp'
 
 graphql(`
@@ -131,7 +132,7 @@ const processJoin = async (accept: boolean) => {
       workspace_id: props.workspace.id
     })
 
-    router.push(`/workspaces/${props.workspace.id}`)
+    router.push(workspaceRoute(props.workspace.slug))
   } else {
     triggerNotification({
       type: ToastNotificationType.Danger,


### PR DESCRIPTION
When you have a discoverable workspace banner, and click join, now you are redirected to the workspace on success. 

This was the existing function, but it was hard coded to `workspace/id`, which doesn't exist anymore, we use slugs. I updated it to use workspaceRoute, and thanks to Chuck we now can get the slug from WorkspaceInviteDiscoverableWorkspaceBanner_LimitedWorkspace