### PR TITLE
Benjamin/web 2246 various copy fixes

### DIFF
--- a/packages/frontend-2/components/billing/Alert.vue
+++ b/packages/frontend-2/components/billing/Alert.vue
@@ -51,6 +51,9 @@ const isTrial = computed(
 const isPaymentFailed = computed(
   () => planStatus.value === WorkspacePlanStatuses.PaymentFailed
 )
+const isScheduledForCancelation = computed(
+  () => planStatus.value === WorkspacePlanStatuses.CancelationScheduled
+)
 const trialDaysLeft = computed(() => {
   const createdAt = props.workspace.plan?.createdAt
   const trialEndDate = dayjs(createdAt).add(31, 'days')
@@ -65,11 +68,11 @@ const title = computed(() => {
   }
   switch (planStatus.value) {
     case WorkspacePlanStatuses.CancelationScheduled:
-      return `Your ${props.workspace.plan?.name} plan subscription is scheduled for cancellation`
+      return `Your workspace subscription is scheduled for cancellation`
     case WorkspacePlanStatuses.Canceled:
-      return `Your ${props.workspace.plan?.name} plan subscription has been cancelled`
+      return `Your workspace subscription has been cancelled`
     case WorkspacePlanStatuses.Expired:
-      return `Your free ${props.workspace.plan?.name} plan trial has ended`
+      return `Your free trial has ended`
     case WorkspacePlanStatuses.PaymentFailed:
       return "Your last payment didn't go through"
     default:
@@ -84,11 +87,11 @@ const description = computed(() => {
   }
   switch (planStatus.value) {
     case WorkspacePlanStatuses.CancelationScheduled:
-      return 'Your workspace subscription is scheduled for cancellation. After the cancellation, your workspace will be in read-only mode.'
+      return 'Once the current billing cycle ends your workspace will enter read-only mode. Renew your subscription to undo.'
     case WorkspacePlanStatuses.Canceled:
-      return 'Your workspace has been cancelled and is in read-only mode. Upgrade your plan to continue.'
+      return 'Your workspace has been cancelled and is in read-only mode. Subscribe to a plan to regain full access.'
     case WorkspacePlanStatuses.Expired:
-      return "The workspace is in a read-only locked state until there's an active subscription. Upgrade your plan to continue."
+      return "The workspace is in a read-only locked state until there's an active subscription. Subscribe to a plan to regain full access."
     case WorkspacePlanStatuses.PaymentFailed:
       return "Update your payment information now to ensure your workspace doesn't go into maintenance mode."
     default:
@@ -113,6 +116,12 @@ const actions = computed((): AlertAction[] => {
   if (isPaymentFailed.value) {
     actions.push({
       title: 'Update payment information',
+      onClick: () => billingPortalRedirect(props.workspace.id),
+      disabled: !props.workspace.id
+    })
+  } else if (isScheduledForCancelation.value) {
+    actions.push({
+      title: 'Renew subscription',
       onClick: () => billingPortalRedirect(props.workspace.id),
       disabled: !props.workspace.id
     })

--- a/packages/frontend-2/components/settings/workspaces/Billing.vue
+++ b/packages/frontend-2/components/settings/workspaces/Billing.vue
@@ -266,10 +266,10 @@ const billDescription = computed(() => {
 const billTooltip = computed(() => {
   const memberText = `${memberSeatCount.value} member${
     memberSeatCount.value === 1 ? '' : 's'
-  } £${seatPrice.value[Roles.Workspace.Member]}`
+  } at £${seatPrice.value[Roles.Workspace.Member]}/month`
   const guestText = `${guestSeatCount.value} guest${
     guestSeatCount.value === 1 ? '' : 's'
-  } £${seatPrice.value[Roles.Workspace.Guest]}`
+  } at £${seatPrice.value[Roles.Workspace.Guest]}/month`
 
   return `${memberText}${guestSeatCount.value > 0 ? `, ${guestText}` : ''}`
 })

--- a/packages/frontend-2/components/settings/workspaces/Billing.vue
+++ b/packages/frontend-2/components/settings/workspaces/Billing.vue
@@ -252,8 +252,8 @@ const billValue = computed(() => {
   const guestPrice = seatPrice.value[Roles.Workspace.Guest] * guestSeatCount.value
   const memberPrice = seatPrice.value[Roles.Workspace.Member] * memberSeatCount.value
   const totalPrice = guestPrice + memberPrice
-  if (statusIsTrial.value) return `£${totalPrice}.00`
-  return `£0.00`
+  if (statusIsTrial.value) return `£${totalPrice}`
+  return `£0`
 })
 const billDescription = computed(() => {
   const memberText =

--- a/packages/frontend-2/components/settings/workspaces/Billing.vue
+++ b/packages/frontend-2/components/settings/workspaces/Billing.vue
@@ -52,7 +52,7 @@
                 </h3>
                 <template v-if="statusIsTrial">
                   <p class="text-heading-lg text-foreground inline-block">
-                    {{ billValue }}
+                    {{ billValue }} per month
                   </p>
                   <p class="text-body-xs text-foreground-2 flex gap-x-1 items-center">
                     {{ billDescription }}

--- a/packages/frontend-2/components/settings/workspaces/billing/UpgradeDialog.vue
+++ b/packages/frontend-2/components/settings/workspaces/billing/UpgradeDialog.vue
@@ -9,7 +9,7 @@
       <p>You are about to upgrade your workspace to the following plan:</p>
       <CommonCard class="font-medium bg-foundation !p-3 my-2">
         Workspace {{ startCase(plan) }} plan,
-        {{ billingInterval === BillingInterval.Yearly ? 'anual' : 'monthly' }}
+        {{ billingInterval === BillingInterval.Yearly ? 'annual' : 'monthly' }}
       </CommonCard>
       <p>Do you want to proceed?</p>
     </div>

--- a/packages/frontend-2/lib/billing/helpers/types.ts
+++ b/packages/frontend-2/lib/billing/helpers/types.ts
@@ -12,7 +12,7 @@ export enum PlanFeaturesList {
   PrivateAutomateFunctions = 'Private automate functions',
   DomainSecurity = 'Domain security',
   SSO = 'Single Sign-On (SSO)',
-  CustomDataRegion = 'Custom data region',
+  CustomDataRegion = 'Custom data residency',
   PrioritySupport = 'Priority support'
 }
 


### PR DESCRIPTION
Various mostly copy fixes
- Call it data residency in the pricing table
-  Remove decimals from expected bill value and add "per month"
- Fix typo in upgrade modal
- Change cancellation alert copy and add a button to renew subscription
- Other copy updates to the alerts