### PR TITLE
Chore(workspaces): Add support links to billing settings

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/Billing.vue
+++ b/packages/frontend-2/components/settings/workspaces/Billing.vue
@@ -140,9 +140,13 @@
           Need help?
           <NuxtLink
             class="text-foreground"
-            to="https://speckle.guide/workspaces/billing.html"
-            external
-            @click="() => mixpanel.track('Workspace Docs Link Clicked')"
+            :to="guideBillingUrl"
+            target="_blank"
+            @click="
+              mixpanel.track('Workspace Docs Link Clicked', {
+                workspace_id: props.workspaceId
+              })
+            "
           >
             <span class="hover:underline">Read the docs</span>
           </NuxtLink>
@@ -150,7 +154,11 @@
           <a
             class="text-foreground hover:underline"
             href="mailto:billing@speckle.systems"
-            @click="() => mixpanel.track('Workspace Support Link Clicked')"
+            @click="
+              mixpanel.track('Workspace Support Link Clicked', {
+                workspace_id: props.workspaceId
+              })
+            "
           >
             contact support
           </a>
@@ -187,6 +195,7 @@ import { Roles } from '@speckle/shared'
 import { InformationCircleIcon } from '@heroicons/vue/24/outline'
 import { isPaidPlan } from '@/lib/billing/helpers/types'
 import { useMixpanel } from '~/lib/core/composables/mp'
+import { guideBillingUrl } from '~/lib/common/helpers/route'
 
 graphql(`
   fragment SettingsWorkspacesBilling_Workspace on Workspace {

--- a/packages/frontend-2/components/settings/workspaces/Billing.vue
+++ b/packages/frontend-2/components/settings/workspaces/Billing.vue
@@ -136,6 +136,26 @@
           />
         </div>
 
+        <div class="mt-8 text-center text-foreground-2">
+          Need help?
+          <NuxtLink
+            class="text-foreground"
+            to="https://speckle.guide/workspaces/billing.html"
+            external
+            @click="() => mixpanel.track('Workspace Docs Link Clicked')"
+          >
+            <span class="hover:underline">Read the docs</span>
+          </NuxtLink>
+          or
+          <a
+            class="text-foreground hover:underline"
+            href="mailto:billing@speckle.systems"
+            @click="() => mixpanel.track('Workspace Support Link Clicked')"
+          >
+            contact support
+          </a>
+        </div>
+
         <SettingsWorkspacesBillingUpgradeDialog
           v-if="selectedPlanName && selectedPlanCycle && workspaceId"
           v-model:open="isUpgradeDialogOpen"

--- a/packages/frontend-2/lib/common/helpers/route.ts
+++ b/packages/frontend-2/lib/common/helpers/route.ts
@@ -19,6 +19,7 @@ export const docsPageUrl = 'https://speckle.guide/'
 export const forumPageUrl = 'https://speckle.community/'
 export const defaultZapierWebhookUrl =
   'https://hooks.zapier.com/hooks/catch/12120532/2m4okri/'
+export const guideBillingUrl = 'https://speckle.guide/workspaces/billing.html'
 
 export const projectRoute = (
   id: string,


### PR DESCRIPTION
Added links to documentation and support in billing settings. I also included Mixpanel tracking because I actually doubt anyone clicks it – but let's see :).

![CleanShot 2024-12-10 at 09 50 39@2x](https://github.com/user-attachments/assets/e7f82e47-57c1-4932-bab5-7aedeab14a7d)
