### PR TITLE
chore(automate): track redirects from beta site

### DIFF
--- a/packages/frontend-2/components/automate/functions/page/Header.vue
+++ b/packages/frontend-2/components/automate/functions/page/Header.vue
@@ -133,8 +133,10 @@ if (import.meta.client) {
     (isRedirect) => {
       if (!isRedirect?.length) return
       mixpanel.track('Automate Beta Visit Redirected')
-      void router.replace({ query: {} })
-    }
+      const { automateBetaRedirect, ...query } = route.query
+      void router.replace({ query })
+    },
+    { immediate: true }
   )
 }
 </script>

--- a/packages/frontend-2/components/automate/functions/page/Header.vue
+++ b/packages/frontend-2/components/automate/functions/page/Header.vue
@@ -133,6 +133,7 @@ if (import.meta.client) {
     (isRedirect) => {
       if (!isRedirect?.length) return
       mixpanel.track('Automate Beta Visit Redirected')
+      void router.replace({ query: {} })
     }
   )
 }

--- a/packages/frontend-2/components/automate/functions/page/Header.vue
+++ b/packages/frontend-2/components/automate/functions/page/Header.vue
@@ -49,6 +49,7 @@ import type {
   Workspace
 } from '~/lib/common/generated/gql/graphql'
 import { workspaceFunctionsRoute, workspaceRoute } from '~/lib/common/helpers/route'
+import { useMixpanel } from '~/lib/core/composables/mp'
 
 graphql(`
   fragment AutomateFunctionsPageHeader_Query on Query {
@@ -81,6 +82,7 @@ const { on, bind } = useDebouncedTextInput({ model: search })
 const { triggerNotification } = useGlobalToast()
 const route = useRoute()
 const router = useRouter()
+const mixpanel = useMixpanel()
 
 const createDialogOpen = ref(false)
 
@@ -125,6 +127,13 @@ if (import.meta.client) {
       void router.replace({ query: {} })
     },
     { immediate: true }
+  )
+  watch(
+    () => route.query['automateBetaRedirect'] as Nullable<string>,
+    (isRedirect) => {
+      if (!isRedirect?.length) return
+      mixpanel.track('Automate Beta Visit Redirected')
+    }
   )
 }
 </script>


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- We recently started redirecting all traffic from `automate.speckle.dev` to `app.speckle.systems/functions?automateBetaRedirect=true`
- This page is not ideal, it gives no further context, and it's not clear what the best redirect experience should be. But I want to get a clearer picture of how many people are actually affected before investing any time.

## Changes:

- Tracks a mixpanel event when people are redirected from `automate.speckle.dev`
