### PR TITLE
fix(server/multi-region/sql): use parameter binding to prevent secret leak

### DIFF
--- a/packages/server/modules/multiregion/dbSelector.ts
+++ b/packages/server/modules/multiregion/dbSelector.ts
@@ -221,16 +221,21 @@ const setUpUserReplication = async ({
   const port = fromUrl.port ? fromUrl.port : '5432'
   const fromDbName = fromUrl.pathname.replace('/', '')
   const rawSqeel = `SELECT * FROM aiven_extras.pg_create_subscription(
-    '${subName}',
-    'dbname=${fromDbName} host=${fromUrl.hostname} port=${port} sslmode=${sslmode} user=${fromUrl.username} password=${fromUrl.password}',
-    '${pubName}', 
-    '${subName}',
+    ?,
+    ?,
+    ?,
+    ?,
     TRUE,
     TRUE
   );`
   try {
     await to.public.raw('CREATE EXTENSION IF NOT EXISTS "aiven_extras"')
-    await to.public.raw(rawSqeel)
+    await to.public.raw(rawSqeel, [
+      subName,
+      `dbname=${fromDbName} host=${fromUrl.hostname} port=${port} sslmode=${sslmode} user=${fromUrl.username} password=${fromUrl.password}`,
+      pubName,
+      subName
+    ])
   } catch (err) {
     if (!(err instanceof Error)) throw err
     if (!err.message.includes('already exists')) throw err
@@ -261,16 +266,21 @@ const setUpProjectReplication = async ({
   const port = fromUrl.port ? fromUrl.port : '5432'
   const fromDbName = fromUrl.pathname.replace('/', '')
   const rawSqeel = `SELECT * FROM aiven_extras.pg_create_subscription(
-    '${subName}',
-    'dbname=${fromDbName} host=${fromUrl.hostname} port=${port} sslmode=${sslmode} user=${fromUrl.username} password=${fromUrl.password}',
-    '${pubName}', 
-    '${subName}',
+    ?,
+    ?,
+    ?,
+    ?,
     TRUE,
     TRUE
   );`
   try {
     await to.public.raw('CREATE EXTENSION IF NOT EXISTS "aiven_extras"')
-    await to.public.raw(rawSqeel)
+    await to.public.raw(rawSqeel, [
+      subName,
+      `dbname=${fromDbName} host=${fromUrl.hostname} port=${port} sslmode=${sslmode} user=${fromUrl.username} password=${fromUrl.password}`,
+      pubName,
+      subName
+    ])
   } catch (err) {
     if (!(err instanceof Error)) throw err
     if (!err.message.includes('already exists')) throw err


### PR DESCRIPTION
## Description & motivation

- Knex is configured to log SQL statements. It currently logs the password of the database when a subscription is created.
- This leaks passwords into the logs and is a security issue.
- But parameters of SQL statements are not logged.
- So, this parameterises the subscription-creation SQL statements.
- This PR prevents database passwords leaking into the logs.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
