### PR TITLE
chore(workspaces): track deleted workspace in mixpanel

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/General/DeleteDialog.vue
+++ b/packages/frontend-2/components/settings/workspaces/General/DeleteDialog.vue
@@ -122,6 +122,9 @@ const onDelete = async () => {
       workspace_id: props.workspace.id,
       feedback: feedback.value
     })
+    mixpanel.get_group('workspace_id', props.workspace.id).set_once({
+      isDeleted: true
+    })
 
     if (!import.meta.dev) {
       await sendWebhook(defaultZapierWebhookUrl, {

--- a/packages/server/modules/workspaces/services/management.ts
+++ b/packages/server/modules/workspaces/services/management.ts
@@ -68,6 +68,7 @@ import {
   DeleteSsoProvider,
   GetWorkspaceSsoProviderRecord
 } from '@/modules/workspaces/domain/sso/operations'
+import { getClient } from '@/modules/shared/utils/mixpanel'
 
 type WorkspaceCreateArgs = {
   userId: string
@@ -329,6 +330,13 @@ export const deleteWorkspaceFactory =
     for (const projectIdsChunk of chunk(projectIds, 25)) {
       await Promise.all(projectIdsChunk.map((projectId) => deleteProject(projectId)))
     }
+
+    await new Promise<void>((resolve) => {
+      const mp = getClient()
+      mp?.groups.set_once('workspace_id', workspaceId, 'isDeleted', 'true', () => {
+        resolve()
+      })
+    })
   }
 
 type WorkspaceRoleDeleteArgs = {

--- a/packages/server/modules/workspaces/services/management.ts
+++ b/packages/server/modules/workspaces/services/management.ts
@@ -68,7 +68,6 @@ import {
   DeleteSsoProvider,
   GetWorkspaceSsoProviderRecord
 } from '@/modules/workspaces/domain/sso/operations'
-import { getClient } from '@/modules/shared/utils/mixpanel'
 
 type WorkspaceCreateArgs = {
   userId: string
@@ -330,13 +329,6 @@ export const deleteWorkspaceFactory =
     for (const projectIdsChunk of chunk(projectIds, 25)) {
       await Promise.all(projectIdsChunk.map((projectId) => deleteProject(projectId)))
     }
-
-    await new Promise<void>((resolve) => {
-      const mp = getClient()
-      mp?.groups.set_once('workspace_id', workspaceId, 'isDeleted', 'true', () => {
-        resolve()
-      })
-    })
   }
 
 type WorkspaceRoleDeleteArgs = {


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- We don't keep track of workspace deletion in mixpanel, so deleted workspaces are showing up in metrics when they maybe aren't relevant

## Changes:

- Set a mixpanel property on a workspace when deleted