### PR TITLE
Fix: Dont show tooltip on all workspace avatars

### DIFF
--- a/packages/frontend-2/components/workspace/Avatar.vue
+++ b/packages/frontend-2/components/workspace/Avatar.vue
@@ -1,12 +1,10 @@
 <template>
   <component
-    :is="logo ? 'div' : 'button'"
-    v-tippy="logo ? undefined : 'Add a workspace icon'"
+    :is="isButton ? 'div' : 'button'"
     :class="[
       'flex shrink-0 overflow-hidden rounded-md border border-outline-2 bg-foundation-2',
       sizeClasses
     ]"
-    @click="logo ? undefined : openSettingsDialog(SettingMenuKeys.Workspace.General)"
   >
     <div
       class="h-full w-full bg-cover bg-center bg-no-repeat flex items-center justify-center"
@@ -22,20 +20,13 @@
 <script setup lang="ts">
 import type { MaybeNullOrUndefined } from '@speckle/shared'
 import { type UserAvatarSize, useAvatarSizeClasses } from '@speckle/ui-components'
-import {
-  type AvailableSettingsMenuKeys,
-  SettingMenuKeys
-} from '~/lib/settings/helpers/types'
-
-const emit = defineEmits<{
-  (e: 'show-settings-dialog', v: AvailableSettingsMenuKeys): void
-}>()
 
 const props = withDefaults(
   defineProps<{
     size?: UserAvatarSize
     logo: MaybeNullOrUndefined<string>
     name: string
+    isButton?: boolean
   }>(),
   {
     size: 'base'
@@ -43,8 +34,4 @@ const props = withDefaults(
 )
 
 const { sizeClasses } = useAvatarSizeClasses({ props: toRefs(props) })
-
-const openSettingsDialog = (target: AvailableSettingsMenuKeys) => {
-  emit('show-settings-dialog', target)
-}
 </script>

--- a/packages/frontend-2/components/workspace/header/Header.vue
+++ b/packages/frontend-2/components/workspace/header/Header.vue
@@ -13,11 +13,18 @@
     <div class="flex items-center justify-between gap-4">
       <div class="flex items-center gap-3 lg:gap-4">
         <WorkspaceAvatar
+          v-tippy="workspaceInfo.logo ? undefined : 'Add a workspace icon'"
           :name="workspaceInfo.name"
           :logo="workspaceInfo.logo"
           size="lg"
           class="hidden md:block"
-          @show-settings-dialog="openSettingsDialog(SettingMenuKeys.Workspace.General)"
+          :class="{ 'cursor-pointer': !workspaceInfo.logo }"
+          is-button
+          @click="
+            workspaceInfo.logo
+              ? undefined
+              : openSettingsDialog(SettingMenuKeys.Workspace.General)
+          "
         />
         <WorkspaceAvatar
           class="md:hidden"


### PR DESCRIPTION
<img width="292" alt="Screenshot 2024-12-23 at 13 54 32" src="https://github.com/user-attachments/assets/46c6f984-3cfc-48d8-bf73-2f2daffab7c7" />
<img width="217" alt="Screenshot 2024-12-23 at 13 53 11" src="https://github.com/user-attachments/assets/3de14c0d-9449-4a6f-979b-954b6474d5b7" />
