### PR TITLE
refactor(fe2): Add loading state to Access Tokens

### DIFF
--- a/packages/frontend-2/components/settings/user/developer/AccessTokens/AccessTokens.vue
+++ b/packages/frontend-2/components/settings/user/developer/AccessTokens/AccessTokens.vue
@@ -46,6 +46,7 @@
         { id: 'actions', header: '', classes: 'col-span-1 flex justify-end' }
       ]"
       :items="tokens"
+      :loading="loading"
     >
       <template #name="{ item }">
         {{ item.name }}
@@ -107,9 +108,11 @@ const emit = defineEmits<{
   (e: 'delete', item: TokenItem): void
 }>()
 
-const { result: tokensResult, refetch: refetchTokens } = useQuery(
-  developerSettingsAccessTokensQuery
-)
+const {
+  result: tokensResult,
+  refetch: refetchTokens,
+  loading
+} = useQuery(developerSettingsAccessTokensQuery)
 
 const tokenSuccess = ref('')
 const showCreateTokenDialog = ref(false)

--- a/packages/ui-components/src/components/layout/Table.vue
+++ b/packages/ui-components/src/components/layout/Table.vue
@@ -19,13 +19,10 @@
       >
         <div
           v-if="loading || !items"
+          class="flex items-center justify-center py-3"
           tabindex="0"
-          :style="{ paddingRight: paddingRightStyle }"
-          :class="rowsWrapperClasses"
         >
-          <div :class="getClasses(undefined, 0, { noPadding: true })" tabindex="0">
-            <CommonLoadingBar loading />
-          </div>
+          <CommonLoadingIcon />
         </div>
         <template v-else-if="items?.length">
           <div
@@ -85,7 +82,7 @@
 import { noop, isString } from 'lodash'
 import { computed } from 'vue'
 import type { PropAnyComponent } from '~~/src/helpers/common/components'
-import { CommonLoadingBar, FormButton } from '~~/src/lib'
+import { CommonLoadingIcon, FormButton } from '~~/src/lib'
 import { directive as vTippy } from 'vue-tippy'
 
 export type TableColumn<I> = {


### PR DESCRIPTION
[LINEAR TICKET](https://linear.app/speckle/issue/WEB-2054/personal-access-tokens-shows-empty-state-while-loading)

Bug reported by Jonathan. We now show a loading state to Personal Access Tokens table. 