### PR TITLE
Fix: Align settings sidebar with main sidebar

### DIFF
--- a/packages/ui-components/src/components/layout/sidebar/menu/group/Group.vue
+++ b/packages/ui-components/src/components/layout/sidebar/menu/group/Group.vue
@@ -21,15 +21,11 @@
         >
           <slot name="title-icon"></slot>
         </div>
-        <div class="flex flex-1 items-center truncate">
+        <div class="flex flex-1 items-center truncate justify-between">
           <h6 class="font-semibold text-foreground-2 truncate text-body-2xs pr-2">
             {{ title }}
           </h6>
-          <CommonBadge
-            v-if="tag"
-            rounded
-            color-classes="bg-foundation-2 text-foreground-2"
-          >
+          <CommonBadge v-if="tag" rounded>
             {{ tag }}
           </CommonBadge>
         </div>


### PR DESCRIPTION
<img width="261" alt="Screenshot 2024-12-23 at 14 32 48" src="https://github.com/user-attachments/assets/150aab73-df07-43fd-a775-ef7c24bb43d8" />
