### PR TITLE
fix(sso): continue with sso from any verified email

### DIFF
--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -152,11 +152,7 @@ import {
   WorkspaceSubscriptions
 } from '@/modules/shared/utils/subscriptions'
 import { updateStreamRoleAndNotifyFactory } from '@/modules/core/services/streams/management'
-import {
-  getUserByEmailFactory,
-  getUserFactory,
-  getUsersFactory
-} from '@/modules/core/repositories/users'
+import { getUserFactory, getUsersFactory } from '@/modules/core/repositories/users'
 import { getServerInfoFactory } from '@/modules/core/repositories/server'
 import { commandFactory } from '@/modules/shared/command'
 import { withTransaction } from '@/modules/shared/helpers/dbHelper'
@@ -312,7 +308,7 @@ export = FF_WORKSPACES_MODULE_ENABLED
         },
         workspaceSsoByEmail: async (_parent, args) => {
           const workspaces = await listWorkspaceSsoMembershipsByUserEmailFactory({
-            getUserByEmail: getUserByEmailFactory({ db }),
+            findEmail: findEmailFactory({ db }),
             listWorkspaceSsoMemberships: listWorkspaceSsoMembershipsFactory({ db })
           })({
             userEmail: args.email


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- The backend logic used by the "Continue with SSO" button uses `findUserByEmail`, but this is implicitly only by _primary_ email.
- Users will want to continue with their company email regardless of if it's also their primary email

## Changes:

- `findUserByEmail` => `findEmail` then user user id
