### PR TITLE
fix(fe2): Adjust word wrap of slug input help text

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/General.vue
+++ b/packages/frontend-2/components/settings/workspaces/General.vue
@@ -33,6 +33,7 @@
           read-only
           :right-icon="disableSlugInput ? undefined : IconEdit"
           :right-icon-title="disableSlugInput ? undefined : 'Edit short ID'"
+          custom-help-class="!break-all"
           @right-icon-click="openSlugEditDialog"
         />
         <hr class="my-4 border-outline-3" />

--- a/packages/ui-components/src/components/form/TextInput.vue
+++ b/packages/ui-components/src/components/form/TextInput.vue
@@ -302,6 +302,10 @@ const props = defineProps({
   tooltipText: {
     type: String,
     default: undefined
+  },
+  customHelpClass: {
+    type: String,
+    default: undefined
   }
 })
 

--- a/packages/ui-components/src/composables/form/textInput.ts
+++ b/packages/ui-components/src/composables/form/textInput.ts
@@ -30,6 +30,7 @@ export function useTextInputCore<V extends string | string[] = string>(params: {
     hideErrorMessage?: boolean
     color?: InputColor
     labelPosition?: LabelPosition
+    customHelpClass?: string
   }>
   emit: {
     (e: 'change', val: { event?: Event; value: V }): void
@@ -122,12 +123,16 @@ export function useTextInputCore<V extends string | string[] = string>(params: {
   )
   const helpTip = computed(() => errorMessage.value || unref(props.help))
   const hasHelpTip = computed(() => !!helpTip.value)
+  const customHelpTipClass = computed(() => unref(props.customHelpClass))
   const helpTipId = computed(() =>
     hasHelpTip.value ? `${unref(props.name)}-${internalHelpTipId.value}` : undefined
   )
   const helpTipClasses = computed((): string => {
     const classParts = ['text-body-2xs break-words']
     classParts.push(hasError.value ? 'text-danger' : 'text-foreground-2')
+    if (customHelpTipClass.value) {
+      classParts.push(customHelpTipClass.value)
+    }
     return classParts.join(' ')
   })
   const shouldShowClear = computed(() => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ac3e8f39-0431-4d9c-9230-d6287bf84c79)

Although we still want the default behaviour to be `break-words`, in the case of the slug, `break-all` is more appropriate. Now you can pass custom classes to the help text to achieve this. 