### PR TITLE
refactor(tailwind-theme): Update colour variables - primary-focus, info, outline-1

### DIFF
--- a/packages/tailwind-theme/src/plugin.ts
+++ b/packages/tailwind-theme/src/plugin.ts
@@ -56,10 +56,10 @@ export const lightThemeVariables = {
   '--warning-darker': '#E0AB20',
 
   /* info variations */
-  '--info': '#B9B8CC',
-  '--info-lighter': '#D2D1E5',
+  '--info': '#B8C0CC',
+  '--info-lighter': '#E0ECFF',
   '--info-lightest': '#EEEEFE',
-  '--info-darker': '#6D6B99',
+  '--info-darker': '#6B7D99',
 
   /* danger variations */
   '--danger': '#C45959',
@@ -93,12 +93,12 @@ export const darkThemeVariables = {
   /* primary color */
   '--primary': '#136CFF',
   /* focused primary color */
-  '--primary-focus': '#458CFF',
+  '--primary-focus': '#0057E5',
   /* muted primary color */
   '--primary-muted': '#292B39',
 
   /* outline variations */
-  '--outline-1': '#2B7CFF',
+  '--outline-1': '#276FE5',
   '--outline-2': '#2E313F',
   '--outline-3': '#282833',
   '--outline-4': '#4B40C9',
@@ -122,10 +122,10 @@ export const darkThemeVariables = {
   '--warning-darker': '#E0AB20',
 
   /* info variations */
-  '--info': '#B9B8CC',
-  '--info-lighter': '#D2D1E5',
+  '--info': '#B8C0CC',
+  '--info-lighter': '#E0ECFF',
   '--info-lightest': '#030330',
-  '--info-darker': '#6D6B99',
+  '--info-darker': '#6B7D99',
 
   /* danger variations */
   '--danger': '#F87171',


### PR DESCRIPTION
Michal has made some changes to our colour palette. This branch implements these changes in `tailwind-theme`.

The main change is to the info colours. We are moving away from purple and into a more neutral tone.

There were also changes to the `primary-focus` and `outline-1` dark mode variants. 

[FIGMA FILE](https://www.figma.com/design/z9qYUyM3kLH534M19jvCGE/Michal's-library-WIP?node-id=2469-3658&t=RFY9t2zl9Kp6e5XE-4)

`[LINEAR TICKET](https://linear.app/speckle/issue/WEB-2368/implement-new-colours)`