### PR TITLE
fix(fe2): Handle no webflow api token errors more gracefully

### DIFF
--- a/packages/frontend-2/server/api/webflow.ts
+++ b/packages/frontend-2/server/api/webflow.ts
@@ -33,13 +33,11 @@ const getSixMonthsAgo = (): Date => {
 
 export default defineEventHandler(async (): Promise<{ items: WebflowItem[] }> => {
   const { webflowApiToken } = useRuntimeConfig()
+  const logger = useLogger()
 
   if (!webflowApiToken) {
-    throw createError({
-      statusCode: 500,
-      fatal: true,
-      message: 'Webflow API token is not set'
-    })
+    logger.info('Webflow API token is not set. Returning an empty array of items.')
+    return { items: [] }
   }
 
   const url =
@@ -55,11 +53,8 @@ export default defineEventHandler(async (): Promise<{ items: WebflowItem[] }> =>
 
     if (!response.ok) {
       const errMsg = `Webflow API Error: ${response.status} ${response.statusText}`
-      throw createError({
-        statusCode: response.status,
-        fatal: true,
-        message: errMsg
-      })
+      logger.error(errMsg)
+      return { items: [] }
     }
 
     const data = (await response.json()) as WebflowApiResponse
@@ -88,10 +83,7 @@ export default defineEventHandler(async (): Promise<{ items: WebflowItem[] }> =>
     }
   } catch (e) {
     const errMsg = ensureError(e).message
-    throw createError({
-      statusCode: 500,
-      fatal: true,
-      message: `Error fetching webflow items: ${errMsg}`
-    })
+    logger.error(`Error fetching webflow items: ${errMsg}`)
+    return { items: [] }
   }
 })

--- a/packages/frontend-2/server/api/webflow.ts
+++ b/packages/frontend-2/server/api/webflow.ts
@@ -53,8 +53,11 @@ export default defineEventHandler(async (): Promise<{ items: WebflowItem[] }> =>
 
     if (!response.ok) {
       const errMsg = `Webflow API Error: ${response.status} ${response.statusText}`
-      logger.error(errMsg)
-      return { items: [] }
+      throw createError({
+        statusCode: response.status,
+        fatal: true,
+        message: errMsg
+      })
     }
 
     const data = (await response.json()) as WebflowApiResponse
@@ -83,7 +86,10 @@ export default defineEventHandler(async (): Promise<{ items: WebflowItem[] }> =>
     }
   } catch (e) {
     const errMsg = ensureError(e).message
-    logger.error(`Error fetching webflow items: ${errMsg}`)
-    return { items: [] }
+    throw createError({
+      statusCode: 500,
+      fatal: true,
+      message: `Error fetching webflow items: ${errMsg}`
+    })
   }
 })


### PR DESCRIPTION
The change gracefully handles missing Webflow API tokens and other error cases by returning an empty array instead of throwing errors, while logging appropriate messages for debugging and monitoring.