### PR TITLE
fix(sso): distinguish between missing and invalid sso user profile

### DIFF
--- a/packages/server/modules/workspaces/errors/sso.ts
+++ b/packages/server/modules/workspaces/errors/sso.ts
@@ -34,6 +34,17 @@ export class SsoProviderProfileMissingError extends BaseError {
   static code = 'SSO_PROVIDER_PROFILE_MISSING_ERROR'
 }
 
+export class SsoProviderProfileMissingPropertiesError extends BaseError {
+  static code = 'SSO_PROVIDER_PROFILE_MISSING_PROPERTIES_ERROR'
+  constructor(properties: string[]) {
+    super(
+      `User profile from identity provider missing required properties: ${properties.join(
+        ', '
+      )}`
+    )
+  }
+}
+
 export class SsoProviderProfileInvalidError extends BaseError {
   static defaultMessage = 'SSO provider user profile is invalid.'
   static code = 'SSO_PROVIDER_PROFILE_INVALID_ERROR'

--- a/packages/server/modules/workspaces/rest/sso.ts
+++ b/packages/server/modules/workspaces/rest/sso.ts
@@ -103,6 +103,7 @@ import {
   SsoGenericProviderValidationError,
   SsoProviderMissingError,
   SsoProviderProfileMissingError,
+  SsoProviderProfileMissingPropertiesError,
   SsoUserClaimedError,
   SsoUserEmailUnverifiedError,
   SsoVerificationCodeMissingError
@@ -595,8 +596,11 @@ const getOidcProviderUserDataFactory =
     )
 
     const oidcProviderUserData = await client.userinfo(tokenSet)
-    if (!oidcProviderUserData || !oidcProviderUserData.email) {
+    if (!oidcProviderUserData) {
       throw new SsoProviderProfileMissingError()
+    }
+    if (!oidcProviderUserData.email) {
+      throw new SsoProviderProfileMissingPropertiesError(['email'])
     }
 
     return oidcProviderUserData as UserinfoResponse<{ email: string }>


### PR DESCRIPTION
## Description & motivation

- Invalid profiles from identity providers were throwing the same error as missing profiles, which was confusing and wrong.
