### PR TITLE
Fix: Billing switch

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/billing/PricingTable/Plan.vue
+++ b/packages/frontend-2/components/settings/workspaces/billing/PricingTable/Plan.vue
@@ -167,7 +167,9 @@ const isSelectable = computed(() => {
 const toggleEnabled = computed(() => {
   return isSelectable.value && statusIsTrial.value
     ? true
-    : canUpgradeToPlan.value && props.currentPlan?.name !== props.plan.name
+    : canUpgradeToPlan.value ||
+        (props.currentPlan?.name === props.plan.name &&
+          props.activeBillingInterval === BillingInterval.Monthly)
 })
 const buttonText = computed(() => {
   // Trial plan case


### PR DESCRIPTION
Only enable billing switch if:
In trial period
OR can upgrade to plan
OR (matches current plan AND the active billing interval is monthly)

@benjaminvo Could you double-check if this is how you would like it to work?