### PR TITLE
fix(fe2): Only show "New Discussion" button when an object is selected

### DIFF
--- a/packages/frontend-2/components/project/page/latest-items/comments/EmptyState.vue
+++ b/packages/frontend-2/components/project/page/latest-items/comments/EmptyState.vue
@@ -1,9 +1,5 @@
 <template>
-  <ProjectEmptyState
-    :small="small"
-    title="No discussions, yet."
-    :text="small ? undefined : 'Open a model and start the collaboration today!'"
-  >
+  <ProjectEmptyState :small="small" title="No discussions, yet." :text="text">
     <template #cta>
       <div v-if="showButton" class="mt-3">
         <FormButton :icon-left="PlusIcon" @click="() => $emit('new-discussion')">
@@ -23,5 +19,6 @@ defineEmits<{
 defineProps<{
   small?: boolean
   showButton?: boolean
+  text?: string
 }>()
 </script>

--- a/packages/frontend-2/components/viewer/comments/Comments.vue
+++ b/packages/frontend-2/components/viewer/comments/Comments.vue
@@ -62,7 +62,10 @@
       <div v-if="commentThreads.length === 0" class="pb-4">
         <ProjectPageLatestItemsCommentsEmptyState
           small
-          :show-button="canPostComment"
+          :show-button="canPostComment && hasSelectedObjects"
+          :text="
+            hasSelectedObjects ? undefined : 'Select an object to start collaborating'
+          "
           @new-discussion="onNewDiscussion"
         />
       </div>
@@ -88,6 +91,7 @@ import {
 } from '~~/lib/viewer/composables/setup'
 import { useMixpanel } from '~~/lib/core/composables/mp'
 import { useCheckViewerCommentingAccess } from '~~/lib/viewer/composables/commentManagement'
+import { useSelectionUtilities } from '~~/lib/viewer/composables/ui'
 
 defineEmits(['close'])
 
@@ -168,7 +172,12 @@ watch(includeArchived, (newVal) =>
   })
 )
 
+const { objectIds: selectedObjectIds } = useSelectionUtilities()
+
+const hasSelectedObjects = computed(() => selectedObjectIds.value.size > 0)
+
 const onNewDiscussion = () => {
+  if (!hasSelectedObjects.value) return
   newThreadEditor.value = true
 }
 </script>


### PR DESCRIPTION
[LINEAR TICKET](https://linear.app/speckle/issue/WEB-2087/new-discussion-button-doesnt-do-anything)

Now, we only show the button when an object is selected. If not, we show a message telling them to select something. 