### PR TITLE
Feat(dui3): send batches sequentially from server bridges

### DIFF
--- a/packages/dui3/lib/bridge/server.ts
+++ b/packages/dui3/lib/bridge/server.ts
@@ -34,6 +34,7 @@ export type CreateVersionViaBrowserArgs = {
   accountId: string
   message: string
   referencedObjectId: string
+  sourceApplication: string
   sendConversionResults: ConversionResult[]
 }
 
@@ -66,7 +67,7 @@ export type CreateVersionArgs = {
   projectId: string
   modelId: string
   accountId: string
-  objectId: string
+  referencedObjectId: string
   message?: string
   sourceApplication?: string
 }
@@ -218,22 +219,21 @@ export class ServerBridge {
       modelCardId,
       referencedObjectId,
       message,
+      sourceApplication,
       sendConversionResults
     } = eventPayload
-    const args: CreateVersionArgs = {
+    const versionId = await this.createVersion({
       modelCardId,
       projectId,
       modelId,
       accountId,
-      objectId: referencedObjectId,
-      sourceApplication: 'sketchup',
-      message: message || 'send from sketchup'
-    }
-    const versionId = await this.createVersion(args)
+      referencedObjectId,
+      sourceApplication,
+      message
+    })
     const hostAppStore = useHostAppStore()
-    // TODO: Alignment needed
     hostAppStore.setModelSendResult({
-      modelCardId: args.modelCardId,
+      modelCardId,
       versionId: versionId as string,
       sendConversionResults
     })
@@ -297,7 +297,7 @@ export class ServerBridge {
       projectId,
       modelId,
       accountId,
-      objectId: rootCommitObjectId,
+      referencedObjectId: rootCommitObjectId,
       sourceApplication: hostAppStore.hostAppName?.toLowerCase(),
       message: message || `send from ${hostAppStore.hostAppName?.toLowerCase()}`
     }
@@ -325,7 +325,7 @@ export class ServerBridge {
     const result = await createVersion.mutate({
       input: {
         modelId: args.modelId,
-        objectId: args.objectId,
+        objectId: args.referencedObjectId,
         sourceApplication: hostAppStore.hostAppName,
         projectId: args.projectId
       }

--- a/packages/dui3/lib/bridge/server.ts
+++ b/packages/dui3/lib/bridge/server.ts
@@ -169,7 +169,9 @@ export class ServerBridge {
   }
 
   /**
-   * Internal sketchup method for sending batch data via the browser.
+   * Internal server method for sending batch data via REST api.
+   * Whenever batches are completed it triggers to host application to notify it is done.
+   * To be able to use this function properly, expected objects in batch must have hashed (speckle ids generated, detached, chucked bla bla) on connector.
    * @param eventPayload
    */
   private async sendBatchViaBrowser(eventPayload: SendBatchViaBrowserArgs) {
@@ -204,6 +206,10 @@ export class ServerBridge {
     }
   }
 
+  /**
+   * Whenever we make sure we sent every object to the server, we can safely call this function from connector to trigger version create and populate conversion reports.
+   * @param eventPayload
+   */
   private async createVersionViaBrowser(eventPayload: CreateVersionViaBrowserArgs) {
     const {
       projectId,
@@ -234,7 +240,7 @@ export class ServerBridge {
   }
 
   /**
-   * Internal server bridge method for sending data via the browser.
+   * Internal server bridge method for sending data via object sender.
    * @param eventPayload
    */
   private async sendByBrowser(eventPayload: SendViaBrowserArgs) {

--- a/packages/dui3/lib/bridge/sketchup.ts
+++ b/packages/dui3/lib/bridge/sketchup.ts
@@ -221,7 +221,7 @@ export class SketchupBridge extends BaseBridge {
       projectId,
       modelId,
       accountId,
-      objectId: referencedObjectId,
+      referencedObjectId,
       sourceApplication: 'sketchup',
       message: message || 'send from sketchup'
     }
@@ -281,7 +281,7 @@ export class SketchupBridge extends BaseBridge {
       projectId,
       modelId,
       accountId,
-      objectId: sendObject.id,
+      referencedObjectId: sendObject.id,
       sourceApplication: 'sketchup',
       message: message || 'send from sketchup'
     }
@@ -308,7 +308,7 @@ export class SketchupBridge extends BaseBridge {
     const result = await createVersion.mutate({
       input: {
         modelId: args.modelId,
-        objectId: args.objectId,
+        objectId: args.referencedObjectId,
         sourceApplication: 'sketchup',
         projectId: args.projectId
       }

--- a/packages/dui3/lib/bridge/sketchup.ts
+++ b/packages/dui3/lib/bridge/sketchup.ts
@@ -13,21 +13,16 @@ import { useAccountStore } from '~/store/accounts'
 import { useHostAppStore } from '~/store/hostApp'
 import type { ConversionResult } from '~/lib/conversions/conversionResult'
 import { storeToRefs } from 'pinia'
+import type {
+  SendBatchViaBrowserArgs,
+  CreateVersionViaBrowserArgs,
+  ReceiveViaBrowserArgs,
+  CreateVersionArgs
+} from '~/lib/bridge/server'
 
 declare let sketchup: {
   exec: (data: Record<string, unknown>) => void
   getBindingsMethodNames: (viewId: string) => void
-}
-
-type SendBatchViaBrowserArgs = {
-  modelCardId: string
-  projectId: string
-  token: string
-  serverUrl: string
-  batch: string
-  currentBatch: number
-  totalBatch: number
-  referencedObjectId: string
 }
 
 type SendViaBrowserArgs = {
@@ -44,37 +39,6 @@ type SendViaBrowserArgs = {
     totalChildrenCount: number
     batches: string[]
   }
-}
-
-type createVersionViaBrowserArgs = {
-  modelCardId: string
-  projectId: string
-  modelId: string
-  token: string
-  serverUrl: string
-  accountId: string
-  message: string
-  referencedObjectId: string
-  sendConversionResults: ConversionResult[]
-}
-
-type ReceiveViaBrowserArgs = {
-  modelCardId: string
-  projectId: string
-  modelId: string
-  objectId: string
-  accountId: string
-  selectedVersionId: string
-}
-
-type CreateVersionArgs = {
-  modelCardId: string
-  projectId: string
-  modelId: string
-  accountId: string
-  objectId: string
-  message?: string
-  sourceApplication?: string
 }
 
 /**
@@ -130,7 +94,7 @@ export class SketchupBridge extends BaseBridge {
     else if (eventName === 'sendBatchViaBrowser')
       this.sendBatchViaBrowser(eventPayload as SendBatchViaBrowserArgs)
     else if (eventName === 'createVersionViaBrowser')
-      this.createVersionViaBrowser(eventPayload as createVersionViaBrowserArgs)
+      this.createVersionViaBrowser(eventPayload as CreateVersionViaBrowserArgs)
     else if (eventName === 'receiveViaBrowser')
       this.receiveViaBrowser(eventPayload as ReceiveViaBrowserArgs)
 
@@ -242,7 +206,7 @@ export class SketchupBridge extends BaseBridge {
     }
   }
 
-  private async createVersionViaBrowser(eventPayload: createVersionViaBrowserArgs) {
+  private async createVersionViaBrowser(eventPayload: CreateVersionViaBrowserArgs) {
     const {
       projectId,
       accountId,

--- a/packages/dui3/lib/bridge/sketchup.ts
+++ b/packages/dui3/lib/bridge/sketchup.ts
@@ -19,6 +19,17 @@ declare let sketchup: {
   getBindingsMethodNames: (viewId: string) => void
 }
 
+type SendBatchViaBrowserArgs = {
+  modelCardId: string
+  projectId: string
+  token: string
+  serverUrl: string
+  batch: string
+  currentBatch: number
+  totalBatch: number
+  referencedObjectId: string
+}
+
 type SendViaBrowserArgs = {
   modelCardId: string
   projectId: string
@@ -33,6 +44,18 @@ type SendViaBrowserArgs = {
     totalChildrenCount: number
     batches: string[]
   }
+}
+
+type createVersionViaBrowserArgs = {
+  modelCardId: string
+  projectId: string
+  modelId: string
+  token: string
+  serverUrl: string
+  accountId: string
+  message: string
+  referencedObjectId: string
+  sendConversionResults: ConversionResult[]
 }
 
 type ReceiveViaBrowserArgs = {
@@ -104,6 +127,10 @@ export class SketchupBridge extends BaseBridge {
 
     if (eventName === 'sendViaBrowser')
       this.sendViaBrowser(eventPayload as SendViaBrowserArgs)
+    else if (eventName === 'sendBatchViaBrowser')
+      this.sendBatchViaBrowser(eventPayload as SendBatchViaBrowserArgs)
+    else if (eventName === 'createVersionViaBrowser')
+      this.createVersionViaBrowser(eventPayload as createVersionViaBrowserArgs)
     else if (eventName === 'receiveViaBrowser')
       this.receiveViaBrowser(eventPayload as ReceiveViaBrowserArgs)
 
@@ -180,8 +207,74 @@ export class SketchupBridge extends BaseBridge {
   }
 
   /**
+   * Internal sketchup method for sending batch data via the browser.
+   * @param eventPayload
+   */
+  private async sendBatchViaBrowser(eventPayload: SendBatchViaBrowserArgs) {
+    const {
+      serverUrl,
+      token,
+      projectId,
+      modelCardId,
+      batch,
+      totalBatch,
+      currentBatch,
+      referencedObjectId
+    } = eventPayload
+    this.emit('setModelProgress', {
+      modelCardId,
+      progress: {
+        status: 'Uploading',
+        progress: currentBatch / totalBatch
+      }
+    } as unknown as string)
+    const formData = new FormData()
+    formData.append(`batch-1`, new Blob([batch], { type: 'application/json' }))
+    await fetch(`${serverUrl}/objects/${projectId}`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer ' + token },
+      body: formData
+    })
+
+    if (currentBatch === totalBatch) {
+      const args = [eventPayload.modelCardId, referencedObjectId]
+      await this.runMethod('afterSendObjects', args as unknown as unknown[])
+    }
+  }
+
+  private async createVersionViaBrowser(eventPayload: createVersionViaBrowserArgs) {
+    const {
+      projectId,
+      accountId,
+      modelId,
+      modelCardId,
+      referencedObjectId,
+      message,
+      sendConversionResults
+    } = eventPayload
+    const args: CreateVersionArgs = {
+      modelCardId,
+      projectId,
+      modelId,
+      accountId,
+      objectId: referencedObjectId,
+      sourceApplication: 'sketchup',
+      message: message || 'send from sketchup'
+    }
+    const versionId = await this.createVersion(args)
+    const hostAppStore = useHostAppStore()
+    // TODO: Alignment needed
+    hostAppStore.setModelSendResult({
+      modelCardId: args.modelCardId,
+      versionId: versionId as string,
+      sendConversionResults
+    })
+  }
+
+  /**
    * Internal sketchup method for sending data via the browser.
    * @param eventPayload
+   * @deprecated replaced with sendBatchViaBrowser. NOTE: remove completely!
    */
   private async sendViaBrowser(eventPayload: SendViaBrowserArgs) {
     const {


### PR DESCRIPTION
mostly for archicad to be able to send batches (100mb) sequentially instead of passing all JSON object to browser. There was huge performance penalty on `JSON.parse`

PS: Sketchup bridge still has some differences other that generic and server bridge, I would keep them separete till when we have more bandwidth to do it better

PS2: Changes are backward compatible, even if we merge this, nothing will be side effected.

also related to: https://github.com/specklesystems/speckle-sketchup/pull/397

validated with sketchup
<img width="853" alt="Screenshot 2024-11-25 at 21 31 28" src="https://github.com/user-attachments/assets/2202a7e7-4d1b-49ca-bf55-424468172f45">
<img width="1678" alt="Screenshot 2024-11-25 at 21 31 04" src="https://github.com/user-attachments/assets/0e501844-63be-47d1-8e02-1324cb60f689">

