### PR TITLE
fix(fe2): Add workspace name to workspace page title

### DIFF
--- a/packages/frontend-2/components/workspace/ProjectList.vue
+++ b/packages/frontend-2/components/workspace/ProjectList.vue
@@ -277,6 +277,9 @@ const onShowSettingsDialog = (target: AvailableSettingsMenuKeys) => {
 onResult((queryResult) => {
   if (queryResult.data?.workspaceBySlug) {
     workspaceMixpanelUpdateGroup(queryResult.data.workspaceBySlug)
+    useHead({
+      title: queryResult.data.workspaceBySlug.name
+    })
   }
 })
 </script>

--- a/packages/frontend-2/components/workspace/ProjectList.vue
+++ b/packages/frontend-2/components/workspace/ProjectList.vue
@@ -277,7 +277,7 @@ const onShowSettingsDialog = (target: AvailableSettingsMenuKeys) => {
 onResult((queryResult) => {
   if (queryResult.data?.workspaceBySlug) {
     workspaceMixpanelUpdateGroup(queryResult.data.workspaceBySlug)
-    useHead({
+    useHeadSafe({
       title: queryResult.data.workspaceBySlug.name
     })
   }


### PR DESCRIPTION
Added the workspace name to the page title on the workspace page. 

Set it once we have the name available.