### PR TITLE
fix(helm chart): provide service account with access to multi-region 

### DIFF
--- a/utils/helm/speckle-server/templates/fileimport_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/serviceaccount.yml
@@ -11,4 +11,7 @@ metadata:
 automountServiceAccountToken: false
 secrets:
   - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
+{{- if .Values.featureFlags.workspacesMultiRegionEnabled }}
+  - name: {{ default .Values.secretName .Values.multiRegion.config.secretName }}
+{{- end }}
 {{- end -}}

--- a/utils/helm/speckle-server/templates/monitoring/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/monitoring/serviceaccount.yml
@@ -11,4 +11,7 @@ metadata:
 automountServiceAccountToken: false
 secrets:
   - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
+{{- if .Values.featureFlags.workspacesMultiRegionEnabled }}
+  - name: {{ default .Values.secretName .Values.multiRegion.config.secretName }}
+{{- end }}
 {{- end -}}

--- a/utils/helm/speckle-server/templates/objects/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/objects/serviceaccount.yml
@@ -38,5 +38,7 @@ secrets:
 {{- if .Values.featureFlags.workspaceModuleEnabled }}
   - name: {{ default .Values.secretName .Values.server.licenseTokenSecret.secretName }}
 {{- end }}
-
+{{- if .Values.featureFlags.workspacesMultiRegionEnabled }}
+  - name: {{ default .Values.secretName .Values.multiRegion.config.secretName }}
+{{- end }}
 {{- end -}}

--- a/utils/helm/speckle-server/templates/preview_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/preview_service/serviceaccount.yml
@@ -11,4 +11,7 @@ metadata:
 automountServiceAccountToken: false
 secrets:
   - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
+{{- if .Values.featureFlags.workspacesMultiRegionEnabled }}
+  - name: {{ default .Values.secretName .Values.multiRegion.config.secretName }}
+{{- end }}
 {{- end -}}

--- a/utils/helm/speckle-server/templates/server/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/server/serviceaccount.yml
@@ -38,5 +38,8 @@ secrets:
 {{- if .Values.featureFlags.workspaceModuleEnabled }}
   - name: {{ default .Values.secretName .Values.server.licenseTokenSecret.secretName }}
 {{- end }}
+{{- if .Values.featureFlags.workspacesMultiRegionEnabled }}
+  - name: {{ default .Values.secretName .Values.multiRegion.config.secretName }}
+{{- end }}
 
 {{- end -}}

--- a/utils/helm/speckle-server/templates/webhook_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/serviceaccount.yml
@@ -11,4 +11,7 @@ metadata:
 automountServiceAccountToken: false
 secrets:
   - name: {{ ( default .Values.secretName .Values.db.connectionString.secretName ) }}
+{{- if .Values.featureFlags.workspacesMultiRegionEnabled }}
+  - name: {{ default .Values.secretName .Values.multiRegion.config.secretName }}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
## Description & motivation

When deployed to Kubernetes via Helm Chart, the multi-region config was unable to be mounted to the deployment. This was because the secret was not accessible by the service account.

This PR provides access to the multi-region secret by the service account.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
