### PR TITLE
Fix: Update text in biling settings if plan is cancelled

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/Billing.vue
+++ b/packages/frontend-2/components/settings/workspaces/Billing.vue
@@ -84,6 +84,8 @@
                   {{
                     statusIsTrial && isPurchasablePlan
                       ? 'Trial ends'
+                      : statusIsCanceled
+                      ? 'Cancels'
                       : 'Next payment due'
                   }}
                 </h3>
@@ -222,6 +224,9 @@ const statusIsTrial = computed(
   () =>
     currentPlan.value?.status === WorkspacePlanStatuses.Trial ||
     !currentPlan.value?.status
+)
+const statusIsCanceled = computed(
+  () => currentPlan.value?.status === WorkspacePlanStatuses.Canceled
 )
 const isActivePlan = computed(
   () =>


### PR DESCRIPTION
Update this text to "Cancels" if the plan is cancelled:

![image](https://github.com/user-attachments/assets/d5ce08ea-7fed-4c13-8070-3256c7af5e53)

This is consistent with what the user sees in the billing portal:

![CleanShot 2024-12-09 at 21 27 34@2x](https://github.com/user-attachments/assets/63c3271b-45d1-4ee9-a69f-98d822f64a14)
