### PR TITLE
feat(database monitor): query configured postgres values

### DIFF
--- a/packages/monitor-deployment/src/observability/metrics/dbMaxLogicalReplicationWorkers.ts
+++ b/packages/monitor-deployment/src/observability/metrics/dbMaxLogicalReplicationWorkers.ts
@@ -1,0 +1,33 @@
+import prometheusClient from 'prom-client'
+import { join } from 'lodash-es'
+import type { MetricInitializer } from '@/observability/types.js'
+
+export const init: MetricInitializer = (config) => {
+  const { labelNames, namePrefix, logger } = config
+  const metric = new prometheusClient.Gauge({
+    name: join([namePrefix, 'db', 'max_logical_replication_workers'], '_'),
+    help: 'Configured value of max_logical_replication_workers for the Postgres database',
+    labelNames: ['region', ...labelNames]
+  })
+  return async (params) => {
+    const { dbClients, labels } = params
+    await Promise.all(
+      dbClients.map(async ({ client, regionKey }) => {
+        const queryResults = await client.raw<{
+          rows: [{ max_logical_replication_workers: string }]
+        }>(`SHOW max_logical_replication_workers;`)
+        if (!queryResults.rows.length) {
+          logger.error(
+            { region: regionKey },
+            "No max_logical_replication_workers found for region '{region}'. This is odd."
+          )
+          return
+        }
+        metric.set(
+          { ...labels, region: regionKey },
+          parseInt(queryResults.rows[0].max_logical_replication_workers)
+        )
+      })
+    )
+  }
+}

--- a/packages/monitor-deployment/src/observability/metrics/dbMaxReplicationSlots.ts
+++ b/packages/monitor-deployment/src/observability/metrics/dbMaxReplicationSlots.ts
@@ -1,0 +1,33 @@
+import prometheusClient from 'prom-client'
+import { join } from 'lodash-es'
+import type { MetricInitializer } from '@/observability/types.js'
+
+export const init: MetricInitializer = (config) => {
+  const { labelNames, namePrefix, logger } = config
+  const metric = new prometheusClient.Gauge({
+    name: join([namePrefix, 'db_max_replication_slots'], '_'),
+    help: 'Configured value of max_replication_slots for the Postgres database',
+    labelNames: ['region', ...labelNames]
+  })
+  return async (params) => {
+    const { dbClients, labels } = params
+    await Promise.all(
+      dbClients.map(async ({ client, regionKey }) => {
+        const queryResults = await client.raw<{
+          rows: [{ max_replication_slots: string }]
+        }>(`SHOW max_replication_slots;`)
+        if (!queryResults.rows.length) {
+          logger.error(
+            { region: regionKey },
+            "No max_replication_slots found for region '{region}'. This is odd."
+          )
+          return
+        }
+        metric.set(
+          { ...labels, region: regionKey },
+          parseInt(queryResults.rows[0].max_replication_slots)
+        )
+      })
+    )
+  }
+}

--- a/packages/monitor-deployment/src/observability/metrics/dbMaxSyncWorkersPerSubscription.ts
+++ b/packages/monitor-deployment/src/observability/metrics/dbMaxSyncWorkersPerSubscription.ts
@@ -1,0 +1,33 @@
+import prometheusClient from 'prom-client'
+import { join } from 'lodash-es'
+import type { MetricInitializer } from '@/observability/types.js'
+
+export const init: MetricInitializer = (config) => {
+  const { labelNames, namePrefix, logger } = config
+  const metric = new prometheusClient.Gauge({
+    name: join([namePrefix, 'db', 'max_sync_workers_per_subscription'], '_'),
+    help: 'Configured value of max_sync_workers_per_subscription for the Postgres database',
+    labelNames: ['region', ...labelNames]
+  })
+  return async (params) => {
+    const { dbClients, labels } = params
+    await Promise.all(
+      dbClients.map(async ({ client, regionKey }) => {
+        const queryResults = await client.raw<{
+          rows: [{ max_sync_workers_per_subscription: string }]
+        }>(`SHOW max_sync_workers_per_subscription;`)
+        if (!queryResults.rows.length) {
+          logger.error(
+            { region: regionKey },
+            "No max_sync_workers_per_subscription found for region '{region}'. This is odd."
+          )
+          return
+        }
+        metric.set(
+          { ...labels, region: regionKey },
+          parseInt(queryResults.rows[0].max_sync_workers_per_subscription)
+        )
+      })
+    )
+  }
+}

--- a/packages/monitor-deployment/src/observability/metrics/dbMaxWalSenders.ts
+++ b/packages/monitor-deployment/src/observability/metrics/dbMaxWalSenders.ts
@@ -1,0 +1,33 @@
+import prometheusClient from 'prom-client'
+import { join } from 'lodash-es'
+import type { MetricInitializer } from '@/observability/types.js'
+
+export const init: MetricInitializer = (config) => {
+  const { labelNames, namePrefix, logger } = config
+  const metric = new prometheusClient.Gauge({
+    name: join([namePrefix, 'db_max_wal_senders'], '_'),
+    help: 'Configured value of max_wal_senders for the Postgres database',
+    labelNames: ['region', ...labelNames]
+  })
+  return async (params) => {
+    const { dbClients, labels } = params
+    await Promise.all(
+      dbClients.map(async ({ client, regionKey }) => {
+        const queryResults = await client.raw<{
+          rows: [{ max_wal_senders: string }]
+        }>(`SHOW max_wal_senders;`)
+        if (!queryResults.rows.length) {
+          logger.error(
+            { region: regionKey },
+            "No max_wal_senders found for region '{region}'. This is odd."
+          )
+          return
+        }
+        metric.set(
+          { ...labels, region: regionKey },
+          parseInt(queryResults.rows[0].max_wal_senders)
+        )
+      })
+    )
+  }
+}

--- a/packages/monitor-deployment/src/observability/metrics/dbMaxWorkerProcesses.ts
+++ b/packages/monitor-deployment/src/observability/metrics/dbMaxWorkerProcesses.ts
@@ -1,0 +1,33 @@
+import prometheusClient from 'prom-client'
+import { join } from 'lodash-es'
+import type { MetricInitializer } from '@/observability/types.js'
+
+export const init: MetricInitializer = (config) => {
+  const { labelNames, namePrefix, logger } = config
+  const metric = new prometheusClient.Gauge({
+    name: join([namePrefix, 'db', 'max_worker_processes'], '_'),
+    help: 'Configured value of max_worker_processes for the Postgres database',
+    labelNames: ['region', ...labelNames]
+  })
+  return async (params) => {
+    const { dbClients, labels } = params
+    await Promise.all(
+      dbClients.map(async ({ client, regionKey }) => {
+        const queryResults = await client.raw<{
+          rows: [{ max_worker_processes: string }]
+        }>(`SHOW max_worker_processes;`)
+        if (!queryResults.rows.length) {
+          logger.error(
+            { region: regionKey },
+            "No max_worker_processes found for region '{region}'. This is odd."
+          )
+          return
+        }
+        metric.set(
+          { ...labels, region: regionKey },
+          parseInt(queryResults.rows[0].max_worker_processes)
+        )
+      })
+    )
+  }
+}

--- a/packages/monitor-deployment/src/observability/metrics/dbWalLevel.ts
+++ b/packages/monitor-deployment/src/observability/metrics/dbWalLevel.ts
@@ -1,0 +1,33 @@
+import prometheusClient from 'prom-client'
+import { join } from 'lodash-es'
+import type { MetricInitializer } from '@/observability/types.js'
+
+export const init: MetricInitializer = (config) => {
+  const { labelNames, namePrefix, logger } = config
+  const metric = new prometheusClient.Gauge({
+    name: join([namePrefix, 'db_wal_level_is_logical'], '_'),
+    help: "Indicates whether the value of wal_level for the Postgres database is 'logical'",
+    labelNames: ['region', ...labelNames]
+  })
+  return async (params) => {
+    const { dbClients, labels } = params
+    await Promise.all(
+      dbClients.map(async ({ client, regionKey }) => {
+        const queryResults = await client.raw<{
+          rows: [{ wal_level: string }]
+        }>(`SHOW wal_level;`)
+        if (!queryResults.rows.length) {
+          logger.error(
+            { region: regionKey },
+            "No wal_level found for region '{region}'. This is odd."
+          )
+          return
+        }
+        metric.set(
+          { ...labels, region: regionKey },
+          queryResults.rows[0].wal_level === 'logical' ? 1 : 0
+        )
+      })
+    )
+  }
+}

--- a/packages/monitor-deployment/src/observability/prometheusMetrics.ts
+++ b/packages/monitor-deployment/src/observability/prometheusMetrics.ts
@@ -5,7 +5,13 @@ import { join } from 'lodash-es'
 import { Counter, Histogram, Registry } from 'prom-client'
 import prometheusClient from 'prom-client'
 import { init as commits } from '@/observability/metrics/commits.js'
+import { init as dbMaxLogicalReplicationWorkers } from '@/observability/metrics/dbMaxLogicalReplicationWorkers.js'
+import { init as dbMaxReplicationSlots } from '@/observability/metrics/dbMaxReplicationSlots.js'
+import { init as dbMaxSyncWorkersPerSubscription } from '@/observability/metrics/dbMaxSyncWorkersPerSubscription.js'
+import { init as dbMaxWalSenders } from '@/observability/metrics/dbMaxWalSenders.js'
+import { init as dbMaxWorkerProcesses } from '@/observability/metrics/dbMaxWorkerProcesses.js'
 import { init as dbSize } from '@/observability/metrics/dbSize.js'
+import { init as dbWalLevel } from '@/observability/metrics/dbWalLevel.js'
 import { init as dbWorkers } from '@/observability/metrics/dbWorkers.js'
 import { init as dbWorkersAwaitingLocks } from '@/observability/metrics/dbWorkersAwaitingLocks.js'
 import { init as fileImports } from '@/observability/metrics/fileImports.js'
@@ -54,9 +60,15 @@ function initMonitoringMetrics(params: {
 
   const metricsToInitialize = [
     commits,
+    dbMaxLogicalReplicationWorkers,
+    dbMaxReplicationSlots,
+    dbMaxSyncWorkersPerSubscription,
+    dbMaxWalSenders,
+    dbMaxWorkerProcesses,
+    dbWalLevel,
+    dbSize,
     dbWorkers,
     dbWorkersAwaitingLocks,
-    dbSize,
     fileImports,
     fileSize,
     inactiveReplicationSlots,


### PR DESCRIPTION
## Description & motivation

These are the values which the Postgres server is configured with at startup.

We need these values in Prometheus/AlertManager in order to provide a threshold for alerting.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<img width="1163" alt="Screenshot 2024-12-17 at 22 07 28" src="https://github.com/user-attachments/assets/15054f96-31c5-4266-ba35-cd2bd54df317" />


## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
