### PR TITLE
Update README.md to use new repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
   <img src="https://user-images.githubusercontent.com/2679513/131189167-18ea5fe1-c578-47f6-9785-3748178e4312.png" width="150px"/><br/>
   Speckle | Server
 </h1>
+
+<p align="center"><a href="https://twitter.com/SpeckleSystems"><img src="https://img.shields.io/twitter/follow/SpeckleSystems?style=social" alt="Twitter Follow"></a> <a href="https://speckle.community"><img src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fspeckle.community&amp;style=flat-square&amp;logo=discourse&amp;logoColor=white" alt="Community forum users"></a> <a href="https://speckle.systems"><img src="https://img.shields.io/badge/https://-speckle.systems-royalblue?style=flat-square" alt="website"></a> <a href="https://speckle.guide/dev/"><img src="https://img.shields.io/badge/docs-speckle.guide-orange?style=flat-square&amp;logo=read-the-docs&amp;logoColor=white" alt="docs"></a></p>
+
+> Speckle is the first AEC data hub that connects with your favorite AEC tools. Speckle exists to overcome the challenges of working in a fragmented industry where communication, creative workflows, and the exchange of data are often hindered by siloed software and processes. It is here to make the industry better.
+
 <h3 align="center">
     Server and Web packages
 </h3>
-<p align="center"><b>Speckle</b> is data infrastructure for the AEC industry.</p><br/>
-
-<p align="center"><a href="https://twitter.com/SpeckleSystems"><img src="https://img.shields.io/twitter/follow/SpeckleSystems?style=social" alt="Twitter Follow"></a> <a href="https://speckle.community"><img src="https://img.shields.io/discourse/users?server=https%3A%2F%2Fspeckle.community&amp;style=flat-square&amp;logo=discourse&amp;logoColor=white" alt="Community forum users"></a> <a href="https://speckle.systems"><img src="https://img.shields.io/badge/https://-speckle.systems-royalblue?style=flat-square" alt="website"></a> <a href="https://speckle.guide/dev/"><img src="https://img.shields.io/badge/docs-speckle.guide-orange?style=flat-square&amp;logo=read-the-docs&amp;logoColor=white" alt="docs"></a></p>
 
 <p align="center">
 <a href="https://codecov.io/gh/specklesystems/speckle-server">
@@ -65,8 +67,10 @@ This monorepo is the home of the Speckle v2 web packages:
 
 Make sure to also check and ⭐️ these other Speckle repositories:
 
-- [`speckle-sharp`](https://github.com/specklesystems/speckle-sharp): .NET tooling, connectors and interoperability
+- [`speckle-sharp-connectors`](https://github.com/specklesystems/speckle-sharp-connectors): .NET connectors and desktop UI
+- [`speckle-sharp-sdk`](https://github.com/specklesystems/speckle-sharp-sdk): .NET SDK, tests, and Objects
 - [`specklepy`](https://github.com/specklesystems/specklepy): Python SDK 🐍
+- [`speckle-sketchup`](https://github.com/specklesystems/speckle-sketchup): Sketchup connector
 - [`speckle-excel`](https://github.com/specklesystems/speckle-excel): Excel connector
 - [`speckle-unity`](https://github.com/specklesystems/speckle-unity): Unity 3D connector
 - [`speckle-blender`](https://github.com/specklesystems/speckle-blender): Blender connector


### PR DESCRIPTION
https://linear.app/speckle/issue/CNX-699/update-github-links-to-point-to-v3

