### PR TITLE
fix(workspaces): no default discovery

### DIFF
--- a/packages/frontend-2/lib/settings/composables/management.ts
+++ b/packages/frontend-2/lib/settings/composables/management.ts
@@ -88,8 +88,7 @@ export function useAddWorkspaceDomain() {
                     domain: input.domain
                   }
                 ],
-                discoverabilityEnabled:
-                  domains.length === 0 ? true : discoverabilityEnabled,
+                discoverabilityEnabled,
                 domainBasedMembershipProtectionEnabled,
                 hasAccessToSSO
               }

--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -589,7 +589,6 @@ export = FF_WORKSPACES_MODULE_ENABLED
             getWorkspace: getWorkspaceFactory({ db }),
             findEmailsByUserId: findEmailsByUserIdFactory({ db }),
             storeWorkspaceDomain: storeWorkspaceDomainFactory({ db }),
-            upsertWorkspace: upsertWorkspaceFactory({ db }),
             getDomains: getWorkspaceDomainsFactory({ db }),
             emitWorkspaceEvent: getEventBus().emit
           })({

--- a/packages/server/modules/workspaces/services/management.ts
+++ b/packages/server/modules/workspaces/services/management.ts
@@ -467,14 +467,12 @@ export const addDomainToWorkspaceFactory =
     findEmailsByUserId,
     storeWorkspaceDomain,
     getWorkspace,
-    upsertWorkspace,
     emitWorkspaceEvent,
     getDomains
   }: {
     findEmailsByUserId: FindEmailsByUserId
     storeWorkspaceDomain: StoreWorkspaceDomain
     getWorkspace: GetWorkspace
-    upsertWorkspace: UpsertWorkspace
     getDomains: GetWorkspaceDomains
     emitWorkspaceEvent: EventBus['emit']
   }) =>
@@ -532,12 +530,6 @@ export const addDomainToWorkspaceFactory =
     }
 
     await storeWorkspaceDomain({ workspaceDomain })
-
-    if (domains.length === 0) {
-      await upsertWorkspace({
-        workspace: { ...workspace, discoverabilityEnabled: true }
-      })
-    }
 
     await emitWorkspaceEvent({
       eventName: WorkspaceEvents.Updated,

--- a/packages/server/modules/workspaces/tests/helpers/creation.ts
+++ b/packages/server/modules/workspaces/tests/helpers/creation.ts
@@ -150,7 +150,6 @@ export const createTestWorkspace = async (
       findEmailsByUserId: findEmailsByUserIdFactory({ db }),
       storeWorkspaceDomain: storeWorkspaceDomainFactory({ db }),
       getWorkspace: getWorkspaceFactory({ db }),
-      upsertWorkspace: upsertWorkspaceFactory({ db }),
       emitWorkspaceEvent: getEventBus().emit,
       getDomains: getWorkspaceDomainsFactory({ db })
     })({


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- With paid workspaces, we want to add friction/intention behind adding seats. The current "discoverable workspaces" feature turns on by default, which was fine when access was free, but we'd like it to be on purpose now.

## Changes:

- Do not enable domain discovery by default when adding a domain
