### PR TITLE
fix(workspaces): randomize first default logo

### DIFF
--- a/packages/frontend-2/components/workspace/CreateDialog.vue
+++ b/packages/frontend-2/components/workspace/CreateDialog.vue
@@ -73,7 +73,7 @@ const workspaceShortId = ref('')
 const debouncedWorkspaceShortId = ref('')
 const editAvatarMode = ref(false)
 const workspaceLogo = ref<MaybeNullOrUndefined<string>>()
-const defaultLogoIndex = ref(0)
+const defaultLogoIndex = ref(generateDefaultLogoIndex())
 const shortIdManuallyEdited = ref(false)
 
 const { error, loading } = useQuery(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5dc94345-22e0-4cda-9ef5-ed4504281466)

Default logo index was being randomized/reset on modal close, but set to 0 on first open. So nearly everyone was getting this lil guy as the default logo.

NO LONGER