### PR TITLE
fix(fe2): Allow server:admin access to all workspace settings

### DIFF
--- a/packages/frontend-2/components/settings/Dialog.vue
+++ b/packages/frontend-2/components/settings/Dialog.vue
@@ -84,10 +84,13 @@
                   "
                   :disabled="!isAdmin && (workspaceMenuItem.disabled || needsSsoSession(workspaceItem, itemKey as string))"
                   extra-padding
-                  @click="() => {
-    if (!isAdmin && (workspaceMenuItem.disabled || needsSsoSession(workspaceItem, itemKey as string))) return
-    onWorkspaceMenuItemClick(workspaceItem.id, `${itemKey}`)
-  }"
+                  @click="
+                    handleMenuItemClick(
+                      workspaceMenuItem,
+                      workspaceItem,
+                      itemKey as string
+                    )
+                  "
                 />
               </template>
             </LayoutSidebarMenuGroup>
@@ -237,6 +240,19 @@ const needsSsoSession = (workspace: SettingsMenu_WorkspaceFragment, key: string)
     ? !workspace.sso?.session?.validUntil
     : false
 }
+
+const handleMenuItemClick = (
+  workspaceMenuItem: SettingsMenuItem,
+  workspaceItem: SettingsMenu_WorkspaceFragment,
+  itemKey: string
+) => {
+  const isDisabled =
+    !isAdmin.value &&
+    (workspaceMenuItem.disabled || needsSsoSession(workspaceItem, itemKey))
+  if (isDisabled) return
+  onWorkspaceMenuItemClick(workspaceItem.id, `${itemKey}`)
+}
+
 // not ideal, but it works temporarily while this is still a modal
 useSetupMenuState({
   goToWorkspaceMenuItem: onWorkspaceMenuItemClick

--- a/packages/frontend-2/components/settings/Dialog.vue
+++ b/packages/frontend-2/components/settings/Dialog.vue
@@ -86,12 +86,10 @@
                     workspaceMenuItem.disabled || needsSsoSession(workspaceItem, itemKey as string)
                   "
                   extra-padding
-                  @click="
-                    () =>
-                      workspaceMenuItem.disabled
-                        ? noop
-                        : onWorkspaceMenuItemClick(workspaceItem.id, `${itemKey}`)
-                  "
+                  @click="() => {
+                    if (workspaceMenuItem.disabled || needsSsoSession(workspaceItem, itemKey as string)) return
+                    onWorkspaceMenuItemClick(workspaceItem.id, `${itemKey}`)
+                  }"
                 />
               </template>
             </LayoutSidebarMenuGroup>

--- a/packages/frontend-2/components/settings/Dialog.vue
+++ b/packages/frontend-2/components/settings/Dialog.vue
@@ -82,14 +82,12 @@
                       ? 'Log in with your SSO provider to access this page'
                       : workspaceMenuItem.tooltipText
                   "
-                  :disabled="
-                    workspaceMenuItem.disabled || needsSsoSession(workspaceItem, itemKey as string)
-                  "
+                  :disabled="!isAdmin && (workspaceMenuItem.disabled || needsSsoSession(workspaceItem, itemKey as string))"
                   extra-padding
                   @click="() => {
-                    if (workspaceMenuItem.disabled || needsSsoSession(workspaceItem, itemKey as string)) return
-                    onWorkspaceMenuItemClick(workspaceItem.id, `${itemKey}`)
-                  }"
+    if (!isAdmin && (workspaceMenuItem.disabled || needsSsoSession(workspaceItem, itemKey as string))) return
+    onWorkspaceMenuItemClick(workspaceItem.id, `${itemKey}`)
+  }"
                 />
               </template>
             </LayoutSidebarMenuGroup>


### PR DESCRIPTION
Bug reported by @iainsproat in discord:

as a server admin, I'm able to see all workspace settings. (expected?)
The tooltip and menu on the left suggest that I need to sign in with SSO (bug)
I'm able to click on the greyed-out link anyway and it opens the page (expected?)

![image](https://github.com/user-attachments/assets/c0279a3e-72ac-4d33-93b2-4434f53a3f39)