### PR TITLE
Rename view modes

### DIFF
--- a/packages/frontend-2/lib/viewer/helpers/shortcuts/shortcuts.ts
+++ b/packages/frontend-2/lib/viewer/helpers/shortcuts/shortcuts.ts
@@ -58,24 +58,24 @@ export const ToolShortcuts = {
 
 export const ViewModeShortcuts = {
   SetViewModeDefault: {
-    name: 'Default',
-    description: 'Set view mode to Default',
+    name: 'Rendered',
+    description: 'Set view mode to Rendered',
     modifiers: [ModifierKeys.Shift],
     key: 'Digit1',
     action: 'SetViewModeDefault',
     viewMode: ViewMode.DEFAULT
   },
   SetViewModeDefaultEdges: {
-    name: 'Default + Edges',
-    description: 'Set view mode to Default + Edges',
+    name: 'Rendered + Edges',
+    description: 'Set view mode to Rendered + Edges',
     modifiers: [ModifierKeys.Shift],
     key: 'Digit2',
     action: 'SetViewModeDefaultEdges',
     viewMode: ViewMode.DEFAULT_EDGES
   },
   SetViewModeShaded: {
-    name: 'Shaded',
-    description: 'Set view mode to Shaded',
+    name: 'Solid',
+    description: 'Set view mode to Solid',
     modifiers: [ModifierKeys.Shift],
     key: 'Digit3',
     action: 'SetViewModeShaded',
@@ -98,8 +98,8 @@ export const ViewModeShortcuts = {
     viewMode: ViewMode.ARCTIC
   },
   SetViewModeColors: {
-    name: 'Colors',
-    description: 'Set view mode to Colors',
+    name: 'Shaded',
+    description: 'Set view mode to Shaded',
     modifiers: [ModifierKeys.Shift],
     key: 'Digit6',
     action: 'SetViewModeColors',


### PR DESCRIPTION
This updates the view mode names in the frontend. Thanks Claire for the suggestions.

For now I didn't update the naming of the objects etc so those are still aligned with the names coming from the viewer library. Confusing inconsistency – but maybe we're OK with that for now while naming might still be changing? 

![CleanShot 2024-12-13 at 10 35 15@2x](https://github.com/user-attachments/assets/0a3c4975-58e5-436a-a116-301fa1026408)
