### PR TITLE
feat(server): multi region support in dataloaders

### DIFF
--- a/packages/server/modules/accessrequests/tests/streamAccessRequests.spec.ts
+++ b/packages/server/modules/accessrequests/tests/streamAccessRequests.spec.ts
@@ -176,7 +176,7 @@ describe('Stream access requests', () => {
     ])
     apollo = {
       apollo: await buildApolloServer(),
-      context: createAuthedTestContext(me.id)
+      context: await createAuthedTestContext(me.id)
     }
     notificationsStateManager = buildNotificationsStateTracker()
   })

--- a/packages/server/modules/auth/tests/integration/registration.spec.ts
+++ b/packages/server/modules/auth/tests/integration/registration.spec.ts
@@ -165,7 +165,7 @@ describe('Server registration', () => {
           streamId: basicAdminStream.id
         },
         {
-          context: createTestContext({
+          context: await createTestContext({
             userId: newUser.id,
             auth: true,
             role: Roles.Server.User,

--- a/packages/server/modules/automate/tests/automations.spec.ts
+++ b/packages/server/modules/automate/tests/automations.spec.ts
@@ -578,7 +578,7 @@ const buildAutomationUpdate = () => {
         )
 
         apollo = await testApolloServer({
-          context: createTestContext({
+          context: await createTestContext({
             userId: me.id,
             token: 'abc',
             role: Roles.Server.User

--- a/packages/server/modules/blobstorage/tests/blobstorage.graph.spec.js
+++ b/packages/server/modules/blobstorage/tests/blobstorage.graph.spec.js
@@ -149,7 +149,7 @@ describe('Blobs graphql @blobstorage', () => {
     user.id = await createUser(user)
     graphqlServer = {
       apollo: await buildApolloServer(),
-      context: createAuthedTestContext(user.id)
+      context: await createAuthedTestContext(user.id)
     }
   })
 

--- a/packages/server/modules/comments/tests/comments.graph.spec.js
+++ b/packages/server/modules/comments/tests/comments.graph.spec.js
@@ -1129,10 +1129,10 @@ describe('Graphql @comments', () => {
           apollo = {
             apollo: await buildApolloServer(),
             context: user
-              ? createAuthedTestContext(user.id, {
+              ? await createAuthedTestContext(user.id, {
                   ...(user.role ? { role: user.role } : {})
                 })
-              : createTestContext()
+              : await createTestContext()
           }
 
           if (user && stream.role) {

--- a/packages/server/modules/comments/tests/comments.spec.js
+++ b/packages/server/modules/comments/tests/comments.spec.js
@@ -1255,7 +1255,7 @@ describe('Comments @comments', () => {
       // Init apollo instance w/ authenticated context
       apollo = {
         apollo: await buildApolloServer(),
-        context: createAuthedTestContext(user.id)
+        context: await createAuthedTestContext(user.id)
       }
 
       // Init token for authenticating w/ REST API

--- a/packages/server/modules/core/graph/dataloaders/index.ts
+++ b/packages/server/modules/core/graph/dataloaders/index.ts
@@ -1,0 +1,650 @@
+import {
+  defineRequestDataloaders,
+  simpleTupleCacheKey
+} from '@/modules/shared/helpers/graphqlHelper'
+import DataLoader from 'dataloader'
+import {
+  getStreamsFactory,
+  getCommitStreamsFactory,
+  getBatchUserFavoriteDataFactory,
+  getBatchStreamFavoritesCountsFactory,
+  getOwnedFavoritesCountByUserIdsFactory,
+  getStreamRolesFactory,
+  getUserStreamCountsFactory,
+  getStreamsSourceAppsFactory
+} from '@/modules/core/repositories/streams'
+import { keyBy } from 'lodash'
+import {
+  BranchRecord,
+  CommitRecord,
+  StreamFavoriteRecord,
+  StreamRecord,
+  UsersMetaRecord
+} from '@/modules/core/helpers/types'
+import { Nullable } from '@/modules/shared/helpers/typeHelper'
+import { ServerInviteRecord } from '@/modules/serverinvites/domain/types'
+import {
+  getCommitBranchesFactory,
+  getCommitsFactory,
+  getSpecificBranchCommitsFactory,
+  getStreamCommitCountsFactory,
+  getUserAuthoredCommitCountsFactory,
+  getUserStreamCommitCountsFactory
+} from '@/modules/core/repositories/commits'
+import { ResourceIdentifier, Scope } from '@/modules/core/graph/generated/graphql'
+import {
+  getBranchCommentCountsFactory,
+  getCommentParentsFactory,
+  getCommentReplyAuthorIdsFactory,
+  getCommentReplyCountsFactory,
+  getCommentsResourcesFactory,
+  getCommentsViewedAtFactory,
+  getCommitCommentCountsFactory,
+  getStreamCommentCountsFactory
+} from '@/modules/comments/repositories/comments'
+import {
+  getBranchCommitCountsFactory,
+  getBranchesByIdsFactory,
+  getBranchLatestCommitsFactory,
+  getStreamBranchCountsFactory,
+  getStreamBranchesByNameFactory
+} from '@/modules/core/repositories/branches'
+import { CommentRecord } from '@/modules/comments/helpers/types'
+import { metaHelpers } from '@/modules/core/helpers/meta'
+import { Users } from '@/modules/core/dbSchema'
+import { getStreamPendingModelsFactory } from '@/modules/fileuploads/repositories/fileUploads'
+import { FileUploadRecord } from '@/modules/fileuploads/helpers/types'
+import {
+  AutomateRevisionFunctionRecord,
+  AutomationRecord,
+  AutomationRevisionRecord,
+  AutomationRunTriggerRecord,
+  AutomationTriggerDefinitionRecord
+} from '@/modules/automate/helpers/types'
+import {
+  getAutomationRevisionsFactory,
+  getAutomationRunsTriggersFactory,
+  getAutomationsFactory,
+  getFunctionAutomationCountsFactory,
+  getLatestAutomationRevisionsFactory,
+  getRevisionsFunctionsFactory,
+  getRevisionsTriggerDefinitionsFactory
+} from '@/modules/automate/repositories/automations'
+import {
+  getFunction,
+  getFunctionReleases
+} from '@/modules/automate/clients/executionEngine'
+import {
+  FunctionReleaseSchemaType,
+  FunctionSchemaType
+} from '@/modules/automate/helpers/executionEngine'
+import {
+  ExecutionEngineFailedResponseError,
+  ExecutionEngineNetworkError
+} from '@/modules/automate/errors/executionEngine'
+import { queryInvitesFactory } from '@/modules/serverinvites/repositories/serverInvites'
+import { getAppScopesFactory } from '@/modules/auth/repositories'
+import { StreamWithCommitId } from '@/modules/core/domain/streams/types'
+import {
+  getUsersFactory,
+  UserWithOptionalRole
+} from '@/modules/core/repositories/users'
+
+declare module '@/modules/core/loaders' {
+  interface ModularizedDataLoaders extends ReturnType<typeof dataLoadersDefinition> {}
+}
+
+const dataLoadersDefinition = defineRequestDataloaders(
+  ({ ctx, createLoader, deps: { db } }) => {
+    const userId = ctx.userId
+
+    const getStreams = getStreamsFactory({ db })
+    const getStreamPendingModels = getStreamPendingModelsFactory({ db })
+    const getAppScopes = getAppScopesFactory({ db })
+    const getAutomations = getAutomationsFactory({ db })
+    const getAutomationRevisions = getAutomationRevisionsFactory({ db })
+    const getLatestAutomationRevisions = getLatestAutomationRevisionsFactory({ db })
+    const getRevisionsTriggerDefinitions = getRevisionsTriggerDefinitionsFactory({ db })
+    const getRevisionsFunctions = getRevisionsFunctionsFactory({ db })
+    const getFunctionAutomationCounts = getFunctionAutomationCountsFactory({ db })
+    const getStreamCommentCounts = getStreamCommentCountsFactory({ db })
+    const getAutomationRunsTriggers = getAutomationRunsTriggersFactory({ db })
+    const getCommentsResources = getCommentsResourcesFactory({ db })
+    const getCommentsViewedAt = getCommentsViewedAtFactory({ db })
+    const getCommitCommentCounts = getCommitCommentCountsFactory({ db })
+    const getBranchCommentCounts = getBranchCommentCountsFactory({ db })
+    const getCommentReplyCounts = getCommentReplyCountsFactory({ db })
+    const getCommentReplyAuthorIds = getCommentReplyAuthorIdsFactory({ db })
+    const getCommentParents = getCommentParentsFactory({ db })
+    const getBranchesByIds = getBranchesByIdsFactory({ db })
+    const getStreamBranchesByName = getStreamBranchesByNameFactory({ db })
+    const getBranchLatestCommits = getBranchLatestCommitsFactory({ db })
+    const getStreamBranchCounts = getStreamBranchCountsFactory({ db })
+    const getBranchCommitCounts = getBranchCommitCountsFactory({ db })
+    const getCommits = getCommitsFactory({ db })
+    const getSpecificBranchCommits = getSpecificBranchCommitsFactory({ db })
+    const getCommitBranches = getCommitBranchesFactory({ db })
+    const getStreamCommitCounts = getStreamCommitCountsFactory({ db })
+    const getUserStreamCommitCounts = getUserStreamCommitCountsFactory({ db })
+    const getUserAuthoredCommitCounts = getUserAuthoredCommitCountsFactory({ db })
+    const getCommitStreams = getCommitStreamsFactory({ db })
+    const getBatchUserFavoriteData = getBatchUserFavoriteDataFactory({ db })
+    const getBatchStreamFavoritesCounts = getBatchStreamFavoritesCountsFactory({ db })
+    const getOwnedFavoritesCountByUserIds = getOwnedFavoritesCountByUserIdsFactory({
+      db
+    })
+    const getStreamRoles = getStreamRolesFactory({ db })
+    const getUserStreamCounts = getUserStreamCountsFactory({ db })
+    const getStreamsSourceApps = getStreamsSourceAppsFactory({ db })
+    const getUsers = getUsersFactory({ db })
+
+    return {
+      streams: {
+        getAutomation: (() => {
+          type AutomationDataLoader = DataLoader<string, Nullable<AutomationRecord>>
+          const streamAutomationLoaders = new Map<string, AutomationDataLoader>()
+          return {
+            clearAll: () => streamAutomationLoaders.clear(),
+            forStream(streamId: string): AutomationDataLoader {
+              let loader = streamAutomationLoaders.get(streamId)
+              if (!loader) {
+                loader = createLoader<string, Nullable<AutomationRecord>>(
+                  async (automationIds) => {
+                    const results = keyBy(
+                      await getAutomations({ automationIds: automationIds.slice() }),
+                      (a) => a.id
+                    )
+                    return automationIds.map((i) => results[i] || null)
+                  }
+                )
+                streamAutomationLoaders.set(streamId, loader)
+              }
+
+              return loader
+            }
+          }
+        })(),
+
+        /**
+         * Get a specific commit of a specific stream. Each stream ID technically has its own loader &
+         * thus its own query.
+         */
+        getStreamCommit: (() => {
+          type CommitDataLoader = DataLoader<string, Nullable<CommitRecord>>
+          const streamCommitLoaders = new Map<string, CommitDataLoader>()
+          return {
+            clearAll: () => streamCommitLoaders.clear(),
+            forStream(streamId: string): CommitDataLoader {
+              let loader = streamCommitLoaders.get(streamId)
+              if (!loader) {
+                loader = createLoader<string, Nullable<CommitRecord>>(
+                  async (commitIds) => {
+                    const results = keyBy(
+                      await getCommits(commitIds.slice(), { streamId }),
+                      'id'
+                    )
+                    return commitIds.map((i) => results[i] || null)
+                  }
+                )
+                streamCommitLoaders.set(streamId, loader)
+              }
+
+              return loader
+            }
+          }
+        })(),
+
+        /**
+         * Get favorite metadata for a specific stream and user
+         */
+        getUserFavoriteData: createLoader<string, Nullable<StreamFavoriteRecord>>(
+          async (streamIds) => {
+            if (!userId) {
+              return streamIds.map(() => null)
+            }
+
+            const results = await getBatchUserFavoriteData({
+              userId,
+              streamIds: streamIds.slice()
+            })
+            return streamIds.map((k) => results[k])
+          }
+        ),
+
+        /**
+         * Get amount of favorites for a specific stream
+         */
+        getFavoritesCount: createLoader<string, number>(async (streamIds) => {
+          const results = await getBatchStreamFavoritesCounts(streamIds.slice())
+          return streamIds.map((k) => results[k] || 0)
+        }),
+
+        /**
+         * Get total amount of favorites of owned streams
+         */
+        getOwnedFavoritesCount: createLoader<string, number>(async (userIds) => {
+          const results = await getOwnedFavoritesCountByUserIds(userIds.slice())
+          return userIds.map((i) => results[i] || 0)
+        }),
+
+        /**
+         * Get stream from DB
+         *
+         * Note: Considering the difficulty of writing a single query that queries for multiple stream IDs
+         * and multiple user IDs also, currently this dataloader will only use a single userId
+         */
+        getStream: createLoader<string, Nullable<StreamRecord>>(async (streamIds) => {
+          const results = keyBy(await getStreams(streamIds.slice()), 'id')
+          return streamIds.map((i) => results[i] || null)
+        }),
+
+        /**
+         * Get stream role from DB
+         */
+        getRole: createLoader<string, Nullable<string>>(async (streamIds) => {
+          if (!userId) return streamIds.map(() => null)
+
+          const results = await getStreamRoles(userId, streamIds.slice())
+          return streamIds.map((id) => results[id] || null)
+        }),
+        /**
+         * Works in FE2 mode - skips `main` if it doesn't have any versions
+         */
+        getBranchCount: createLoader<string, number>(async (streamIds) => {
+          const results = keyBy(
+            await getStreamBranchCounts(streamIds.slice(), { skipEmptyMain: true }),
+            'streamId'
+          )
+          return streamIds.map((i) => results[i]?.count || 0)
+        }),
+        getCommitCountWithoutGlobals: createLoader<string, number>(
+          async (streamIds) => {
+            const results = keyBy(
+              await getStreamCommitCounts(streamIds.slice(), {
+                ignoreGlobalsBranch: true
+              }),
+              'streamId'
+            )
+            return streamIds.map((i) => results[i]?.count || 0)
+          }
+        ),
+        getCommentThreadCount: createLoader<string, number>(async (streamIds) => {
+          const results = keyBy(
+            await getStreamCommentCounts(streamIds.slice(), { threadsOnly: true }),
+            'streamId'
+          )
+          return streamIds.map((i) => results[i]?.count || 0)
+        }),
+        getSourceApps: createLoader<string, string[]>(async (streamIds) => {
+          const results = await getStreamsSourceApps(streamIds.slice())
+          return streamIds.map((i) => results[i] || [])
+        }),
+        /**
+         * Get a specific branch of a specific stream. Each stream ID technically has its own loader &
+         * thus its own query.
+         */
+        getStreamBranchByName: (() => {
+          type BranchDataLoader = DataLoader<string, Nullable<BranchRecord>>
+          const streamBranchLoaders = new Map<string, BranchDataLoader>()
+          return {
+            clearAll: () => streamBranchLoaders.clear(),
+            forStream(streamId: string): BranchDataLoader {
+              let loader = streamBranchLoaders.get(streamId)
+              if (!loader) {
+                loader = createLoader<string, Nullable<BranchRecord>>(
+                  async (branchNames) => {
+                    const results = keyBy(
+                      await getStreamBranchesByName(streamId, branchNames.slice()),
+                      'name'
+                    )
+                    return branchNames.map((n) => results[n] || null)
+                  }
+                )
+                streamBranchLoaders.set(streamId, loader)
+              }
+
+              return loader
+            }
+          }
+        })(),
+        /**
+         * Get a specific pending model (upload) of a specific stream. Each stream ID technically has its own loader &
+         * thus its own query.
+         */
+        getStreamPendingBranchByName: (() => {
+          type BranchDataLoader = DataLoader<string, Nullable<FileUploadRecord>>
+          const streamBranchLoaders = new Map<string, BranchDataLoader>()
+          return {
+            clearAll: () => streamBranchLoaders.clear(),
+            forStream(streamId: string): BranchDataLoader {
+              let loader = streamBranchLoaders.get(streamId)
+              if (!loader) {
+                loader = createLoader<string, Nullable<FileUploadRecord>>(
+                  async (branchNames) => {
+                    const results = keyBy(
+                      await getStreamPendingModels(streamId, {
+                        branchNamePattern: `(${branchNames.slice().join('|')})`
+                      }),
+                      'branchName'
+                    )
+                    return branchNames.map((n) => results[n] || null)
+                  }
+                )
+                streamBranchLoaders.set(streamId, loader)
+              }
+
+              return loader
+            }
+          }
+        })()
+      },
+      branches: {
+        getCommitCount: createLoader<string, number>(async (branchIds) => {
+          const results = keyBy(await getBranchCommitCounts(branchIds.slice()), 'id')
+          return branchIds.map((i) => results[i]?.count || 0)
+        }),
+        getLatestCommit: createLoader<string, Nullable<CommitRecord>>(
+          async (branchIds) => {
+            const results = keyBy(
+              await getBranchLatestCommits(branchIds.slice()),
+              'branchId'
+            )
+            return branchIds.map((i) => results[i] || null)
+          }
+        ),
+        getCommentThreadCount: createLoader<string, number>(async (branchIds) => {
+          const results = keyBy(
+            await getBranchCommentCounts(branchIds.slice(), { threadsOnly: true }),
+            'id'
+          )
+          return branchIds.map((i) => results[i]?.count || 0)
+        }),
+        getById: createLoader<string, Nullable<BranchRecord>>(async (branchIds) => {
+          const results = keyBy(await getBranchesByIds(branchIds.slice()), 'id')
+          return branchIds.map((i) => results[i] || null)
+        }),
+        getBranchCommit: createLoader<
+          { branchId: string; commitId: string },
+          Nullable<CommitRecord>,
+          string
+        >(
+          async (idPairs) => {
+            const results = keyBy(await getSpecificBranchCommits(idPairs.slice()), 'id')
+            return idPairs.map((p) => {
+              const commit = results[p.commitId]
+              return commit?.id === p.commitId && commit?.branchId === p.branchId
+                ? commit
+                : null
+            })
+          },
+          { cacheKeyFn: (key) => `${key.branchId}:${key.commitId}` }
+        )
+      },
+      commits: {
+        /**
+         * Get a commit's stream from DB
+         */
+        getCommitStream: createLoader<string, Nullable<StreamWithCommitId>>(
+          async (commitIds) => {
+            const results = keyBy(
+              await getCommitStreams({ commitIds: commitIds.slice(), userId }),
+              'commitId'
+            )
+            return commitIds.map((id) => results[id] || null)
+          }
+        ),
+
+        getCommitBranch: createLoader<string, Nullable<BranchRecord>>(
+          async (commitIds) => {
+            const results = keyBy(
+              await getCommitBranches(commitIds.slice()),
+              'commitId'
+            )
+            return commitIds.map((id) => results[id] || null)
+          }
+        ),
+        getCommentThreadCount: createLoader<string, number>(async (commitIds) => {
+          const results = keyBy(
+            await getCommitCommentCounts(commitIds.slice(), { threadsOnly: true }),
+            'commitId'
+          )
+          return commitIds.map((i) => results[i]?.count || 0)
+        }),
+        getById: createLoader<string, Nullable<CommitRecord>>(async (commitIds) => {
+          const results = keyBy(await getCommits(commitIds.slice()), (c) => c.id)
+          return commitIds.map((i) => results[i] || null)
+        })
+      },
+      comments: {
+        getViewedAt: createLoader<string, Nullable<Date>>(async (commentIds) => {
+          if (!userId) return commentIds.slice().map(() => null)
+
+          const results = keyBy(
+            await getCommentsViewedAt(commentIds.slice(), userId),
+            'commentId'
+          )
+          return commentIds.map((id) => results[id]?.viewedAt || null)
+        }),
+        getResources: createLoader<string, ResourceIdentifier[]>(async (commentIds) => {
+          const results = await getCommentsResources(commentIds.slice())
+          return commentIds.map((id) => results[id]?.resources || [])
+        }),
+        getReplyCount: createLoader<string, number>(async (threadIds) => {
+          const results = keyBy(
+            await getCommentReplyCounts(threadIds.slice()),
+            'threadId'
+          )
+          return threadIds.map((id) => results[id]?.count || 0)
+        }),
+        getReplyAuthorIds: createLoader<string, string[]>(async (threadIds) => {
+          const results = await getCommentReplyAuthorIds(threadIds.slice())
+          return threadIds.map((id) => results[id] || [])
+        }),
+        getReplyParent: createLoader<string, Nullable<CommentRecord>>(
+          async (replyIds) => {
+            const results = keyBy(await getCommentParents(replyIds.slice()), 'replyId')
+            return replyIds.map((id) => results[id] || null)
+          }
+        )
+      },
+      users: {
+        /**
+         * Get user from DB
+         */
+        getUser: createLoader<string, Nullable<UserWithOptionalRole>>(
+          async (userIds) => {
+            const results = keyBy(
+              await getUsers(userIds.slice(), { withRole: true }),
+              'id'
+            )
+            return userIds.map((i) => results[i] || null)
+          }
+        ),
+
+        /**
+         * Get meta values associated with one or more users
+         */
+        getUserMeta: createLoader<
+          { userId: string; key: keyof (typeof Users)['meta']['metaKey'] },
+          Nullable<UsersMetaRecord & { id: string }>,
+          string
+        >(
+          async (requests) => {
+            const meta = metaHelpers<UsersMetaRecord, typeof Users>(Users, db)
+            const results = await meta.getMultiple(
+              requests.map((r) => ({
+                id: r.userId,
+                key: r.key
+              }))
+            )
+            return requests.map((r) => {
+              const resultItem = results[r.userId]?.[r.key]
+              return resultItem
+                ? { ...resultItem, id: meta.getGraphqlId(resultItem) }
+                : null
+            })
+          },
+          { cacheKeyFn: (key) => `${key.userId}:${key.key}` }
+        ),
+
+        /**
+         * Get user stream count. Includes private streams.
+         */
+        getOwnStreamCount: createLoader<string, number>(async (userIds) => {
+          const results = await getUserStreamCounts({
+            publicOnly: false,
+            userIds: userIds.slice()
+          })
+          return userIds.map((i) => results[i] || 0)
+        }),
+
+        /**
+         * Get authored commit count. Includes commits from private streams.
+         */
+        getAuthoredCommitCount: createLoader<string, number>(async (userIds) => {
+          const results = await getUserAuthoredCommitCounts({
+            userIds: userIds.slice(),
+            publicOnly: false
+          })
+
+          return userIds.map((i) => results[i] || 0)
+        }),
+
+        /**
+         * Get count of commits in streams that the user is a contributor in. Includes private streams.
+         */
+        getStreamCommitCount: createLoader<string, number>(async (userIds) => {
+          const results = await getUserStreamCommitCounts({
+            userIds: userIds.slice(),
+            publicOnly: false
+          })
+
+          return userIds.map((i) => results[i] || 0)
+        })
+      },
+      invites: {
+        /**
+         * Get invite from DB
+         */
+        getInvite: createLoader<string, Nullable<ServerInviteRecord>>(
+          async (inviteIds) => {
+            const results = keyBy(await queryInvitesFactory({ db })(inviteIds), 'id')
+            return inviteIds.map((i) => results[i] || null)
+          }
+        )
+      },
+      apps: {
+        getAppScopes: createLoader<string, Array<Scope>>(async (appIds) => {
+          const results = await getAppScopes(appIds.slice())
+          return appIds.map((i) => results[i] || [])
+        })
+      },
+      automations: {
+        getFunctionAutomationCount: createLoader<string, number>(
+          async (functionIds) => {
+            const results = await getFunctionAutomationCounts({
+              functionIds: functionIds.slice()
+            })
+            return functionIds.map((i) => results[i] || 0)
+          }
+        ),
+        getAutomation: createLoader<string, Nullable<AutomationRecord>>(async (ids) => {
+          const results = keyBy(
+            await getAutomations({ automationIds: ids.slice() }),
+            (a) => a.id
+          )
+          return ids.map((i) => results[i] || null)
+        }),
+        getAutomationRevision: createLoader<string, Nullable<AutomationRevisionRecord>>(
+          async (ids) => {
+            const results = keyBy(
+              await getAutomationRevisions({ automationRevisionIds: ids.slice() }),
+              (a) => a.id
+            )
+            return ids.map((i) => results[i] || null)
+          }
+        ),
+        getLatestAutomationRevision: createLoader<
+          string,
+          Nullable<AutomationRevisionRecord>
+        >(async (ids) => {
+          const results = await getLatestAutomationRevisions({
+            automationIds: ids.slice()
+          })
+          return ids.map((i) => results[i] || null)
+        }),
+        getRevisionTriggerDefinitions: createLoader<
+          string,
+          AutomationTriggerDefinitionRecord[]
+        >(async (ids) => {
+          const results = await getRevisionsTriggerDefinitions({
+            automationRevisionIds: ids.slice()
+          })
+          return ids.map((i) => results[i] || [])
+        }),
+        getRevisionFunctions: createLoader<string, AutomateRevisionFunctionRecord[]>(
+          async (ids) => {
+            const results = await getRevisionsFunctions({
+              automationRevisionIds: ids.slice()
+            })
+            return ids.map((i) => results[i] || [])
+          }
+        ),
+        getRunTriggers: createLoader<string, AutomationRunTriggerRecord[]>(
+          async (ids) => {
+            const results = await getAutomationRunsTriggers({
+              automationRunIds: ids.slice()
+            })
+            return ids.map((i) => results[i] || [])
+          }
+        )
+      },
+      automationsApi: {
+        getFunction: createLoader<string, Nullable<FunctionSchemaType>>(
+          async (fnIds) => {
+            const results = await Promise.all(
+              fnIds.map(async (fnId) => {
+                try {
+                  return await getFunction({ functionId: fnId })
+                } catch (e) {
+                  const isNotFound =
+                    e instanceof ExecutionEngineFailedResponseError &&
+                    e.response.statusMessage === 'FunctionNotFound'
+                  if (e instanceof ExecutionEngineNetworkError || isNotFound) {
+                    return null
+                  }
+
+                  throw e
+                }
+              })
+            )
+
+            return results
+          }
+        ),
+        getFunctionRelease: createLoader<
+          [fnId: string, fnReleaseId: string],
+          Nullable<FunctionReleaseSchemaType>,
+          string
+        >(
+          async (keys) => {
+            const results = keyBy(
+              await getFunctionReleases({
+                ids: keys.map(([fnId, fnReleaseId]) => ({
+                  functionId: fnId,
+                  functionReleaseId: fnReleaseId
+                }))
+              }),
+              (r) => simpleTupleCacheKey([r.functionId, r.functionVersionId])
+            )
+
+            return keys.map((k) => results[simpleTupleCacheKey(k)] || null)
+          },
+          { cacheKeyFn: simpleTupleCacheKey }
+        )
+      }
+    }
+  }
+)
+
+export default dataLoadersDefinition

--- a/packages/server/modules/core/loaders.ts
+++ b/packages/server/modules/core/loaders.ts
@@ -1,145 +1,42 @@
 import DataLoader from 'dataloader'
-import {
-  getStreamsFactory,
-  getCommitStreamsFactory,
-  getBatchUserFavoriteDataFactory,
-  getBatchStreamFavoritesCountsFactory,
-  getOwnedFavoritesCountByUserIdsFactory,
-  getStreamRolesFactory,
-  getUserStreamCountsFactory,
-  getStreamsSourceAppsFactory
-} from '@/modules/core/repositories/streams'
-import { keyBy } from 'lodash'
 import { AuthContext } from '@/modules/shared/authz'
-import {
-  BranchRecord,
-  CommitRecord,
-  StreamFavoriteRecord,
-  StreamRecord,
-  UsersMetaRecord
-} from '@/modules/core/helpers/types'
-import { Nullable } from '@/modules/shared/helpers/typeHelper'
-import { ServerInviteRecord } from '@/modules/serverinvites/domain/types'
-import {
-  getCommitBranchesFactory,
-  getCommitsFactory,
-  getSpecificBranchCommitsFactory,
-  getStreamCommitCountsFactory,
-  getUserAuthoredCommitCountsFactory,
-  getUserStreamCommitCountsFactory
-} from '@/modules/core/repositories/commits'
-import { ResourceIdentifier, Scope } from '@/modules/core/graph/generated/graphql'
-import {
-  getBranchCommentCountsFactory,
-  getCommentParentsFactory,
-  getCommentReplyAuthorIdsFactory,
-  getCommentReplyCountsFactory,
-  getCommentsResourcesFactory,
-  getCommentsViewedAtFactory,
-  getCommitCommentCountsFactory,
-  getStreamCommentCountsFactory
-} from '@/modules/comments/repositories/comments'
-import {
-  getBranchCommitCountsFactory,
-  getBranchesByIdsFactory,
-  getBranchLatestCommitsFactory,
-  getStreamBranchCountsFactory,
-  getStreamBranchesByNameFactory
-} from '@/modules/core/repositories/branches'
-import { CommentRecord } from '@/modules/comments/helpers/types'
-import { metaHelpers } from '@/modules/core/helpers/meta'
-import { Users } from '@/modules/core/dbSchema'
-import { getStreamPendingModelsFactory } from '@/modules/fileuploads/repositories/fileUploads'
-import { FileUploadRecord } from '@/modules/fileuploads/helpers/types'
-import {
-  AutomateRevisionFunctionRecord,
-  AutomationRecord,
-  AutomationRevisionRecord,
-  AutomationRunTriggerRecord,
-  AutomationTriggerDefinitionRecord
-} from '@/modules/automate/helpers/types'
-import {
-  getAutomationRevisionsFactory,
-  getAutomationRunsTriggersFactory,
-  getAutomationsFactory,
-  getFunctionAutomationCountsFactory,
-  getLatestAutomationRevisionsFactory,
-  getRevisionsFunctionsFactory,
-  getRevisionsTriggerDefinitionsFactory
-} from '@/modules/automate/repositories/automations'
-import {
-  getFunction,
-  getFunctionReleases
-} from '@/modules/automate/clients/executionEngine'
-import {
-  FunctionReleaseSchemaType,
-  FunctionSchemaType
-} from '@/modules/automate/helpers/executionEngine'
-import {
-  ExecutionEngineFailedResponseError,
-  ExecutionEngineNetworkError
-} from '@/modules/automate/errors/executionEngine'
-import { queryInvitesFactory } from '@/modules/serverinvites/repositories/serverInvites'
-import db from '@/db/knex'
 import { graphDataloadersBuilders } from '@/modules'
-import { getAppScopesFactory } from '@/modules/auth/repositories'
-import { StreamWithCommitId } from '@/modules/core/domain/streams/types'
-import {
-  getUsersFactory,
-  UserWithOptionalRole
-} from '@/modules/core/repositories/users'
-
-const simpleTupleCacheKey = (key: [string, string]) => `${key[0]}:${key[1]}`
-
-const getStreams = getStreamsFactory({ db })
-const getStreamPendingModels = getStreamPendingModelsFactory({ db })
-const getAppScopes = getAppScopesFactory({ db })
-const getAutomations = getAutomationsFactory({ db })
-const getAutomationRevisions = getAutomationRevisionsFactory({ db })
-const getLatestAutomationRevisions = getLatestAutomationRevisionsFactory({ db })
-const getRevisionsTriggerDefinitions = getRevisionsTriggerDefinitionsFactory({ db })
-const getRevisionsFunctions = getRevisionsFunctionsFactory({ db })
-const getFunctionAutomationCounts = getFunctionAutomationCountsFactory({ db })
-const getStreamCommentCounts = getStreamCommentCountsFactory({ db })
-const getAutomationRunsTriggers = getAutomationRunsTriggersFactory({ db })
-const getCommentsResources = getCommentsResourcesFactory({ db })
-const getCommentsViewedAt = getCommentsViewedAtFactory({ db })
-const getCommitCommentCounts = getCommitCommentCountsFactory({ db })
-const getBranchCommentCounts = getBranchCommentCountsFactory({ db })
-const getCommentReplyCounts = getCommentReplyCountsFactory({ db })
-const getCommentReplyAuthorIds = getCommentReplyAuthorIdsFactory({ db })
-const getCommentParents = getCommentParentsFactory({ db })
-const getBranchesByIds = getBranchesByIdsFactory({ db })
-const getStreamBranchesByName = getStreamBranchesByNameFactory({ db })
-const getBranchLatestCommits = getBranchLatestCommitsFactory({ db })
-const getStreamBranchCounts = getStreamBranchCountsFactory({ db })
-const getBranchCommitCounts = getBranchCommitCountsFactory({ db })
-const getCommits = getCommitsFactory({ db })
-const getSpecificBranchCommits = getSpecificBranchCommitsFactory({ db })
-const getCommitBranches = getCommitBranchesFactory({ db })
-const getStreamCommitCounts = getStreamCommitCountsFactory({ db })
-const getUserStreamCommitCounts = getUserStreamCommitCountsFactory({ db })
-const getUserAuthoredCommitCounts = getUserAuthoredCommitCountsFactory({ db })
-const getCommitStreams = getCommitStreamsFactory({ db })
-const getBatchUserFavoriteData = getBatchUserFavoriteDataFactory({ db })
-const getBatchStreamFavoritesCounts = getBatchStreamFavoritesCountsFactory({ db })
-const getOwnedFavoritesCountByUserIds = getOwnedFavoritesCountByUserIdsFactory({ db })
-const getStreamRoles = getStreamRolesFactory({ db })
-const getUserStreamCounts = getUserStreamCountsFactory({ db })
-const getStreamsSourceApps = getStreamsSourceAppsFactory({ db })
-const getUsers = getUsersFactory({ db })
+import { ModularizedDataLoadersConstraint } from '@/modules/shared/helpers/graphqlHelper'
+import { Knex } from 'knex'
+import { isNonNullable, Optional } from '@speckle/shared'
+import { flatten, noop } from 'lodash'
+import { db } from '@/db/knex'
 
 /**
- * TODO: Lazy load DataLoaders to reduce memory usage
- * - Instead of keeping them request scoped, cache them identified by request (user ID) with a TTL,
- * so that users with the same ID can re-use them across requests/subscriptions
+ * Lets not waste memory on loaders that may not actually be invoked
  */
+const makeLazyDataLoader = <K, V, C = K>(
+  ...args: ConstructorParameters<typeof DataLoader<K, V, C>>
+): DataLoader<K, V, C> => {
+  let dataloader: Optional<DataLoader<K, V, C>> = undefined
+
+  return new Proxy({} as DataLoader<K, V, C>, {
+    get(_target, prop) {
+      if (!dataloader) {
+        // If invoking clearAll() - we don't really need to do anything, no loader exists
+        if (prop === 'clearAll') {
+          return noop
+        }
+
+        dataloader = new DataLoader<K, V, C>(...args)
+      }
+
+      return dataloader[prop as keyof DataLoader<K, V, C>]
+    }
+  })
+}
 
 const makeSelfClearingDataloader = <K, V, C = K>(
-  batchLoadFn: DataLoader.BatchLoadFn<K, V>,
-  options?: DataLoader.Options<K, V, C>
+  ...args: ConstructorParameters<typeof DataLoader<K, V, C>>
 ) => {
-  const dataloader = new DataLoader<K, V, C>((ids) => {
+  const [batchLoadFn, options] = args
+
+  const dataloader = makeLazyDataLoader<K, V, C>((ids) => {
     dataloader.clearAll()
     return batchLoadFn(ids)
   }, options)
@@ -147,10 +44,9 @@ const makeSelfClearingDataloader = <K, V, C = K>(
 }
 
 const buildDataLoaderCreator = (selfClearing = false) => {
-  return <K, V, C = K>(
-    batchLoadFn: DataLoader.BatchLoadFn<K, V>,
-    options?: DataLoader.Options<K, V, C>
-  ) => {
+  return <K, V, C = K>(...args: ConstructorParameters<typeof DataLoader<K, V, C>>) => {
+    const [batchLoadFn, options] = args
+
     if (selfClearing) {
       return makeSelfClearingDataloader<K, V, C>(batchLoadFn, {
         ...(options || {}),
@@ -158,7 +54,7 @@ const buildDataLoaderCreator = (selfClearing = false) => {
         cache: false
       })
     } else {
-      return new DataLoader<K, V, C>(batchLoadFn, options)
+      return makeLazyDataLoader(batchLoadFn, options)
     }
   }
 }
@@ -167,531 +63,67 @@ const buildDataLoaderCreator = (selfClearing = false) => {
  * Build request-scoped dataloaders
  * @param ctx GraphQL context w/o loaders
  */
-export function buildRequestLoaders(
+export async function buildRequestLoaders(
   ctx: AuthContext,
   options?: Partial<{ cleanLoadersEarly: boolean }>
 ) {
-  const userId = ctx.userId
-
   const createLoader = buildDataLoaderCreator(options?.cleanLoadersEarly || false)
   const modulesLoaders = graphDataloadersBuilders()
 
-  const loaders = {
-    ...(Object.assign(
-      {},
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      ...modulesLoaders.map((l) => l({ ctx, createLoader }))
-    ) as Record<string, unknown>),
-    streams: {
-      getAutomation: (() => {
-        type AutomationDataLoader = DataLoader<string, Nullable<AutomationRecord>>
-        const streamAutomationLoaders = new Map<string, AutomationDataLoader>()
-        return {
-          clearAll: () => streamAutomationLoaders.clear(),
-          forStream(streamId: string): AutomationDataLoader {
-            let loader = streamAutomationLoaders.get(streamId)
-            if (!loader) {
-              loader = createLoader<string, Nullable<AutomationRecord>>(
-                async (automationIds) => {
-                  const results = keyBy(
-                    await getAutomations({ automationIds: automationIds.slice() }),
-                    (a) => a.id
-                  )
-                  return automationIds.map((i) => results[i] || null)
-                }
-              )
-              streamAutomationLoaders.set(streamId, loader)
-            }
+  const mainDb = db
 
-            return loader
-          }
-        }
-      })(),
+  /**
+   * Dataloaders autoloaded from various speckle modules, created for the specified region DB
+   */
+  const createLoadersForRegion = (deps: { db: Knex }) => {
+    return {
+      ...(Object.assign(
+        {},
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        ...modulesLoaders.map((l) => l({ ctx, createLoader, deps }))
+      ) as Record<string, unknown>)
+    } as ModularizedDataLoaders
+  }
 
-      /**
-       * Get a specific commit of a specific stream. Each stream ID technically has its own loader &
-       * thus its own query.
-       */
-      getStreamCommit: (() => {
-        type CommitDataLoader = DataLoader<string, Nullable<CommitRecord>>
-        const streamCommitLoaders = new Map<string, CommitDataLoader>()
-        return {
-          clearAll: () => streamCommitLoaders.clear(),
-          forStream(streamId: string): CommitDataLoader {
-            let loader = streamCommitLoaders.get(streamId)
-            if (!loader) {
-              loader = createLoader<string, Nullable<CommitRecord>>(
-                async (commitIds) => {
-                  const results = keyBy(
-                    await getCommits(commitIds.slice(), { streamId }),
-                    'id'
-                  )
-                  return commitIds.map((i) => results[i] || null)
-                }
-              )
-              streamCommitLoaders.set(streamId, loader)
-            }
+  const mainDbLoaders = createLoadersForRegion({ db: mainDb })
+  const regionLoaders = new Map<Knex, ModularizedDataLoaders>()
 
-            return loader
-          }
-        }
-      })(),
+  // Extra utilities to add on top:
 
-      /**
-       * Get favorite metadata for a specific stream and user
-       */
-      getUserFavoriteData: createLoader<string, Nullable<StreamFavoriteRecord>>(
-        async (streamIds) => {
-          if (!userId) {
-            return streamIds.map(() => null)
-          }
-
-          const results = await getBatchUserFavoriteData({
-            userId,
-            streamIds: streamIds.slice()
-          })
-          return streamIds.map((k) => results[k])
-        }
-      ),
-
-      /**
-       * Get amount of favorites for a specific stream
-       */
-      getFavoritesCount: createLoader<string, number>(async (streamIds) => {
-        const results = await getBatchStreamFavoritesCounts(streamIds.slice())
-        return streamIds.map((k) => results[k] || 0)
-      }),
-
-      /**
-       * Get total amount of favorites of owned streams
-       */
-      getOwnedFavoritesCount: createLoader<string, number>(async (userIds) => {
-        const results = await getOwnedFavoritesCountByUserIds(userIds.slice())
-        return userIds.map((i) => results[i] || 0)
-      }),
-
-      /**
-       * Get stream from DB
-       *
-       * Note: Considering the difficulty of writing a single query that queries for multiple stream IDs
-       * and multiple user IDs also, currently this dataloader will only use a single userId
-       */
-      getStream: createLoader<string, Nullable<StreamRecord>>(async (streamIds) => {
-        const results = keyBy(await getStreams(streamIds.slice()), 'id')
-        return streamIds.map((i) => results[i] || null)
-      }),
-
-      /**
-       * Get stream role from DB
-       */
-      getRole: createLoader<string, Nullable<string>>(async (streamIds) => {
-        if (!userId) return streamIds.map(() => null)
-
-        const results = await getStreamRoles(userId, streamIds.slice())
-        return streamIds.map((id) => results[id] || null)
-      }),
-      /**
-       * Works in FE2 mode - skips `main` if it doesn't have any versions
-       */
-      getBranchCount: createLoader<string, number>(async (streamIds) => {
-        const results = keyBy(
-          await getStreamBranchCounts(streamIds.slice(), { skipEmptyMain: true }),
-          'streamId'
-        )
-        return streamIds.map((i) => results[i]?.count || 0)
-      }),
-      getCommitCountWithoutGlobals: createLoader<string, number>(async (streamIds) => {
-        const results = keyBy(
-          await getStreamCommitCounts(streamIds.slice(), {
-            ignoreGlobalsBranch: true
-          }),
-          'streamId'
-        )
-        return streamIds.map((i) => results[i]?.count || 0)
-      }),
-      getCommentThreadCount: createLoader<string, number>(async (streamIds) => {
-        const results = keyBy(
-          await getStreamCommentCounts(streamIds.slice(), { threadsOnly: true }),
-          'streamId'
-        )
-        return streamIds.map((i) => results[i]?.count || 0)
-      }),
-      getSourceApps: createLoader<string, string[]>(async (streamIds) => {
-        const results = await getStreamsSourceApps(streamIds.slice())
-        return streamIds.map((i) => results[i] || [])
-      }),
-      /**
-       * Get a specific branch of a specific stream. Each stream ID technically has its own loader &
-       * thus its own query.
-       */
-      getStreamBranchByName: (() => {
-        type BranchDataLoader = DataLoader<string, Nullable<BranchRecord>>
-        const streamBranchLoaders = new Map<string, BranchDataLoader>()
-        return {
-          clearAll: () => streamBranchLoaders.clear(),
-          forStream(streamId: string): BranchDataLoader {
-            let loader = streamBranchLoaders.get(streamId)
-            if (!loader) {
-              loader = createLoader<string, Nullable<BranchRecord>>(
-                async (branchNames) => {
-                  const results = keyBy(
-                    await getStreamBranchesByName(streamId, branchNames.slice()),
-                    'name'
-                  )
-                  return branchNames.map((n) => results[n] || null)
-                }
-              )
-              streamBranchLoaders.set(streamId, loader)
-            }
-
-            return loader
-          }
-        }
-      })(),
-      /**
-       * Get a specific pending model (upload) of a specific stream. Each stream ID technically has its own loader &
-       * thus its own query.
-       */
-      getStreamPendingBranchByName: (() => {
-        type BranchDataLoader = DataLoader<string, Nullable<FileUploadRecord>>
-        const streamBranchLoaders = new Map<string, BranchDataLoader>()
-        return {
-          clearAll: () => streamBranchLoaders.clear(),
-          forStream(streamId: string): BranchDataLoader {
-            let loader = streamBranchLoaders.get(streamId)
-            if (!loader) {
-              loader = createLoader<string, Nullable<FileUploadRecord>>(
-                async (branchNames) => {
-                  const results = keyBy(
-                    await getStreamPendingModels(streamId, {
-                      branchNamePattern: `(${branchNames.slice().join('|')})`
-                    }),
-                    'branchName'
-                  )
-                  return branchNames.map((n) => results[n] || null)
-                }
-              )
-              streamBranchLoaders.set(streamId, loader)
-            }
-
-            return loader
-          }
-        }
-      })()
-    },
-    branches: {
-      getCommitCount: createLoader<string, number>(async (branchIds) => {
-        const results = keyBy(await getBranchCommitCounts(branchIds.slice()), 'id')
-        return branchIds.map((i) => results[i]?.count || 0)
-      }),
-      getLatestCommit: createLoader<string, Nullable<CommitRecord>>(
-        async (branchIds) => {
-          const results = keyBy(
-            await getBranchLatestCommits(branchIds.slice()),
-            'branchId'
-          )
-          return branchIds.map((i) => results[i] || null)
-        }
-      ),
-      getCommentThreadCount: createLoader<string, number>(async (branchIds) => {
-        const results = keyBy(
-          await getBranchCommentCounts(branchIds.slice(), { threadsOnly: true }),
-          'id'
-        )
-        return branchIds.map((i) => results[i]?.count || 0)
-      }),
-      getById: createLoader<string, Nullable<BranchRecord>>(async (branchIds) => {
-        const results = keyBy(await getBranchesByIds(branchIds.slice()), 'id')
-        return branchIds.map((i) => results[i] || null)
-      }),
-      getBranchCommit: createLoader<
-        { branchId: string; commitId: string },
-        Nullable<CommitRecord>,
-        string
-      >(
-        async (idPairs) => {
-          const results = keyBy(await getSpecificBranchCommits(idPairs.slice()), 'id')
-          return idPairs.map((p) => {
-            const commit = results[p.commitId]
-            return commit?.id === p.commitId && commit?.branchId === p.branchId
-              ? commit
-              : null
-          })
-        },
-        { cacheKeyFn: (key) => `${key.branchId}:${key.commitId}` }
-      )
-    },
-    commits: {
-      /**
-       * Get a commit's stream from DB
-       */
-      getCommitStream: createLoader<string, Nullable<StreamWithCommitId>>(
-        async (commitIds) => {
-          const results = keyBy(
-            await getCommitStreams({ commitIds: commitIds.slice(), userId }),
-            'commitId'
-          )
-          return commitIds.map((id) => results[id] || null)
-        }
-      ),
-
-      getCommitBranch: createLoader<string, Nullable<BranchRecord>>(
-        async (commitIds) => {
-          const results = keyBy(await getCommitBranches(commitIds.slice()), 'commitId')
-          return commitIds.map((id) => results[id] || null)
-        }
-      ),
-      getCommentThreadCount: createLoader<string, number>(async (commitIds) => {
-        const results = keyBy(
-          await getCommitCommentCounts(commitIds.slice(), { threadsOnly: true }),
-          'commitId'
-        )
-        return commitIds.map((i) => results[i]?.count || 0)
-      }),
-      getById: createLoader<string, Nullable<CommitRecord>>(async (commitIds) => {
-        const results = keyBy(await getCommits(commitIds.slice()), (c) => c.id)
-        return commitIds.map((i) => results[i] || null)
-      })
-    },
-    comments: {
-      getViewedAt: createLoader<string, Nullable<Date>>(async (commentIds) => {
-        if (!userId) return commentIds.slice().map(() => null)
-
-        const results = keyBy(
-          await getCommentsViewedAt(commentIds.slice(), userId),
-          'commentId'
-        )
-        return commentIds.map((id) => results[id]?.viewedAt || null)
-      }),
-      getResources: createLoader<string, ResourceIdentifier[]>(async (commentIds) => {
-        const results = await getCommentsResources(commentIds.slice())
-        return commentIds.map((id) => results[id]?.resources || [])
-      }),
-      getReplyCount: createLoader<string, number>(async (threadIds) => {
-        const results = keyBy(
-          await getCommentReplyCounts(threadIds.slice()),
-          'threadId'
-        )
-        return threadIds.map((id) => results[id]?.count || 0)
-      }),
-      getReplyAuthorIds: createLoader<string, string[]>(async (threadIds) => {
-        const results = await getCommentReplyAuthorIds(threadIds.slice())
-        return threadIds.map((id) => results[id] || [])
-      }),
-      getReplyParent: createLoader<string, Nullable<CommentRecord>>(
-        async (replyIds) => {
-          const results = keyBy(await getCommentParents(replyIds.slice()), 'replyId')
-          return replyIds.map((id) => results[id] || null)
-        }
-      )
-    },
-    users: {
-      /**
-       * Get user from DB
-       */
-      getUser: createLoader<string, Nullable<UserWithOptionalRole>>(async (userIds) => {
-        const results = keyBy(await getUsers(userIds.slice(), { withRole: true }), 'id')
-        return userIds.map((i) => results[i] || null)
-      }),
-
-      /**
-       * Get meta values associated with one or more users
-       */
-      getUserMeta: createLoader<
-        { userId: string; key: keyof (typeof Users)['meta']['metaKey'] },
-        Nullable<UsersMetaRecord & { id: string }>,
-        string
-      >(
-        async (requests) => {
-          const meta = metaHelpers<UsersMetaRecord, typeof Users>(Users, db)
-          const results = await meta.getMultiple(
-            requests.map((r) => ({
-              id: r.userId,
-              key: r.key
-            }))
-          )
-          return requests.map((r) => {
-            const resultItem = results[r.userId]?.[r.key]
-            return resultItem
-              ? { ...resultItem, id: meta.getGraphqlId(resultItem) }
-              : null
-          })
-        },
-        { cacheKeyFn: (key) => `${key.userId}:${key.key}` }
-      ),
-
-      /**
-       * Get user stream count. Includes private streams.
-       */
-      getOwnStreamCount: createLoader<string, number>(async (userIds) => {
-        const results = await getUserStreamCounts({
-          publicOnly: false,
-          userIds: userIds.slice()
-        })
-        return userIds.map((i) => results[i] || 0)
-      }),
-
-      /**
-       * Get authored commit count. Includes commits from private streams.
-       */
-      getAuthoredCommitCount: createLoader<string, number>(async (userIds) => {
-        const results = await getUserAuthoredCommitCounts({
-          userIds: userIds.slice(),
-          publicOnly: false
-        })
-
-        return userIds.map((i) => results[i] || 0)
-      }),
-
-      /**
-       * Get count of commits in streams that the user is a contributor in. Includes private streams.
-       */
-      getStreamCommitCount: createLoader<string, number>(async (userIds) => {
-        const results = await getUserStreamCommitCounts({
-          userIds: userIds.slice(),
-          publicOnly: false
-        })
-
-        return userIds.map((i) => results[i] || 0)
-      })
-    },
-    invites: {
-      /**
-       * Get invite from DB
-       */
-      getInvite: createLoader<string, Nullable<ServerInviteRecord>>(
-        async (inviteIds) => {
-          const results = keyBy(await queryInvitesFactory({ db })(inviteIds), 'id')
-          return inviteIds.map((i) => results[i] || null)
-        }
-      )
-    },
-    apps: {
-      getAppScopes: createLoader<string, Array<Scope>>(async (appIds) => {
-        const results = await getAppScopes(appIds.slice())
-        return appIds.map((i) => results[i] || [])
-      })
-    },
-    automations: {
-      getFunctionAutomationCount: createLoader<string, number>(async (functionIds) => {
-        const results = await getFunctionAutomationCounts({
-          functionIds: functionIds.slice()
-        })
-        return functionIds.map((i) => results[i] || 0)
-      }),
-      getAutomation: createLoader<string, Nullable<AutomationRecord>>(async (ids) => {
-        const results = keyBy(
-          await getAutomations({ automationIds: ids.slice() }),
-          (a) => a.id
-        )
-        return ids.map((i) => results[i] || null)
-      }),
-      getAutomationRevision: createLoader<string, Nullable<AutomationRevisionRecord>>(
-        async (ids) => {
-          const results = keyBy(
-            await getAutomationRevisions({ automationRevisionIds: ids.slice() }),
-            (a) => a.id
-          )
-          return ids.map((i) => results[i] || null)
-        }
-      ),
-      getLatestAutomationRevision: createLoader<
-        string,
-        Nullable<AutomationRevisionRecord>
-      >(async (ids) => {
-        const results = await getLatestAutomationRevisions({
-          automationIds: ids.slice()
-        })
-        return ids.map((i) => results[i] || null)
-      }),
-      getRevisionTriggerDefinitions: createLoader<
-        string,
-        AutomationTriggerDefinitionRecord[]
-      >(async (ids) => {
-        const results = await getRevisionsTriggerDefinitions({
-          automationRevisionIds: ids.slice()
-        })
-        return ids.map((i) => results[i] || [])
-      }),
-      getRevisionFunctions: createLoader<string, AutomateRevisionFunctionRecord[]>(
-        async (ids) => {
-          const results = await getRevisionsFunctions({
-            automationRevisionIds: ids.slice()
-          })
-          return ids.map((i) => results[i] || [])
-        }
-      ),
-      getRunTriggers: createLoader<string, AutomationRunTriggerRecord[]>(
-        async (ids) => {
-          const results = await getAutomationRunsTriggers({
-            automationRunIds: ids.slice()
-          })
-          return ids.map((i) => results[i] || [])
-        }
-      )
-    },
-    automationsApi: {
-      getFunction: createLoader<string, Nullable<FunctionSchemaType>>(async (fnIds) => {
-        const results = await Promise.all(
-          fnIds.map(async (fnId) => {
-            try {
-              return await getFunction({ functionId: fnId })
-            } catch (e) {
-              const isNotFound =
-                e instanceof ExecutionEngineFailedResponseError &&
-                e.response.statusMessage === 'FunctionNotFound'
-              if (e instanceof ExecutionEngineNetworkError || isNotFound) {
-                return null
-              }
-
-              throw e
-            }
-          })
-        )
-
-        return results
-      }),
-      getFunctionRelease: createLoader<
-        [fnId: string, fnReleaseId: string],
-        Nullable<FunctionReleaseSchemaType>,
-        string
-      >(
-        async (keys) => {
-          const results = keyBy(
-            await getFunctionReleases({
-              ids: keys.map(([fnId, fnReleaseId]) => ({
-                functionId: fnId,
-                functionReleaseId: fnReleaseId
-              }))
-            }),
-            (r) => simpleTupleCacheKey([r.functionId, r.functionVersionId])
-          )
-
-          return keys.map((k) => results[simpleTupleCacheKey(k)] || null)
-        },
-        { cacheKeyFn: simpleTupleCacheKey }
-      )
+  /**
+   * Get dataloaders for specific region
+   */
+  const forRegion = (deps: { db: Knex }) => {
+    if (!regionLoaders.has(deps.db)) {
+      regionLoaders.set(deps.db, createLoadersForRegion(deps))
     }
+    return regionLoaders.get(deps.db) as ModularizedDataLoaders
   }
 
   /**
-   * Clear all loaders
+   * Clear all request loaders across all regions
    */
   const clearAll = () => {
-    for (const groupedLoaders of Object.values(loaders)) {
+    const allLoaderGroups = flatten(
+      [mainDbLoaders, ...regionLoaders.values()].map((l) =>
+        Object.values(l || {}).filter(isNonNullable)
+      )
+    )
+
+    for (const groupedLoaders of allLoaderGroups) {
       for (const loaderItem of Object.values(groupedLoaders)) {
-        ;(loaderItem as DataLoader<unknown, unknown>).clearAll()
+        loaderItem.clearAll()
       }
     }
   }
 
   return {
-    ...loaders,
-    clearAll
+    ...mainDbLoaders,
+    clearAll,
+    forRegion
   }
 }
 
-export interface AllRequestDataLoaders {}
+export interface ModularizedDataLoaders extends ModularizedDataLoadersConstraint {}
 
-export type RequestDataLoaders = ReturnType<typeof buildRequestLoaders> &
-  AllRequestDataLoaders
+export type RequestDataLoaders = Awaited<ReturnType<typeof buildRequestLoaders>>

--- a/packages/server/modules/core/tests/apitokens.spec.ts
+++ b/packages/server/modules/core/tests/apitokens.spec.ts
@@ -62,7 +62,7 @@ describe('API Tokens', () => {
     await createTestUsers([user1])
 
     apollo = await testApolloServer({
-      context: createTestContext({
+      context: await createTestContext({
         auth: true,
         userId: user1.id,
         role: Roles.Server.Admin,
@@ -229,7 +229,7 @@ describe('API Tokens', () => {
       testApp1Token = appToken
 
       apollo = await testApolloServer({
-        context: createTestContext({
+        context: await createTestContext({
           auth: true,
           userId: user1.id,
           role: Roles.Server.Admin,
@@ -380,7 +380,7 @@ describe('API Tokens', () => {
         }
 
         apollo = await testApolloServer({
-          context: createTestContext({
+          context: await createTestContext({
             auth: true,
             userId: user1.id,
             role: Roles.Server.Admin,

--- a/packages/server/modules/core/tests/batchCommits.spec.ts
+++ b/packages/server/modules/core/tests/batchCommits.spec.ts
@@ -174,7 +174,7 @@ describe('Batch commits', () => {
     before(async () => {
       apollo = {
         apollo: await buildApolloServer(),
-        context: createAuthedTestContext(me.id)
+        context: await createAuthedTestContext(me.id)
       }
       invokeBatchAction = buildBatchActionInvoker(apollo)
     })
@@ -310,7 +310,7 @@ describe('Batch commits', () => {
     before(async () => {
       apollo = {
         apollo: await buildApolloServer(),
-        context: createTestContext()
+        context: await createTestContext()
       }
       invokeBatchAction = buildBatchActionInvoker(apollo)
     })

--- a/packages/server/modules/core/tests/commitsGraphql.spec.ts
+++ b/packages/server/modules/core/tests/commitsGraphql.spec.ts
@@ -129,7 +129,7 @@ describe('Commits (GraphQL)', () => {
     before(async () => {
       apollo = {
         apollo: await buildApolloServer(),
-        context: createAuthedTestContext(me.id)
+        context: await createAuthedTestContext(me.id)
       }
     })
 

--- a/packages/server/modules/core/tests/discoverableStreams.spec.ts
+++ b/packages/server/modules/core/tests/discoverableStreams.spec.ts
@@ -120,7 +120,7 @@ describe('Discoverable streams', () => {
 
     apollo = {
       apollo: await buildApolloServer(),
-      context: createTestContext()
+      context: await createTestContext()
     }
   })
 
@@ -249,7 +249,7 @@ describe('Discoverable streams', () => {
     before(async () => {
       apollo = {
         apollo: await buildApolloServer(),
-        context: createAuthedTestContext(me.id)
+        context: await createAuthedTestContext(me.id)
       }
     })
 

--- a/packages/server/modules/core/tests/favoriteStreams.spec.js
+++ b/packages/server/modules/core/tests/favoriteStreams.spec.js
@@ -279,7 +279,7 @@ describe('Favorite streams', () => {
     before(async () => {
       apollo = {
         apollo: await buildApolloServer(),
-        context: createAuthedTestContext(me.id)
+        context: await createAuthedTestContext(me.id)
       }
 
       // Drop all favorites to ensure we don't favorite already favorited streams
@@ -448,7 +448,7 @@ describe('Favorite streams', () => {
           // "Log in" with other user
           const apollo = {
             apollo: await buildApolloServer(),
-            context: createAuthedTestContext(otherGuy.id)
+            context: await createAuthedTestContext(otherGuy.id)
           }
 
           const { data, errors } = await executeOperation(
@@ -474,7 +474,7 @@ describe('Favorite streams', () => {
     before(async () => {
       apollo = {
         apollo: await buildApolloServer(),
-        context: createTestContext()
+        context: await createTestContext()
       }
     })
 

--- a/packages/server/modules/core/tests/streams.spec.ts
+++ b/packages/server/modules/core/tests/streams.spec.ts
@@ -371,7 +371,7 @@ describe('Streams @core-streams', () => {
 
       const apollo = {
         apollo: await buildApolloServer(),
-        context: createAuthedTestContext(userTwo.id)
+        context: await createAuthedTestContext(userTwo.id)
       }
       const { data, errors } = await leaveStream(apollo, { streamId })
 
@@ -706,7 +706,7 @@ describe('Streams @core-streams', () => {
         activeUserId = userOne.id
         apollo = {
           apollo: await buildApolloServer(),
-          context: createAuthedTestContext(activeUserId)
+          context: await createAuthedTestContext(activeUserId)
         }
       })
 
@@ -735,7 +735,7 @@ describe('Streams @core-streams', () => {
       before(async () => {
         apollo = {
           apollo: await buildApolloServer(),
-          context: createTestContext()
+          context: await createTestContext()
         }
       })
 

--- a/packages/server/modules/core/tests/usersAdminList.spec.ts
+++ b/packages/server/modules/core/tests/usersAdminList.spec.ts
@@ -287,7 +287,7 @@ describe('[Admin users list]', () => {
 
     apollo = {
       apollo: await buildApolloServer(),
-      context: createAuthedTestContext(me.id!, { role: Roles.Server.Admin })
+      context: await createAuthedTestContext(me.id!, { role: Roles.Server.Admin })
     }
   })
 

--- a/packages/server/modules/core/tests/usersGraphql.spec.ts
+++ b/packages/server/modules/core/tests/usersGraphql.spec.ts
@@ -103,7 +103,7 @@ describe('Users (GraphQL)', () => {
     before(async () => {
       apollo = {
         apollo: await buildApolloServer(),
-        context: createTestContext()
+        context: await createTestContext()
       }
     })
 
@@ -130,7 +130,7 @@ describe('Users (GraphQL)', () => {
     before(async () => {
       apollo = {
         apollo: await buildApolloServer(),
-        context: createAuthedTestContext(me.id)
+        context: await createAuthedTestContext(me.id)
       }
     })
 

--- a/packages/server/modules/emails/tests/verifications.spec.ts
+++ b/packages/server/modules/emails/tests/verifications.spec.ts
@@ -107,7 +107,7 @@ describe('Email verifications @emails', () => {
     before(async () => {
       apollo = {
         apollo: await buildApolloServer(),
-        context: createAuthedTestContext(userA.id)
+        context: await createAuthedTestContext(userA.id)
       }
     })
 
@@ -137,7 +137,7 @@ describe('Email verifications @emails', () => {
       const invokeRequestVerification = async (user: BasicTestUser) => {
         const apollo = {
           apollo: await buildApolloServer(),
-          context: createAuthedTestContext(user.id)
+          context: await createAuthedTestContext(user.id)
         }
         return await requestVerification(apollo, {})
       }
@@ -189,7 +189,7 @@ describe('Email verifications @emails', () => {
     before(async () => {
       apollo = {
         apollo: await buildApolloServer(),
-        context: createTestContext()
+        context: await createTestContext()
       }
     })
 

--- a/packages/server/modules/serverinvites/tests/invites.spec.ts
+++ b/packages/server/modules/serverinvites/tests/invites.spec.ts
@@ -478,7 +478,7 @@ describe('[Stream & Server Invites]', () => {
 
       before(async () => {
         apollo = await testApolloServer({
-          context: createTestContext({
+          context: await createTestContext({
             auth: true,
             userId: me.id,
             role: Roles.Server.Admin, // Marking the user as an admin

--- a/packages/server/modules/shared/middleware/index.ts
+++ b/packages/server/modules/shared/middleware/index.ts
@@ -160,13 +160,13 @@ export async function authContextMiddleware(
   next()
 }
 
-export function addLoadersToCtx(
+export async function addLoadersToCtx(
   ctx: Merge<Omit<GraphQLContext, 'loaders'>, { log?: Optional<pino.Logger> }>,
   options?: Partial<{ cleanLoadersEarly: boolean }>
-): GraphQLContext {
+): Promise<GraphQLContext> {
   const log =
     ctx.log || Observability.extendLoggerComponent(Observability.getLogger(), 'graphql')
-  const loaders = buildRequestLoaders(ctx, options)
+  const loaders = await buildRequestLoaders(ctx, options)
   return { ...ctx, loaders, log }
 }
 
@@ -212,7 +212,7 @@ export async function buildContext({
   }
 
   // Adding request data loaders
-  return addLoadersToCtx(
+  return await addLoadersToCtx(
     {
       ...ctx,
       log

--- a/packages/server/modules/workspaces/graph/dataloaders/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/dataloaders/workspaces.ts
@@ -1,4 +1,3 @@
-import { db } from '@/db/knex'
 import { getFeatureFlags } from '@/modules/shared/helpers/envHelper'
 import { defineRequestDataloaders } from '@/modules/shared/helpers/graphqlHelper'
 import {
@@ -14,42 +13,46 @@ import { keyBy } from 'lodash'
 const { FF_WORKSPACES_MODULE_ENABLED } = getFeatureFlags()
 
 declare module '@/modules/core/loaders' {
-  interface AllRequestDataLoaders
+  interface ModularizedDataLoaders
     extends Partial<ReturnType<typeof dataLoadersDefinition>> {}
 }
 
-const dataLoadersDefinition = defineRequestDataloaders(({ ctx, createLoader }) => {
-  const getWorkspaces = getWorkspacesFactory({ db })
-  const getWorkspaceDomains = getWorkspaceDomainsFactory({ db })
+const dataLoadersDefinition = defineRequestDataloaders(
+  ({ ctx, createLoader, deps: { db } }) => {
+    const getWorkspaces = getWorkspacesFactory({ db })
+    const getWorkspaceDomains = getWorkspaceDomainsFactory({ db })
 
-  return {
-    workspaces: {
-      /**
-       * Get workspace, with the active user's role attached
-       */
-      getWorkspace: createLoader<string, WorkspaceWithOptionalRole | null>(
-        async (ids) => {
-          const results = keyBy(
-            await getWorkspaces({ workspaceIds: ids.slice(), userId: ctx.userId }),
-            (w) => w.id
-          )
-          return ids.map((id) => results[id] || null)
-        }
-      )
-    },
-    workspaceDomains: {
-      /**
-       * Get workspace, with the active user's role attached
-       */
-      getWorkspaceDomains: createLoader<string, WorkspaceDomain | null>(async (ids) => {
-        const results = keyBy(
-          await getWorkspaceDomains({ workspaceIds: ids.slice() }),
-          (w) => w.id
+    return {
+      workspaces: {
+        /**
+         * Get workspace, with the active user's role attached
+         */
+        getWorkspace: createLoader<string, WorkspaceWithOptionalRole | null>(
+          async (ids) => {
+            const results = keyBy(
+              await getWorkspaces({ workspaceIds: ids.slice(), userId: ctx.userId }),
+              (w) => w.id
+            )
+            return ids.map((id) => results[id] || null)
+          }
         )
-        return ids.map((id) => results[id] || null)
-      })
+      },
+      workspaceDomains: {
+        /**
+         * Get workspace, with the active user's role attached
+         */
+        getWorkspaceDomains: createLoader<string, WorkspaceDomain | null>(
+          async (ids) => {
+            const results = keyBy(
+              await getWorkspaceDomains({ workspaceIds: ids.slice() }),
+              (w) => w.id
+            )
+            return ids.map((id) => results[id] || null)
+          }
+        )
+      }
     }
   }
-})
+)
 
 export default FF_WORKSPACES_MODULE_ENABLED ? dataLoadersDefinition : undefined

--- a/packages/server/modules/workspaces/tests/integration/invites.graph.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/invites.graph.spec.ts
@@ -1667,7 +1667,7 @@ describe('Workspaces Invites GQL', () => {
           }
         },
         {
-          context: createTestContext({
+          context: await createTestContext({
             userId: newUser.id,
             auth: true,
             role: Roles.Server.User,

--- a/packages/server/modules/workspaces/tests/integration/projects.graph.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/projects.graph.spec.ts
@@ -59,7 +59,7 @@ describe('Workspace project GQL CRUD', () => {
     await createTestUsers([serverAdminUser, serverMemberUser])
     const token = await createAuthTokenForUser(serverAdminUser.id, AllScopes)
     apollo = await testApolloServer({
-      context: createTestContext({
+      context: await createTestContext({
         auth: true,
         userId: serverAdminUser.id,
         token,

--- a/packages/server/modules/workspaces/tests/integration/roles.graph.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/roles.graph.spec.ts
@@ -54,7 +54,7 @@ describe('Workspaces Roles GQL', () => {
     await createTestUsers([serverAdminUser, serverMemberUser])
     const token = await createAuthTokenForUser(serverAdminUser.id, AllScopes)
     apollo = await testApolloServer({
-      context: createTestContext({
+      context: await createTestContext({
         auth: true,
         userId: serverAdminUser.id,
         token,
@@ -551,7 +551,7 @@ describe('Workspaces Roles GQL', () => {
     before(async () => {
       const token = await createAuthTokenForUser(serverMemberUser.id, AllScopes)
       workspaceMemberApollo = await testApolloServer({
-        context: createTestContext({
+        context: await createTestContext({
           auth: true,
           userId: serverMemberUser.id,
           token,

--- a/packages/server/modules/workspaces/tests/integration/sso.graph.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/sso.graph.spec.ts
@@ -86,7 +86,7 @@ describe('Workspace SSO', () => {
     ])
 
     memberApollo = await testApolloServer({
-      context: createTestContext({
+      context: await createTestContext({
         auth: true,
         userId: workspaceMember.id,
         token: await createAuthTokenForUser(workspaceMember.id),
@@ -95,7 +95,7 @@ describe('Workspace SSO', () => {
       })
     })
     guestApollo = await testApolloServer({
-      context: createTestContext({
+      context: await createTestContext({
         auth: true,
         userId: workspaceGuest.id,
         token: await createAuthTokenForUser(workspaceGuest.id),

--- a/packages/server/modules/workspaces/tests/integration/workspaces.graph.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/workspaces.graph.spec.ts
@@ -129,7 +129,7 @@ describe('Workspaces GQL CRUD', () => {
     await createTestUsers([testAdminUser, testMemberUser])
     const token = await createAuthTokenForUser(testAdminUser.id, AllScopes)
     apollo = await testApolloServer({
-      context: createTestContext({
+      context: await createTestContext({
         auth: true,
         userId: testAdminUser.id,
         token,
@@ -834,7 +834,7 @@ describe('Workspaces GQL CRUD', () => {
 
       it('should throw if non-workspace-admin triggers delete', async () => {
         const memberApollo: TestApolloServer = (apollo = await testApolloServer({
-          context: createTestContext({
+          context: await createTestContext({
             auth: true,
             userId: testAdminUser.id,
             token: '',

--- a/packages/server/test/graphqlHelper.ts
+++ b/packages/server/test/graphqlHelper.ts
@@ -58,7 +58,7 @@ export async function executeOperation<
   context?: GraphQLContext
 ): Promise<ExecuteOperationResponse<R>> {
   const server: ApolloServer<GraphQLContext> = apollo.apollo
-  const contextValue = context || apollo.context || createTestContext()
+  const contextValue = context || apollo.context || (await createTestContext())
 
   const res = (await server.executeOperation(
     {
@@ -83,7 +83,9 @@ export async function executeOperation<
  * Create a test context for a GraphQL request. Optionally override any of the default values.
  * By default the context will be unauthenticated
  */
-export const createTestContext = (ctx?: Partial<GraphQLContext>): GraphQLContext =>
+export const createTestContext = async (
+  ctx?: Partial<GraphQLContext>
+): Promise<GraphQLContext> =>
   addLoadersToCtx({
     auth: false,
     userId: undefined,
@@ -95,10 +97,10 @@ export const createTestContext = (ctx?: Partial<GraphQLContext>): GraphQLContext
     ...(ctx || {})
   })
 
-export const createAuthedTestContext = (
+export const createAuthedTestContext = async (
   userId: string,
   ctxOverrides?: Partial<GraphQLContext>
-): GraphQLContext =>
+): Promise<GraphQLContext> =>
   addLoadersToCtx({
     auth: true,
     userId,
@@ -122,13 +124,13 @@ const buildMergedContext = async (params: {
    */
   authUserId?: string
 }) => {
-  let baseCtx: GraphQLContext = params.baseCtx || createTestContext()
+  let baseCtx: GraphQLContext = params.baseCtx || (await createTestContext())
 
   // Init ctx from userId?
   if (params?.authUserId) {
     const userData = await getUser(params.authUserId, { withRole: true })
     const role = userData?.role || Roles.Server.User
-    const userCtx = createAuthedTestContext(params.authUserId, { role })
+    const userCtx = await createAuthedTestContext(params.authUserId, { role })
 
     // Apply authed context to base
     baseCtx = {
@@ -148,7 +150,7 @@ const buildMergedContext = async (params: {
   }
 
   // Apply dataloaders from scratch
-  baseCtx = createTestContext(baseCtx)
+  baseCtx = await createTestContext(baseCtx)
 
   return baseCtx
 }


### PR DESCRIPTION
So all of the preexisting dataloaders still exist but only use the main DB. If you want to spawn a set of loaders for your specific region, you have to do `ctx.loaders.forRegion({ db })` and then this set will use that new region DB.

Loaders of course won't be shared across regions. So if you do `ctx.loaders.streams.getStream.load()` and `ctx.loaders.forRegion({ db: regionDb }).streams.getStream.load()` these 2 will be 2 different queries in 2 different databases.