### PR TITLE
fix(automate): handle newline in status messages

### DIFF
--- a/packages/frontend-2/components/automate/viewer/panel/FunctionRunRow.vue
+++ b/packages/frontend-2/components/automate/viewer/panel/FunctionRunRow.vue
@@ -36,19 +36,11 @@
       <div class="space-y-1">
         <div class="text-xs font-medium text-foreground-2">Status</div>
         <div
-          v-if="
-            [
-              AutomateRunStatus.Initializing,
-              AutomateRunStatus.Running,
-              AutomateRunStatus.Pending
-            ].includes(functionRun.status)
-          "
+          v-for="(fragment, i) in statusMessageFragments"
+          :key="`status-fragment-${i}`"
           class="text-xs text-foreground-2 italic"
         >
-          Function is {{ functionRun.status.toLowerCase() }}.
-        </div>
-        <div v-else class="text-xs text-foreground-2 italic">
-          {{ functionRun.statusMessage || 'No status message' }}
+          {{ fragment }}
         </div>
       </div>
 
@@ -167,5 +159,16 @@ const hasValidContextView = computed(() => {
 
   const currentPath = route.fullPath
   return !doesRouteFitTarget(ctxView, currentPath)
+})
+const statusMessageFragments = computed(() => {
+  const isFinished = ![
+    AutomateRunStatus.Initializing,
+    AutomateRunStatus.Running,
+    AutomateRunStatus.Pending
+  ].includes(props.functionRun.status)
+
+  return isFinished
+    ? (props.functionRun.statusMessage ?? 'No status message').split('\n')
+    : [`Function is ${props.functionRun.status.toLowerCase()}.`]
 })
 </script>

--- a/packages/frontend-2/components/automate/viewer/panel/FunctionRunRow.vue
+++ b/packages/frontend-2/components/automate/viewer/panel/FunctionRunRow.vue
@@ -35,12 +35,8 @@
       <!-- Status message -->
       <div class="space-y-1">
         <div class="text-xs font-medium text-foreground-2">Status</div>
-        <div
-          v-for="(fragment, i) in statusMessageFragments"
-          :key="`status-fragment-${i}`"
-          class="text-xs text-foreground-2 italic"
-        >
-          {{ fragment }}
+        <div class="text-xs text-foreground-2 italic whitespace-pre-wrap">
+          {{ statusMessage }}
         </div>
       </div>
 
@@ -160,7 +156,8 @@ const hasValidContextView = computed(() => {
   const currentPath = route.fullPath
   return !doesRouteFitTarget(ctxView, currentPath)
 })
-const statusMessageFragments = computed(() => {
+
+const statusMessage = computed(() => {
   const isFinished = ![
     AutomateRunStatus.Initializing,
     AutomateRunStatus.Running,
@@ -168,7 +165,7 @@ const statusMessageFragments = computed(() => {
   ].includes(props.functionRun.status)
 
   return isFinished
-    ? (props.functionRun.statusMessage ?? 'No status message').split('\n')
-    : [`Function is ${props.functionRun.status.toLowerCase()}.`]
+    ? props.functionRun.statusMessage ?? 'No status message'
+    : `Function is ${props.functionRun.status.toLowerCase()}.`
 })
 </script>


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

We don't handle any formatting characters for function run status messages, so the result can be a bit hard to read.

Before:

<img width="1018" alt="automate status" src="https://github.com/user-attachments/assets/60a38007-93e9-42c0-8d79-f0639ce9d391">

After:

![Screen Shot 2024-11-20 at 23 19 19](https://github.com/user-attachments/assets/e4b10677-690f-46d9-885d-3c31c16d5c04)
