### PR TITLE
fix(fe2): Turn off breadcrumb separator in automate functions page

### DIFF
--- a/packages/frontend-2/components/automate/functions/page/Header.vue
+++ b/packages/frontend-2/components/automate/functions/page/Header.vue
@@ -4,7 +4,11 @@
       class="pt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
     >
       <Portal to="navigation">
-        <HeaderNavLink :to="automationFunctionsRoute" :name="'Automate functions'" />
+        <HeaderNavLink
+          :separator="false"
+          :to="automationFunctionsRoute"
+          :name="'Automate functions'"
+        />
       </Portal>
 
       <h1 class="text-heading-xl">Automate functions</h1>


### PR DESCRIPTION
To fix this:
![image](https://github.com/user-attachments/assets/2fde7935-aa9b-4f9e-a681-d4c664c93546)
