### PR TITLE
fix(sso): oidc state parameter

### DIFF
--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -324,8 +324,6 @@ export type AutomateFunctionTemplate = {
 };
 
 export enum AutomateFunctionTemplateLanguage {
-  Demonstration = 'DEMONSTRATION',
-  Demonstrationpython = 'DEMONSTRATIONPYTHON',
   DotNet = 'DOT_NET',
   Python = 'PYTHON',
   Typescript = 'TYPESCRIPT'

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -305,8 +305,6 @@ export type AutomateFunctionTemplate = {
 };
 
 export enum AutomateFunctionTemplateLanguage {
-  Demonstration = 'DEMONSTRATION',
-  Demonstrationpython = 'DEMONSTRATIONPYTHON',
   DotNet = 'DOT_NET',
   Python = 'PYTHON',
   Typescript = 'TYPESCRIPT'

--- a/packages/server/modules/workspaces/clients/oidcProvider.ts
+++ b/packages/server/modules/workspaces/clients/oidcProvider.ts
@@ -13,11 +13,13 @@ import { generators, Issuer, type Client } from 'openid-client'
 export const getProviderAuthorizationUrl = async ({
   provider,
   redirectUrl,
-  codeVerifier
+  codeVerifier,
+  state
 }: {
   provider: OidcProvider
   redirectUrl: URL
   codeVerifier: string
+  state: string
 }): Promise<URL> => {
   const { client } = await initializeIssuerAndClient({ provider, redirectUrl })
   const code_challenge = generators.codeChallenge(codeVerifier)
@@ -26,7 +28,8 @@ export const getProviderAuthorizationUrl = async ({
       scope: 'openid email profile',
       redirect_uri: redirectUrl.toString(),
       code_challenge,
-      code_challenge_method: 'S256'
+      code_challenge_method: 'S256',
+      state
     })
   )
 }

--- a/packages/server/modules/workspaces/domain/sso/types.ts
+++ b/packages/server/modules/workspaces/domain/sso/types.ts
@@ -49,3 +49,7 @@ export type OidcProviderAttributes = {
     grantTypes: string[]
   }
 }
+
+export type SsoSessionState = {
+  isValidationFlow: boolean
+}

--- a/packages/server/modules/workspaces/errors/sso.ts
+++ b/packages/server/modules/workspaces/errors/sso.ts
@@ -82,3 +82,13 @@ export class OidcProviderMissingGrantTypeError extends BaseError {
   static code = 'SSO_OIDC_PROVIDER_MISSING_GRANT_TYPE'
   static statusCode = 400
 }
+
+export class OidcStateInvalidError extends BaseError {
+  static defaultMessage = 'OIDC state information malformed or invalid.'
+  static code = 'SSO_OIDC_STATE_INVALID'
+}
+
+export class OidcStateMissingError extends BaseError {
+  static defaultMessage = 'OIDC state missing for specified session.'
+  static code = 'SSO_OIDC_STATE_MISSING'
+}

--- a/packages/server/modules/workspaces/rest/sso.ts
+++ b/packages/server/modules/workspaces/rest/sso.ts
@@ -397,7 +397,7 @@ const handleSsoAuthRequestFactory =
   async ({ params, session, res }) => {
     try {
       if (!session.workspaceId) throw new WorkspaceNotFoundError()
-      if (!session.ssoNonce) throw new Error()
+      if (!session.ssoNonce) throw new OidcStateInvalidError()
 
       const { provider } =
         (await getWorkspaceSsoProvider({ workspaceId: session.workspaceId })) ?? {}
@@ -644,7 +644,7 @@ const getOidcProviderUserDataFactory =
     >,
     provider: OidcProvider
   ): Promise<UserinfoResponse<{ email: string }>> => {
-    if (!req.session.ssoNonce) throw new Error()
+    if (!req.session.ssoNonce) throw new OidcStateInvalidError()
 
     const codeVerifier = await parseCodeVerifier(req)
     const { client } = await initializeIssuerAndClient({ provider })

--- a/packages/server/modules/workspaces/services/sso.ts
+++ b/packages/server/modules/workspaces/services/sso.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import {
   GetOidcProviderAttributes,
   StoreOidcProviderValidationRequest,
@@ -148,14 +146,10 @@ export const createWorkspaceUserFromSsoProfileFactory =
     }
 
     // Create Speckle user
-    const { name, email, email_verified } = args.ssoProfile
+    const { name, email } = args.ssoProfile
 
     if (!name) {
       throw new SsoProviderProfileInvalidError('SSO provider user requires a name')
-    }
-
-    if (!email_verified) {
-      throw new SsoProviderProfileInvalidError('SSO provider user email is unverified')
     }
 
     const newSpeckleUser = {

--- a/packages/server/modules/workspaces/tests/unit/helpers/sso.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/helpers/sso.spec.ts
@@ -7,12 +7,8 @@ import { expect } from 'chai'
 
 describe('buildAuthRedirectUrl', () => {
   it('should include workspace slug provided', () => {
-    const url = buildAuthRedirectUrl('my-workspace', false)
+    const url = buildAuthRedirectUrl('my-workspace')
     expect(url.toString().includes('my-workspace')).to.equal(true)
-  })
-  it('should include validate param if provided', () => {
-    const url = buildAuthRedirectUrl('my-workspace', true)
-    expect(url.searchParams.get('validate')).to.equal('true')
   })
 })
 

--- a/packages/server/modules/workspaces/tests/unit/services/sso.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/services/sso.spec.ts
@@ -118,28 +118,6 @@ describe('Workspace SSO services', () => {
       )
       expect(err.message).to.include('requires a name')
     })
-    it('throws if SSO provider user profile does not have a verified email', async () => {
-      const createWorkspaceUserFromSsoProfile =
-        createWorkspaceUserFromSsoProfileFactory({
-          createUser: async () => '',
-          upsertWorkspaceRole: async () => {},
-          findInvite: async () => ({} as unknown as any),
-          deleteInvite: async () => true
-        })
-
-      const err = await expectToThrow(() =>
-        createWorkspaceUserFromSsoProfile({
-          ssoProfile: {
-            name: 'John Speckle',
-            sub: '',
-            email: '',
-            email_verified: false
-          },
-          workspaceId: cryptoRandomString({ length: 9 })
-        })
-      )
-      expect(err.message).to.include('email is unverified')
-    })
     it('throws if workspace role on invite is not a valid workspace role', async () => {
       const createWorkspaceUserFromSsoProfile =
         createWorkspaceUserFromSsoProfileFactory({


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Use OIDC `state` parameter instead of our `?validate=true` business
- Appease Okta with these changes

## Changes:

- One callback, with middleware for setting/confirming access to `state`
- Update copy in FE form to drop `?validate=true`
- Also stop checking if sso provider email is verified because EntraId
