### PR TITLE
Trigger mention dialog after a single character

### DIFF
--- a/packages/frontend-2/components/common/tiptap/MentionList.vue
+++ b/packages/frontend-2/components/common/tiptap/MentionList.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-show="(query?.length || 0) >= 3"
+    v-show="(query?.length || 0) >= 1"
     class="bg-foundation text-foreground rounded shadow-md p-2"
   >
     <ul>
@@ -14,7 +14,7 @@
         </li>
       </template>
       <template v-else>
-        <li>Couldn't find anything 🤷</li>
+        <li>Couldn't find anyone</li>
       </template>
     </ul>
   </div>

--- a/packages/frontend-2/lib/core/tiptap/mentionExtension.ts
+++ b/packages/frontend-2/lib/core/tiptap/mentionExtension.ts
@@ -20,7 +20,7 @@ export type MentionData = { label: string; id: string }
 
 const suggestionOptions: Omit<SuggestionOptions<SuggestionOptionsItem>, 'editor'> = {
   async items({ query, editor }) {
-    if (query.length < 3) return []
+    if (query.length < 1) return []
 
     const state = editor.storage.editorInstanceState as EditorInstanceStateStorage
     const projectId = state.state.projectId

--- a/packages/server/modules/core/graph/resolvers/users.ts
+++ b/packages/server/modules/core/graph/resolvers/users.ts
@@ -139,8 +139,8 @@ export = {
     },
 
     async users(_parent, args) {
-      if (args.input.query.length < 3)
-        throw new BadRequestError('Search query must be at least 3 characters.')
+      if (args.input.query.length < 1)
+        throw new BadRequestError('Search query must be at least 1 character.')
 
       if ((args.input.limit || 0) > 100)
         throw new BadRequestError(

--- a/packages/server/modules/core/tests/integration/users.graph.spec.ts
+++ b/packages/server/modules/core/tests/integration/users.graph.spec.ts
@@ -201,7 +201,7 @@ describe('Users @graphql', () => {
 
     it('doesnt work with less than 1 character', async () => {
       const res = await search({
-        query: 'fi'
+        query: ''
       })
       expect(res).to.haveGraphQLErrors('Search query must be at least 1 character')
     })

--- a/packages/server/modules/core/tests/integration/users.graph.spec.ts
+++ b/packages/server/modules/core/tests/integration/users.graph.spec.ts
@@ -199,11 +199,11 @@ describe('Users @graphql', () => {
       ])
     })
 
-    it('doesnt work with less than 3 characters', async () => {
+    it('doesnt work with less than 1 character', async () => {
       const res = await search({
         query: 'fi'
       })
-      expect(res).to.haveGraphQLErrors('Search query must be at least 3 characters')
+      expect(res).to.haveGraphQLErrors('Search query must be at least 1 character')
     })
 
     it('doesnt work with more than 100 items', async () => {


### PR DESCRIPTION
Follow up to #3635.

Now that you can only mention project collaborators I think it's safe to show the mention dropdown after typing a single character. Better UX.