### PR TITLE
Update billing summary for trial plans

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/Billing.vue
+++ b/packages/frontend-2/components/settings/workspaces/Billing.vue
@@ -52,7 +52,7 @@
                 <h3 class="text-body-xs text-foreground-2 pb-1">
                   {{
                     statusIsTrial
-                      ? 'First bill'
+                      ? 'Expected bill'
                       : subscription?.billingInterval === BillingInterval.Yearly
                       ? 'Yearly bill'
                       : 'Monthly bill'

--- a/packages/frontend-2/components/settings/workspaces/Billing.vue
+++ b/packages/frontend-2/components/settings/workspaces/Billing.vue
@@ -17,7 +17,7 @@
               class="grid grid-cols-1 lg:grid-cols-3 divide-y divide-outline-3 lg:divide-y-0 lg:divide-x"
             >
               <div class="p-5 pt-4 flex flex-col gap-y-1">
-                <h3 class="text-body-xs text-foreground-2 pb-2">
+                <h3 class="text-body-xs text-foreground-2 pb-1">
                   {{ statusIsTrial ? 'Trial plan' : 'Current plan' }}
                 </h3>
                 <div class="flex gap-x-2">
@@ -32,19 +32,27 @@
                   </div>
                 </div>
                 <p v-if="isPurchasablePlan" class="text-body-xs text-foreground-2">
-                  £{{ seatPrice[Roles.Workspace.Member] }} per seat/month, billed
-                  {{
-                    subscription?.billingInterval === BillingInterval.Yearly
-                      ? 'yearly'
-                      : 'monthly'
-                  }}
+                  <span v-if="statusIsTrial">
+                    <span class="line-through mr-1">
+                      £{{ seatPrice[Roles.Workspace.Member] }} per seat/month
+                    </span>
+                    Free
+                  </span>
+                  <span v-else>
+                    £{{ seatPrice[Roles.Workspace.Member] }} per seat/month, billed
+                    {{
+                      subscription?.billingInterval === BillingInterval.Yearly
+                        ? 'yearly'
+                        : 'monthly'
+                    }}
+                  </span>
                 </p>
               </div>
               <div class="p-5 pt-4 flex flex-col gap-y-1">
-                <h3 class="text-body-xs text-foreground-2 pb-2">
+                <h3 class="text-body-xs text-foreground-2 pb-1">
                   {{
                     statusIsTrial
-                      ? 'Expected bill'
+                      ? 'First bill'
                       : subscription?.billingInterval === BillingInterval.Yearly
                       ? 'Yearly bill'
                       : 'Monthly bill'
@@ -72,10 +80,10 @@
                 </div>
               </div>
               <div class="p-5 pt-4 flex flex-col gap-y-1">
-                <h3 class="text-body-xs text-foreground-2 pb-2">
+                <h3 class="text-body-xs text-foreground-2 pb-1">
                   {{
                     statusIsTrial && isPurchasablePlan
-                      ? 'First payment due'
+                      ? 'Trial ends'
                       : 'Next payment due'
                   }}
                 </h3>
@@ -83,14 +91,15 @@
                   {{ isPurchasablePlan ? nextPaymentDue : 'Never' }}
                 </p>
                 <p v-if="isPurchasablePlan" class="text-body-xs text-foreground-2">
-                  <span class="capitalize">
+                  <span v-if="statusIsTrial">Subscribe before this date</span>
+                  <span v-else>
                     {{
                       subscription?.billingInterval === BillingInterval.Yearly
                         ? 'Yearly'
                         : 'Monthly'
                     }}
+                    billing period
                   </span>
-                  billing period
                 </p>
               </div>
             </div>

--- a/packages/frontend-2/components/settings/workspaces/Billing.vue
+++ b/packages/frontend-2/components/settings/workspaces/Billing.vue
@@ -42,7 +42,7 @@
                     £{{ seatPrice[Roles.Workspace.Member] }} per seat/month, billed
                     {{
                       subscription?.billingInterval === BillingInterval.Yearly
-                        ? 'yearly'
+                        ? 'annually'
                         : 'monthly'
                     }}
                   </span>
@@ -54,7 +54,7 @@
                     statusIsTrial
                       ? 'Expected bill'
                       : subscription?.billingInterval === BillingInterval.Yearly
-                      ? 'Yearly bill'
+                      ? 'Annual bill'
                       : 'Monthly bill'
                   }}
                 </h3>
@@ -95,7 +95,7 @@
                   <span v-else>
                     {{
                       subscription?.billingInterval === BillingInterval.Yearly
-                        ? 'Yearly'
+                        ? 'Annual'
                         : 'Monthly'
                     }}
                     billing period

--- a/packages/frontend-2/lib/billing/helpers/constants.ts
+++ b/packages/frontend-2/lib/billing/helpers/constants.ts
@@ -32,7 +32,7 @@ export const pricingPlansConfig: {
     [PlanFeaturesList.GuestUsers]: {
       name: PlanFeaturesList.GuestUsers,
       description: (price?: number) =>
-        `Give guests access to specific projects £${price}/month/guest`
+        `Give guests access to specific projects in the workspace at £${price}/month/guest`
     },
     [PlanFeaturesList.PrivateAutomateFunctions]: {
       name: PlanFeaturesList.PrivateAutomateFunctions,
@@ -49,7 +49,7 @@ export const pricingPlansConfig: {
     },
     [PlanFeaturesList.CustomDataRegion]: {
       name: PlanFeaturesList.CustomDataRegion,
-      description: () => `Store the workspace data in a custom region of choice`
+      description: () => `Store the workspace data in a custom region`
     },
     [PlanFeaturesList.PrioritySupport]: {
       name: PlanFeaturesList.PrioritySupport,


### PR DESCRIPTION
- Make it clearer that the trial is free
- Also make it clearer that there's no payment due

### Before
![CleanShot 2024-12-03 at 15 28 47@2x](https://github.com/user-attachments/assets/c7978783-8ee3-4426-b812-f7f7c916e9e5)

### After
![CleanShot 2024-12-03 at 15 30 50@2x](https://github.com/user-attachments/assets/75e725dc-cc37-4679-9045-5032f72f6241)

