### PR TITLE
Fix(dui3): do not pass selectedobjectids from idmap

### DIFF
--- a/packages/dui3/lib/bindings/definitions/ISendBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/ISendBinding.ts
@@ -26,5 +26,9 @@ export interface ISendBindingEvents
     versionId: string
     sendConversionResults: ConversionResult[]
   }) => void
-  setIdMap: (args: { modelCardId: string; idMap: Record<string, string> }) => void
+  setIdMap: (args: {
+    modelCardId: string
+    idMap: Record<string, string>
+    newSelectedObjectIds: string[]
+  }) => void
 }

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -180,20 +180,23 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     () => sendFilters.value?.find((f) => f.name === 'Selection') as ISendFilter
   )
 
-  app.$sendBinding?.on('setIdMap', async ({ modelCardId, idMap }) => {
-    const modelCard = models.value.find(
-      (card) => card.modelCardId === modelCardId
-    ) as ISenderModelCard
-    if (!modelCard) return
+  app.$sendBinding?.on(
+    'setIdMap',
+    async ({ modelCardId, idMap, newSelectedObjectIds }) => {
+      const modelCard = models.value.find(
+        (card) => card.modelCardId === modelCardId
+      ) as ISenderModelCard
+      if (!modelCard) return
 
-    const newFilter = {
-      ...modelCard.sendFilter,
-      selectedObjectIds: Object.values(idMap),
-      idMap
+      const newFilter = {
+        ...modelCard.sendFilter,
+        selectedObjectIds: newSelectedObjectIds,
+        idMap
+      }
+
+      await patchModel(modelCardId, { sendFilter: newFilter })
     }
-
-    await patchModel(modelCardId, { sendFilter: newFilter })
-  })
+  )
 
   app.$selectionBinding?.on('setSelection', (selInfo) => {
     const modelCards = models.value.filter(


### PR DESCRIPTION
It was populating before `selectedObjectIds` on UI and it became visible only second highligh model after filter changed. Now I pass selectedObjectIds explicitly from host app to fix it.