### PR TITLE
fix(server): remove flaky dblink_slot_create_or_drop calls in tests

### DIFF
--- a/packages/server/test/hooks.ts
+++ b/packages/server/test/hooks.ts
@@ -151,9 +151,11 @@ export const resetPubSubFactory = (deps: { db: Knex }) => async () => {
     await deps.db.raw(
       `SELECT * FROM aiven_extras.pg_drop_subscription('${sub.subname}');`
     )
-    await deps.db.raw(
-      `SELECT * FROM aiven_extras.dblink_slot_create_or_drop('${sub.subconninfo}', '${sub.subslotname}', 'drop');`
-    )
+
+    // TODO: Causes flaky test breakages, maybe we dont need it? ("error: replication slot "test_userssub_region1" is active for PID 2294")
+    // await deps.db.raw(
+    //   `SELECT * FROM aiven_extras.dblink_slot_create_or_drop('${sub.subconninfo}', '${sub.subslotname}', 'drop');`
+    // )
   }
 
   // Drop all pubs


### PR DESCRIPTION
this keeps causing flaky multiregion test breakages https://app.circleci.com/pipelines/github/specklesystems/speckle-server/14136/workflows/adbe28b7-c2bc-4967-ba05-f3aee4d682a0/jobs/231690/tests

maybe we don't need it?