### PR TITLE
fix(sso): disable slug edit if sso enabled

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/General.vue
+++ b/packages/frontend-2/components/settings/workspaces/General.vue
@@ -26,14 +26,14 @@
           label="Short ID"
           name="shortId"
           :help="slugHelp"
-          :disabled="!isAdmin || needsSsoLogin"
+          :disabled="disableSlugInput"
           show-label
           label-position="left"
-          :tooltip-text="disabledTooltipText"
+          :tooltip-text="disabledSlugTooltipText"
           read-only
-          :right-icon="isAdmin || needsSsoLogin ? IconEdit : undefined"
-          right-icon-title="Edit short ID"
-          @right-icon-click="openSlugEditDialog"
+          :right-icon="disableSlugInput ? undefined : IconEdit"
+          :right-icon-title="disableSlugInput ? undefined : 'Edit short ID'"
+          @right-icon-click="disableSlugInput ? undefined : openSlugEditDialog"
         />
         <hr class="my-4 border-outline-3" />
         <FormTextInput
@@ -210,7 +210,7 @@ const { result: workspaceResult, onResult } = useQuery(
   })
 )
 const config = useRuntimeConfig()
-const { needsSsoLogin } = useWorkspaceSsoStatus({
+const { hasSsoEnabled, needsSsoLogin } = useWorkspaceSsoStatus({
   workspaceSlug: computed(() => workspaceResult.value?.workspace?.slug || '')
 })
 
@@ -319,7 +319,16 @@ const disabledTooltipText = computed(() => {
   return undefined
 })
 
+const disableSlugInput = computed(() => !isAdmin.value || hasSsoEnabled.value)
+
+const disabledSlugTooltipText = computed(() => {
+  return hasSsoEnabled.value
+    ? 'Short ID cannot be changed while SSO is enabled.'
+    : disabledTooltipText.value
+})
+
 const openSlugEditDialog = () => {
+  if (hasSsoEnabled.value) return
   showEditSlugDialog.value = true
 }
 

--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -517,6 +517,10 @@ export = FF_WORKSPACES_MODULE_ENABLED
               getWorkspaceBySlug: getWorkspaceBySlugFactory({ db })
             }),
             getWorkspace: getWorkspaceWithDomainsFactory({ db }),
+            getWorkspaceSsoProviderRecord: getWorkspaceSsoProviderFactory({
+              db,
+              decrypt: getDecryptor()
+            }),
             upsertWorkspace: upsertWorkspaceFactory({ db }),
             emitWorkspaceEvent: getEventBus().emit
           })
@@ -620,6 +624,10 @@ export = FF_WORKSPACES_MODULE_ENABLED
                 getWorkspaceBySlug: getWorkspaceBySlugFactory({ db })
               }),
               getWorkspace: getWorkspaceWithDomainsFactory({ db }),
+              getWorkspaceSsoProviderRecord: getWorkspaceSsoProviderFactory({
+                db,
+                decrypt: getDecryptor()
+              }),
               upsertWorkspace: upsertWorkspaceFactory({ db }),
               emitWorkspaceEvent: getEventBus().emit
             })

--- a/packages/server/modules/workspaces/services/management.ts
+++ b/packages/server/modules/workspaces/services/management.ts
@@ -64,7 +64,10 @@ import { userEmailsCompliantWithWorkspaceDomains } from '@/modules/workspaces/do
 import { workspaceRoles as workspaceRoleDefinitions } from '@/modules/workspaces/roles'
 import { blockedDomains } from '@speckle/shared'
 import { DeleteStreamRecord } from '@/modules/core/domain/streams/operations'
-import { DeleteSsoProvider } from '@/modules/workspaces/domain/sso/operations'
+import {
+  DeleteSsoProvider,
+  GetWorkspaceSsoProviderRecord
+} from '@/modules/workspaces/domain/sso/operations'
 
 type WorkspaceCreateArgs = {
   userId: string
@@ -230,11 +233,13 @@ const sanitizeInput = (input: Partial<Workspace>) => {
 export const updateWorkspaceFactory =
   ({
     getWorkspace,
+    getWorkspaceSsoProviderRecord,
     validateSlug,
     upsertWorkspace,
     emitWorkspaceEvent
   }: {
     getWorkspace: GetWorkspaceWithDomains
+    getWorkspaceSsoProviderRecord: GetWorkspaceSsoProviderRecord
     validateSlug: ValidateWorkspaceSlug
     upsertWorkspace: UpsertWorkspace
     emitWorkspaceEvent: EventBus['emit']
@@ -253,7 +258,14 @@ export const updateWorkspaceFactory =
       throw new WorkspaceInvalidUpdateError()
     }
 
-    if (workspaceInput.slug) await validateSlug({ slug: workspaceInput.slug })
+    if (workspaceInput.slug) {
+      const ssoProvider = await getWorkspaceSsoProviderRecord({ workspaceId })
+      if (ssoProvider)
+        throw new WorkspaceInvalidUpdateError(
+          'Cannot update workspace slug if SSO is configured.'
+        )
+      await validateSlug({ slug: workspaceInput.slug })
+    }
 
     const workspace = {
       ...omit(currentWorkspace, 'domains'),

--- a/packages/server/modules/workspaces/tests/helpers/creation.ts
+++ b/packages/server/modules/workspaces/tests/helpers/creation.ts
@@ -196,6 +196,7 @@ export const createTestWorkspace = async (
       getWorkspaceBySlug: getWorkspaceBySlugFactory({ db })
     }),
     getWorkspace: getWorkspaceWithDomainsFactory({ db }),
+    getWorkspaceSsoProviderRecord: getWorkspaceSsoProviderRecordFactory({ db }),
     upsertWorkspace: upsertWorkspaceFactory({ db }),
     emitWorkspaceEvent: (...args) => getEventBus().emit(...args)
   })

--- a/packages/server/modules/workspaces/tests/integration/subs.graph.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/subs.graph.spec.ts
@@ -2,6 +2,7 @@ import { db } from '@/db/knex'
 import { ServerInvites } from '@/modules/core/dbSchema'
 import { getEventBus } from '@/modules/shared/services/eventBus'
 import { getDefaultRegionFactory } from '@/modules/workspaces/repositories/regions'
+import { getWorkspaceSsoProviderRecordFactory } from '@/modules/workspaces/repositories/sso'
 import {
   getWorkspaceBySlugFactory,
   getWorkspaceWithDomainsFactory,
@@ -59,6 +60,7 @@ const updateWorkspace = updateWorkspaceFactory({
     getWorkspaceBySlug: getWorkspaceBySlugFactory({ db })
   }),
   getWorkspace: getWorkspaceWithDomainsFactory({ db }),
+  getWorkspaceSsoProviderRecord: getWorkspaceSsoProviderRecordFactory({ db }),
   upsertWorkspace: upsertWorkspaceFactory({ db }),
   emitWorkspaceEvent: getEventBus().emit
 })

--- a/packages/server/modules/workspaces/tests/unit/services/management.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/services/management.spec.ts
@@ -271,6 +271,7 @@ describe('Workspace services', () => {
       const err = await expectToThrow(async () => {
         await updateWorkspaceFactory({
           getWorkspace: async () => null,
+          getWorkspaceSsoProviderRecord: async () => null,
           validateSlug: async () => {
             expect.fail()
           },
@@ -292,6 +293,7 @@ describe('Workspace services', () => {
       const err = await expectToThrow(async () => {
         await updateWorkspaceFactory({
           getWorkspace: async () => workspace,
+          getWorkspaceSsoProviderRecord: async () => null,
           emitWorkspaceEvent: async () => {
             expect.fail()
           },
@@ -315,6 +317,7 @@ describe('Workspace services', () => {
       const err = await expectToThrow(async () => {
         await updateWorkspaceFactory({
           getWorkspace: async () => workspace,
+          getWorkspaceSsoProviderRecord: async () => null,
           emitWorkspaceEvent: async () => {
             expect.fail()
           },
@@ -338,6 +341,7 @@ describe('Workspace services', () => {
       const err = await expectToThrow(async () => {
         await updateWorkspaceFactory({
           getWorkspace: async () => workspace,
+          getWorkspaceSsoProviderRecord: async () => null,
           emitWorkspaceEvent: async () => {
             expect.fail()
           },
@@ -361,6 +365,7 @@ describe('Workspace services', () => {
       const err = await expectToThrow(async () => {
         await updateWorkspaceFactory({
           getWorkspace: async () => workspace,
+          getWorkspaceSsoProviderRecord: async () => null,
           emitWorkspaceEvent: async () => {
             expect.fail()
           },
@@ -383,6 +388,7 @@ describe('Workspace services', () => {
       const err = await expectToThrow(async () => {
         await updateWorkspaceFactory({
           getWorkspace: async () => workspace,
+          getWorkspaceSsoProviderRecord: async () => null,
           emitWorkspaceEvent: async () => {
             expect.fail()
           },
@@ -406,6 +412,7 @@ describe('Workspace services', () => {
       let newWorkspaceName
       await updateWorkspaceFactory({
         getWorkspace: async () => workspace,
+        getWorkspaceSsoProviderRecord: async () => null,
         emitWorkspaceEvent: async () => {},
         validateSlug: async () => {},
 
@@ -418,6 +425,36 @@ describe('Workspace services', () => {
       })
       expect(newWorkspaceName).to.be.equal(workspace.name)
     })
+
+    it('does not allow updating the workspace slug if SSO is enabled', async () => {
+      const workspace = createTestWorkspaceWithDomainsData()
+
+      const err = await expectToThrow(async () => {
+        await updateWorkspaceFactory({
+          getWorkspace: async () => workspace,
+          getWorkspaceSsoProviderRecord: async () => ({
+            workspaceId: 'foo',
+            providerId: 'bar'
+          }),
+          emitWorkspaceEvent: async () => {
+            expect.fail()
+          },
+          validateSlug: async () => {},
+          upsertWorkspace: async () => {
+            expect.fail()
+          }
+        })({
+          workspaceId: workspace.id,
+          workspaceInput: {
+            slug: 'new-slug'
+          }
+        })
+      })
+      expect(err.message).to.be.equal(
+        'Cannot update workspace slug if SSO is configured.'
+      )
+    })
+
     it('updates the workspace and emits the correct event payload', async () => {
       const workspaceId = cryptoRandomString({ length: 10 })
       const workspace = createTestWorkspaceWithDomainsData({
@@ -444,6 +481,7 @@ describe('Workspace services', () => {
 
       await updateWorkspaceFactory({
         getWorkspace: async () => workspace,
+        getWorkspaceSsoProviderRecord: async () => null,
         emitWorkspaceEvent: async () => {},
         validateSlug: async () => {},
         upsertWorkspace: async ({ workspace }) => {


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- SSO is currently configured with redirects specific to a workspace slug. If the slug changes, SSO breaks. If SSO breaks and your session expires, you're locked out.

## Changes:

- Disable slug edit on FE & BE if SSO is configured

![image](https://github.com/user-attachments/assets/b3ab5b60-9278-42fb-9b98-8b0c98d2aecf)
