### PR TITLE
feat(server options): allow connection timeouts to be configured

### DIFF
--- a/packages/fileimport-service/knex.js
+++ b/packages/fileimport-service/knex.js
@@ -14,8 +14,15 @@ const isDevEnv = process.env.NODE_ENV !== 'production'
 let dbClients
 const getDbClients = async () => {
   if (dbClients) return dbClients
-  const maxConnections =
-    parseInt(process.env.POSTGRES_MAX_CONNECTIONS_FILE_IMPORT_SERVICE) || 1
+  const maxConnections = parseInt(
+    process.env['POSTGRES_MAX_CONNECTIONS_FILE_IMPORT_SERVICE'] || '1'
+  )
+  const connectionAcquireTimeoutMillis = parseInt(
+    process.env['POSTGRES_CONNECTION_ACQUIRE_TIMEOUT_MILLIS'] || '16000'
+  )
+  const connectionCreateTimeoutMillis = parseInt(
+    process.env['POSTGRES_CONNECTION_CREATE_TIMEOUT_MILLIS'] || '5000'
+  )
 
   const configArgs = {
     migrationDirs: [],
@@ -23,7 +30,9 @@ const getDbClients = async () => {
     isDevOrTestEnv: isDevEnv,
     logger,
     maxConnections,
-    applicationName: 'speckle_fileimport_service'
+    applicationName: 'speckle_fileimport_service',
+    connectionAcquireTimeoutMillis,
+    connectionCreateTimeoutMillis
   }
   if (!FF_WORKSPACES_MULTI_REGION_ENABLED) {
     const mainClient = configureKnexClient(

--- a/packages/preview-service/src/utils/env.ts
+++ b/packages/preview-service/src/utils/env.ts
@@ -1,29 +1,40 @@
-export const getAppPort = () => process.env.PORT || '3001'
+function getIntFromEnv(envVarKey: string, aDefault = '0'): number {
+  return parseInt(process.env[envVarKey] || aDefault)
+}
+function getBooleanFromEnv(envVarKey: string, aDefault = false): boolean {
+  return ['1', 'true', true].includes(process.env[envVarKey] || aDefault.toString())
+}
+
+export const getAppPort = () => process.env['PORT'] || '3001'
 export const getChromiumExecutablePath = () => {
   if (isDevelopment()) return undefined // use default
-  return process.env.CHROMIUM_EXECUTABLE_PATH || '/usr/bin/google-chrome-stable'
+  return process.env['CHROMIUM_EXECUTABLE_PATH'] || '/usr/bin/google-chrome-stable'
 }
 export const getHealthCheckFilePath = () =>
-  process.env.HEALTHCHECK_FILE_PATH || '/tmp/last_successful_query'
-export const getHost = () => process.env.HOST || '127.0.0.1'
-export const getMetricsHost = () => process.env.METRICS_HOST || '127.0.0.1'
-export const getLogLevel = () => process.env.LOG_LEVEL || 'info'
-export const getMetricsPort = () => process.env.PROMETHEUS_METRICS_PORT || '9094'
-export const getNodeEnv = () => process.env.NODE_ENV || 'production'
+  process.env['HEALTHCHECK_FILE_PATH'] || '/tmp/last_successful_query'
+export const getHost = () => process.env['HOST'] || '127.0.0.1'
+export const getMetricsHost = () => process.env['METRICS_HOST'] || '127.0.0.1'
+export const getLogLevel = () => process.env['LOG_LEVEL'] || 'info'
+export const getMetricsPort = () => process.env['PROMETHEUS_METRICS_PORT'] || '9094'
+export const getNodeEnv = () => process.env['NODE_ENV'] || 'production'
 export const getPostgresConnectionString = () =>
-  process.env.PG_CONNECTION_STRING || 'postgres://speckle:speckle@127.0.0.1/speckle'
+  process.env['PG_CONNECTION_STRING'] || 'postgres://speckle:speckle@127.0.0.1/speckle'
 export const getPostgresMaxConnections = () =>
-  parseInt(process.env.POSTGRES_MAX_CONNECTIONS_PREVIEW_SERVICE || '2')
-export const getPreviewTimeout = () =>
-  parseInt(process.env.PREVIEW_TIMEOUT || '3600000')
+  getIntFromEnv('POSTGRES_MAX_CONNECTIONS_PREVIEW_SERVICE', '2')
+export const getConnectionAcquireTimeoutMillis = () =>
+  getIntFromEnv('POSTGRES_CONNECTION_ACQUIRE_TIMEOUT_MILLIS', '16000')
+export const getConnectionCreateTimeoutMillis = () =>
+  getIntFromEnv('POSTGRES_CONNECTION_CREATE_TIMEOUT_MILLIS', '5000')
+export const getPreviewTimeout = () => getIntFromEnv('PREVIEW_TIMEOUT', '3600000')
 export const getPuppeteerUserDataDir = () => {
   if (isDevelopment()) return undefined // use default
-  return process.env.USER_DATA_DIR || '/tmp/puppeteer'
+  return process.env['USER_DATA_DIR'] || '/tmp/puppeteer'
 }
 export const isDevelopment = () =>
   getNodeEnv() === 'development' || getNodeEnv() === 'dev'
-export const isLogPretty = () => process.env.LOG_PRETTY?.toLocaleLowerCase() === 'true'
+export const isLogPretty = () => getBooleanFromEnv('LOG_PRETTY')
 export const isProduction = () => getNodeEnv() === 'production'
 export const isTest = () => getNodeEnv() === 'test'
+export const isDevOrTestEnv = () => isDevelopment() || isTest()
 export const serviceOrigin = () => `http://${getHost()}:${getAppPort()}`
-export const shouldBeHeadless = () => process.env.PREVIEWS_HEADED !== 'true'
+export const shouldBeHeadless = () => !getBooleanFromEnv('PREVIEWS_HEADED')

--- a/packages/server/knexfile.ts
+++ b/packages/server/knexfile.ts
@@ -8,8 +8,8 @@ import {
   ignoreMissingMigrations,
   postgresMaxConnections,
   isDevOrTestEnv,
-  postgresConnectionAcquisitionTimeoutMillis,
-  postgresConnectionCreationTimeoutMillis
+  postgresConnectionAcquireTimeoutMillis,
+  postgresConnectionCreateTimeoutMillis
 } from '@/modules/shared/helpers/envHelper'
 import { dbLogger as logger } from '@/logging/logging'
 import { Knex } from 'knex'
@@ -83,8 +83,8 @@ const configArgs: KnexConfigArgs = {
   applicationName: 'speckle_server',
   logger,
   maxConnections: postgresMaxConnections(),
-  connectionAcquisitionTimeoutMillis: postgresConnectionAcquisitionTimeoutMillis(),
-  connectionCreateTimeoutMillis: postgresConnectionCreationTimeoutMillis()
+  connectionAcquireTimeoutMillis: postgresConnectionAcquireTimeoutMillis(),
+  connectionCreateTimeoutMillis: postgresConnectionCreateTimeoutMillis()
 }
 
 const config: Record<string, Knex.Config> = {

--- a/packages/server/modules/shared/helpers/envHelper.ts
+++ b/packages/server/modules/shared/helpers/envHelper.ts
@@ -363,12 +363,12 @@ export function postgresMaxConnections() {
   return getIntFromEnv('POSTGRES_MAX_CONNECTIONS_SERVER', '4')
 }
 
-export function postgresConnectionAcquisitionTimeoutMillis() {
-  return getIntFromEnv('POSTGRES_CONNECTION_ACQUISITION_TIMEOUT_MILLIS', '16000')
+export function postgresConnectionAcquireTimeoutMillis() {
+  return getIntFromEnv('POSTGRES_CONNECTION_ACQUIRE_TIMEOUT_MILLIS', '16000')
 }
 
-export function postgresConnectionCreationTimeoutMillis() {
-  return getIntFromEnv('POSTGRES_CONNECTION_CREATION_TIMEOUT_MILLIS', '5000')
+export function postgresConnectionCreateTimeoutMillis() {
+  return getIntFromEnv('POSTGRES_CONNECTION_CREATE_TIMEOUT_MILLIS', '5000')
 }
 
 export function highFrequencyMetricsCollectionPeriodMs() {

--- a/packages/shared/src/environment/multiRegionConfig.ts
+++ b/packages/shared/src/environment/multiRegionConfig.ts
@@ -94,7 +94,7 @@ export type KnexConfigArgs = {
   logger: Logger
   maxConnections: number
   applicationName: string
-  connectionAcquisitionTimeoutMillis: number
+  connectionAcquireTimeoutMillis: number
   connectionCreateTimeoutMillis: number
 }
 
@@ -106,7 +106,7 @@ export const createKnexConfig = ({
   logger,
   maxConnections,
   caCertificate,
-  connectionAcquisitionTimeoutMillis,
+  connectionAcquireTimeoutMillis,
   connectionCreateTimeoutMillis
 }: {
   connectionString?: string | undefined
@@ -145,7 +145,7 @@ export const createKnexConfig = ({
     pool: {
       min: 0,
       max: maxConnections,
-      acquireTimeoutMillis: connectionAcquisitionTimeoutMillis, // If the maximum number of connections is reached, it wait for 16 seconds trying to acquire an existing connection before throwing a timeout error.
+      acquireTimeoutMillis: connectionAcquireTimeoutMillis, // If the maximum number of connections is reached, it wait for 16 seconds trying to acquire an existing connection before throwing a timeout error.
       createTimeoutMillis: connectionCreateTimeoutMillis // If no existing connection is available and the maximum number of connections is not yet reached, the pool will try to create a new connection for 5 seconds before throwing a timeout error.
       // createRetryIntervalMillis: 200, // Irrelevant & ignored because propogateCreateError is true.
       // propagateCreateError: true // The propagateCreateError is set to true by default in Knex and throws a TimeoutError if the first create connection to the database fails. Knex recommends that this value is NOT set to false, despite what 'helpful' people on Stackoverflow tell you: https://github.com/knex/knex/issues/3455#issuecomment-535554401

--- a/packages/webhook-service/src/knex.js
+++ b/packages/webhook-service/src/knex.js
@@ -13,8 +13,15 @@ const isDevEnv = process.env.NODE_ENV !== 'production'
 let dbClients
 const getDbClients = async () => {
   if (dbClients) return dbClients
-  const maxConnections =
-    parseInt(process.env.POSTGRES_MAX_CONNECTIONS_WEBHOOK_SERVICE) || 1
+  const maxConnections = parseInt(
+    process.env.POSTGRES_MAX_CONNECTIONS_WEBHOOK_SERVICE || '1'
+  )
+  const connectionAcquireTimeoutMillis = parseInt(
+    process.env['POSTGRES_CONNECTION_ACQUIRE_TIMEOUT_MILLIS'] || '16000'
+  )
+  const connectionCreateTimeoutMillis = parseInt(
+    process.env['POSTGRES_CONNECTION_CREATE_TIMEOUT_MILLIS'] || '5000'
+  )
 
   const configArgs = {
     migrationDirs: [],
@@ -22,7 +29,9 @@ const getDbClients = async () => {
     isDevOrTestEnv: isDevEnv,
     logger,
     maxConnections,
-    applicationName: 'speckle_webhook_service'
+    applicationName: 'speckle_webhook_service',
+    connectionAcquireTimeoutMillis,
+    connectionCreateTimeoutMillis
   }
   if (!FF_WORKSPACES_MULTI_REGION_ENABLED) {
     const mainClient = configureKnexClient(

--- a/packages/webhook-service/src/observability/prometheusMetrics.js
+++ b/packages/webhook-service/src/observability/prometheusMetrics.js
@@ -70,8 +70,9 @@ async function initKnexPrometheusMetrics() {
     name: 'speckle_server_knex_remaining_capacity',
     help: 'Remaining capacity of the DB connection pool',
     collect() {
-      const postgresMaxConnections =
-        parseInt(process.env.POSTGRES_MAX_CONNECTIONS_WEBHOOK_SERVICE) || 1
+      const postgresMaxConnections = parseInt(
+        process.env.POSTGRES_MAX_CONNECTIONS_WEBHOOK_SERVICE || '1'
+      )
       const demand =
         knex.client.pool.numUsed() +
         knex.client.pool.numPendingCreates() +

--- a/utils/helm/speckle-server/templates/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/_helpers.tpl
@@ -770,10 +770,10 @@ Generate the environment variables for Speckle server and Speckle objects deploy
       key: {{ default "postgres_url" .Values.db.connectionString.secretKey }}
 - name: POSTGRES_MAX_CONNECTIONS_SERVER
   value: {{ .Values.db.maxConnectionsServer | quote }}
-- name: POSTGRES_CONNECTION_CREATION_TIMEOUT_MILLIS
-  value: {{ .Values.db.connectionCreationTimeoutMillis | quote }}
-- name: POSTGRES_CONNECTION_ACQUISITION_TIMEOUT_MILLIS
-  value: {{ .Values.db.connectionAcquisitionTimeoutMillis | quote }}
+- name: POSTGRES_CONNECTION_CREATE_TIMEOUT_MILLIS
+  value: {{ .Values.db.connectionCreateTimeoutMillis | quote }}
+- name: POSTGRES_CONNECTION_ACQUIRE_TIMEOUT_MILLIS
+  value: {{ .Values.db.connectionAcquireTimeoutMillis | quote }}
 
 - name: PGSSLMODE
   value: "{{ .Values.db.PGSSLMODE }}"

--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -80,6 +80,14 @@ spec:
               secretKeyRef:
                 name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
                 key: {{ default "postgres_url" .Values.db.connectionString.secretKey }}
+          {{- if .Values.fileimport_service.postgresMaxConnections }}
+          - name: POSTGRES_MAX_CONNECTIONS_FILE_IMPORT_SERVICE
+            value: {{ .Values.fileimport_service.postgresMaxConnections | quote }}
+          {{- end }}
+          - name: POSTGRES_CONNECTION_CREATE_TIMEOUT_MILLIS
+            value: {{ .Values.db.connectionCreateTimeoutMillis | quote }}
+          - name: POSTGRES_CONNECTION_ACQUIRE_TIMEOUT_MILLIS
+            value: {{ .Values.db.connectionAcquireTimeoutMillis | quote }}
 
           - name: LOG_LEVEL
             value: {{ .Values.fileimport_service.logLevel | quote }}

--- a/utils/helm/speckle-server/templates/preview_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/preview_service/deployment.yml
@@ -82,6 +82,14 @@ spec:
               secretKeyRef:
                 name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
                 key: {{ default "postgres_url" .Values.db.connectionString.secretKey }}
+          {{- if .Values.preview_service.postgresMaxConnections }}
+          - name: POSTGRES_MAX_CONNECTIONS_PREVIEW_SERVICE
+            value: {{ .Values.preview_service.postgresMaxConnections | quote }}
+          {{- end }}
+          - name: POSTGRES_CONNECTION_CREATE_TIMEOUT_MILLIS
+            value: {{ .Values.db.connectionCreateTimeoutMillis | quote }}
+          - name: POSTGRES_CONNECTION_ACQUIRE_TIMEOUT_MILLIS
+            value: {{ .Values.db.connectionAcquireTimeoutMillis | quote }}
 
           - name: LOG_LEVEL
             value: {{ .Values.preview_service.logLevel | quote }}

--- a/utils/helm/speckle-server/templates/webhook_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/deployment.yml
@@ -74,6 +74,14 @@ spec:
               secretKeyRef:
                 name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
                 key: {{ default "postgres_url" .Values.db.connectionString.secretKey }}
+          {{- if .Values.webhook_service.postgresMaxConnections }}
+          - name: POSTGRES_MAX_CONNECTIONS_WEBHOOK_SERVICE
+            value: {{ .Values.webhook_service.postgresMaxConnections | quote }}
+          {{- end }}
+          - name: POSTGRES_CONNECTION_CREATE_TIMEOUT_MILLIS
+            value: {{ .Values.db.connectionCreateTimeoutMillis | quote }}
+          - name: POSTGRES_CONNECTION_ACQUIRE_TIMEOUT_MILLIS
+            value: {{ .Values.db.connectionAcquireTimeoutMillis | quote }}
 
           - name: LOG_LEVEL
             value: {{ .Values.webhook_service.logLevel }}

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -1891,6 +1891,11 @@
             }
           }
         },
+        "postgresMaxConnections": {
+          "type": "number",
+          "description": "The maximum number of connections that the Preview Service postgres client will make to the Postgres database.",
+          "default": 2
+        },
         "puppeteer": {
           "type": "object",
           "properties": {
@@ -2003,6 +2008,11 @@
           "description": "The Docker image to be used for the Speckle Webhook Service component. If blank, defaults to speckle/speckle-webhook-service:{{ .Values.docker_image_tag }}. If provided, this value should be the full path including tag. The docker_image_tag value will be ignored.",
           "default": ""
         },
+        "postgresMaxConnections": {
+          "type": "number",
+          "description": "The maximum number of connections that the Webhook Service postgres client will make to the Postgres database.",
+          "default": 1
+        },
         "requests": {
           "type": "object",
           "properties": {
@@ -2099,6 +2109,11 @@
           "type": "string",
           "description": "The Docker image to be used for the Speckle FileImport Service component. If blank, defaults to speckle/speckle-fileimport-service:{{ .Values.docker_image_tag }}. If provided, this value should be the full path including tag. The docker_image_tag value will be ignored.",
           "default": ""
+        },
+        "postgresMaxConnections": {
+          "type": "number",
+          "description": "The maximum number of connections that the File Import Service postgres client will make to the Postgres database.",
+          "default": 1
         },
         "requests": {
           "type": "object",

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -1143,6 +1143,10 @@ preview_service:
     ## @param preview_service.monitoring.metricsPort The port on which the metrics server will be exposed.
     metricsPort: '9094'
 
+  ## @param preview_service.postgresMaxConnections The maximum number of connections that the Preview Service postgres client will make to the Postgres database.
+  ##
+  postgresMaxConnections: 2
+
   puppeteer:
     ## @param preview_service.puppeteer.userDataDirectory The path to the user data directory. If not set, defaults to '/tmp/puppeteer'. This is mounted in the deployment as a volume with read-write access.
     userDataDirectory: ''
@@ -1218,6 +1222,9 @@ webhook_service:
   ## @param webhook_service.image The Docker image to be used for the Speckle Webhook Service component. If blank, defaults to speckle/speckle-webhook-service:{{ .Values.docker_image_tag }}. If provided, this value should be the full path including tag. The docker_image_tag value will be ignored.
   ##
   image: ''
+  ## @param webhook_service.postgresMaxConnections The maximum number of connections that the Webhook Service postgres client will make to the Postgres database.
+  ##
+  postgresMaxConnections: 1
 
   requests:
     ## @param webhook_service.requests.cpu The CPU that should be available on a node when scheduling this pod.
@@ -1289,6 +1296,10 @@ fileimport_service:
   ## @param fileimport_service.image The Docker image to be used for the Speckle FileImport Service component. If blank, defaults to speckle/speckle-fileimport-service:{{ .Values.docker_image_tag }}. If provided, this value should be the full path including tag. The docker_image_tag value will be ignored.
   ##
   image: ''
+
+  ## @param fileimport_service.postgresMaxConnections The maximum number of connections that the File Import Service postgres client will make to the Postgres database.
+  ##
+  postgresMaxConnections: 1
 
   requests:
     ## @param fileimport_service.requests.cpu The CPU that should be available on a node when scheduling this pod.


### PR DESCRIPTION
## Description & motivation

Postgres client configuration parameters were hard coded and could not be configured. This PR allows them to be configured by the server operator.

## Changes:

- new environment variables to server, fileimport service, preview service, and webhook service to configure `POSTGRES_CONNECTION_CREATE_TIMEOUT_MILLIS` and `POSTGRES_CONNECTION_ACQUIRE_TIMEOUT_MILLIS`
- updates helm chart to provide `db.connectionAcquisitionTimeoutMillis` and `db.connectionCreationTimeoutMillis` configuration parameters and configure environment variables
- Helm Chart updated to allow `postgresMaxConnections` to be configured for fileimport service, preview service, and webhook service. These were previously configurable via environment variable but not via the Helm Chart.
- tidies environment variable parsing in preview service to use `process.env['key']` syntax over `process.env.key` syntax.

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
