### PR TITLE
fix(logging): taskScheduler should use pino parameters

### DIFF
--- a/packages/server/modules/core/services/taskScheduler.ts
+++ b/packages/server/modules/core/services/taskScheduler.ts
@@ -1,6 +1,5 @@
 import cron from 'node-cron'
 import { InvalidArgumentError } from '@/modules/shared/errors'
-import { ensureError } from '@/modules/shared/helpers/errorHelper'
 import { logger } from '@/logging/logging'
 import {
   AcquireTaskLock,
@@ -23,26 +22,26 @@ export const scheduledCallbackWrapper = async (
 
   // if couldn't acquire it, stop execution
   if (!lock) {
-    boundLogger.warn(`Could not acquire task lock for ${taskName}, stopping execution.`)
+    boundLogger.warn('Could not acquire task lock for {taskName}, stopping execution.')
     return
   }
   try {
     // else continue executing the callback...
-    boundLogger.info(`Executing scheduled function ${taskName} at ${scheduledTime}`)
+    boundLogger.info(
+      { scheduledTime },
+      'Executing scheduled function {taskName} at {scheduledTime}'
+    )
     await callback(scheduledTime)
     // update lock as succeeded
     const finishDate = new Date()
     boundLogger.info(
-      `Finished scheduled function ${taskName} execution in ${
-        (finishDate.getTime() - scheduledTime.getTime()) / 1000
-      } seconds`
+      { durationSeconds: (finishDate.getTime() - scheduledTime.getTime()) / 1000 },
+      'Finished scheduled function {taskName} execution in {durationSeconds} seconds'
     )
   } catch (error) {
     boundLogger.error(
-      error,
-      `The triggered task execution ${taskName} failed at ${scheduledTime}, with error ${
-        ensureError(error, 'unknown reason').message
-      }`
+      { err: error, scheduledTime },
+      'The triggered task execution {taskName} failed at {scheduledTime}'
     )
   } finally {
     releaseTaskLock(lock)


### PR DESCRIPTION

## Description & motivation

Log messages were being interpolated at runtime and not using structured logging. This resulted in a high number of unique messages instead of a single common template.

This PR uses structured logging instead of runtime string formatting, to ensure that the template can be detected & queried.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
