### PR TITLE
Fix: Revert notification changes

### DIFF
--- a/packages/frontend-2/components/invite/dialog/Server.vue
+++ b/packages/frontend-2/components/invite/dialog/Server.vue
@@ -174,7 +174,7 @@ const onSubmit = handleSubmit(async () => {
     isOpen.value = false
   } catch {
     triggerNotification({
-      type: ToastNotificationType.Success,
+      type: ToastNotificationType.Danger,
       title:
         invites.length > 1
           ? 'One or more invites failed to send'

--- a/packages/frontend-2/components/singleton/ToastManager.vue
+++ b/packages/frontend-2/components/singleton/ToastManager.vue
@@ -1,6 +1,6 @@
 <template>
   <Teleport to="#toast-portal">
-    <GlobalToastRenderer v-model:notifications="notifications" @dismiss="dismiss" />
+    <GlobalToastRenderer v-model:notification="notification" />
   </Teleport>
 </template>
 
@@ -8,13 +8,13 @@
 import { useGlobalToastManager } from '~~/lib/common/composables/toast'
 import { GlobalToastRenderer } from '@speckle/ui-components'
 
-const { currentNotifications, dismissAll, dismiss } = useGlobalToastManager()
+const { currentNotification, dismiss } = useGlobalToastManager()
 
-const notifications = computed({
-  get: () => currentNotifications.value,
+const notification = computed({
+  get: () => currentNotification.value,
   set: (newVal) => {
     if (!newVal) {
-      dismissAll()
+      dismiss()
     }
   }
 })

--- a/packages/frontend-2/lib/projects/composables/projectManagement.ts
+++ b/packages/frontend-2/lib/projects/composables/projectManagement.ts
@@ -264,9 +264,11 @@ export function useInviteUserToProject() {
 
   return async (
     projectId: string,
-    input: ProjectInviteCreateInput[] | WorkspaceProjectInviteCreateInput[]
+    input: ProjectInviteCreateInput[] | WorkspaceProjectInviteCreateInput[],
+    options?: { hideToasts?: boolean }
   ) => {
     const userId = activeUser.value?.id
+    const { hideToasts } = options || {}
     if (!userId) return
 
     const isWorkspaceInput = (
@@ -299,7 +301,7 @@ export function useInviteUserToProject() {
       err = !res?.id ? getFirstErrorMessage(errors) : undefined
     }
 
-    if (err) {
+    if (err && !hideToasts) {
       triggerNotification({
         type: ToastNotificationType.Danger,
         title:
@@ -309,13 +311,15 @@ export function useInviteUserToProject() {
         description: err
       })
     } else {
-      triggerNotification({
-        type: ToastNotificationType.Success,
-        title:
-          input.length > 1
-            ? 'Invites successfully send'
-            : `Invite successfully sent to ${input[0].email}`
-      })
+      if (!hideToasts) {
+        triggerNotification({
+          type: ToastNotificationType.Success,
+          title:
+            input.length > 1
+              ? 'Invites successfully send'
+              : `Invite successfully sent to ${input[0].email}`
+        })
+      }
     }
 
     return res

--- a/packages/frontend-2/lib/server/composables/invites.ts
+++ b/packages/frontend-2/lib/server/composables/invites.ts
@@ -22,8 +22,13 @@ export function useInviteUserToServer() {
   const { mutate, loading } = useMutation(inviteServerUserMutation)
 
   return {
-    mutate: async (input: ServerInviteCreateInput | ServerInviteCreateInput[]) => {
+    mutate: async (
+      input: ServerInviteCreateInput | ServerInviteCreateInput[],
+      options?: { hideToasts?: boolean }
+    ) => {
       const finalInput = isArray(input) ? input : [input]
+      const { hideToasts } = options || {}
+
       const res = await mutate(
         {
           input: finalInput
@@ -53,23 +58,27 @@ export function useInviteUserToServer() {
       ).catch(convertThrowIntoFetchResult)
 
       if (res?.data?.serverInviteBatchCreate) {
-        triggerNotification({
-          type: ToastNotificationType.Success,
-          title:
-            finalInput.length > 1
-              ? 'Server invites sent'
-              : `Server invite sent to ${finalInput[0].email}`
-        })
+        if (!hideToasts) {
+          triggerNotification({
+            type: ToastNotificationType.Success,
+            title:
+              finalInput.length > 1
+                ? 'Server invites sent'
+                : `Server invite sent to ${finalInput[0].email}`
+          })
+        }
       } else {
         const errMsg = getFirstErrorMessage(res?.errors)
-        triggerNotification({
-          type: ToastNotificationType.Danger,
-          title:
-            finalInput.length > 1
-              ? "Couldn't send invites"
-              : `Couldn't send invite to ${finalInput[0].email}`,
-          description: errMsg
-        })
+        if (!hideToasts) {
+          triggerNotification({
+            type: ToastNotificationType.Danger,
+            title:
+              finalInput.length > 1
+                ? "Couldn't send invites"
+                : `Couldn't send invite to ${finalInput[0].email}`,
+            description: errMsg
+          })
+        }
       }
 
       return !!res?.data?.serverInviteBatchCreate

--- a/packages/ui-components/src/components/global/ToastRenderer.stories.ts
+++ b/packages/ui-components/src/components/global/ToastRenderer.stories.ts
@@ -7,7 +7,7 @@ import { ToastNotificationType } from '~~/src/helpers/global/toast'
 import type { ToastNotification } from '~~/src/helpers/global/toast'
 import { useGlobalToast } from '~~/src/stories/composables/toast'
 
-type StoryType = StoryObj<{ notifications: ToastNotification[] }>
+type StoryType = StoryObj<{ notification: ToastNotification }>
 
 export default {
   component: ToastRenderer,
@@ -20,11 +20,12 @@ export default {
     }
   },
   argTypes: {
-    notifications: {
-      description: 'ToastNotification array, nullable'
+    notification: {
+      description: 'ToastNotification type object, nullable'
     },
-    dismiss: {
-      description: 'Dismiss event for a notification'
+    'update:notification': {
+      description:
+        "Notification prop update event. Enables two-way binding through 'v-model:notification'"
     }
   }
 } as Meta
@@ -34,11 +35,11 @@ export const Default: StoryType = {
     components: { ToastRenderer, FormButton },
     setup() {
       const { triggerNotification } = useGlobalToast()
-      const notifications = ref(null as Nullable<ToastNotification[]>)
+      const notification = ref(null as Nullable<ToastNotification>)
       const onClick = () => {
-        triggerNotification(args.notifications[0])
+        triggerNotification(args.notification)
       }
-      return { args, onClick, notifications }
+      return { args, onClick, notification }
     },
     template: `
       <div>
@@ -49,34 +50,30 @@ export const Default: StoryType = {
   parameters: {
     docs: {
       source: {
-        code: '<GlobalToastRenderer v-model:notifications="notifications" />'
+        code: '<GlobalToastRenderer v-model:notification="notification"/>'
       }
     }
   },
   args: {
-    notifications: [
-      {
-        type: ToastNotificationType.Info,
-        title: 'Title',
-        description: 'Description',
+    notification: {
+      type: ToastNotificationType.Info,
+      title: 'Title',
+      description: 'Description',
 
-        cta: {
-          title: 'CTA'
-        }
+      cta: {
+        title: 'CTA'
       }
-    ]
+    }
   }
 }
 
 export const WithManualClose: StoryType = {
   ...Default,
   args: {
-    notifications: [
-      {
-        ...Default.args!.notifications![0],
-        autoClose: false
-      }
-    ]
+    notification: {
+      ...Default.args!.notification!,
+      autoClose: false
+    }
   }
 }
 
@@ -84,20 +81,23 @@ export const NoCtaOrDescription: StoryObj = {
   render: (args) => ({
     components: { ToastRenderer, FormButton },
     setup() {
-      const { triggerNotification } = useGlobalToast()
-      const notifications = ref(null as Nullable<ToastNotification[]>)
+      const notification = ref(null as Nullable<ToastNotification>)
       const onClick = () => {
-        triggerNotification({
+        // Update notification without cta or description
+        notification.value = {
           type: ToastNotificationType.Info,
           title: 'Displays a toast notification'
-        })
+        }
+
+        // Clear after 2s
+        setTimeout(() => (notification.value = null), 2000)
       }
-      return { args, onClick, notifications }
+      return { args, onClick, notification }
     },
     template: `
       <div>
         <FormButton @click="onClick">Trigger Title Only</FormButton>
-        <ToastRenderer v-model:notifications="notifications" />
+        <ToastRenderer v-model:notification="notification"/>
       </div>
     `
   }),
@@ -108,8 +108,8 @@ export const NoCtaOrDescription: StoryObj = {
       },
       source: {
         code: `
-          <FormButton @click="onClick">Trigger Title Only</FormButton>
-          <ToastRenderer v-model:notifications="notifications" />
+<FormButton @click="onClick">Trigger Title Only</FormButton>
+<ToastRenderer v-model:notification="notification"/>
         `
       }
     }

--- a/packages/ui-components/src/components/global/ToastRenderer.vue
+++ b/packages/ui-components/src/components/global/ToastRenderer.vue
@@ -5,7 +5,7 @@
   >
     <div class="flex w-full flex-col items-center space-y-4 sm:items-end">
       <!-- Notification panel, dynamically insert this into the live region when it needs to be displayed -->
-      <TransitionGroup
+      <Transition
         enter-active-class="transform ease-out duration-300 transition"
         enter-from-class="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
         enter-to-class="translate-y-0 opacity-100 sm:translate-x-0"
@@ -14,10 +14,9 @@
         leave-to-class="opacity-0"
       >
         <div
-          v-for="(notification, index) in notifications"
-          :key="`toast-${index}`"
+          v-if="notification"
           class="pointer-events-auto w-full max-w-[20rem] overflow-hidden rounded bg-foundation text-foreground shadow-lg border border-outline-2 p-3"
-          :class="{ 'pb-2': !notification?.description && !notification?.cta }"
+          :class="{ 'pb-2': isTitleOnly }"
         >
           <div class="flex space-x-2">
             <div class="flex-shrink-0 mt-1">
@@ -60,7 +59,7 @@
                   class="mt-1 color-primary"
                   :to="notification.cta.url"
                   size="sm"
-                  @click="(e: MouseEvent) => onCtaClick(notification, e)"
+                  @click="onCtaClick"
                 >
                   {{ notification.cta.title }}
                 </TextLink>
@@ -70,7 +69,7 @@
               <button
                 type="button"
                 class="inline-flex rounded-md bg-foundation text-foreground-2 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
-                @click="dismiss(notification)"
+                @click="dismiss"
               >
                 <span class="sr-only">Close</span>
                 <XMarkIcon class="h-5 w-5" aria-hidden="true" />
@@ -78,7 +77,7 @@
             </div>
           </div>
         </div>
-      </TransitionGroup>
+      </Transition>
     </div>
   </div>
 </template>
@@ -91,24 +90,29 @@ import {
   InformationCircleIcon,
   XMarkIcon
 } from '@heroicons/vue/20/solid'
+import { computed } from 'vue'
 import type { MaybeNullOrUndefined } from '@speckle/shared'
 import { ToastNotificationType } from '~~/src/helpers/global/toast'
 import type { ToastNotification } from '~~/src/helpers/global/toast'
 
 const emit = defineEmits<{
-  (e: 'dismiss', val: ToastNotification): void
+  (e: 'update:notification', val: MaybeNullOrUndefined<ToastNotification>): void
 }>()
 
-defineProps<{
-  notifications: MaybeNullOrUndefined<ToastNotification[]>
+const props = defineProps<{
+  notification: MaybeNullOrUndefined<ToastNotification>
 }>()
 
-const dismiss = (notification: ToastNotification) => {
-  emit('dismiss', notification)
+const isTitleOnly = computed(
+  () => !props.notification?.description && !props.notification?.cta
+)
+
+const dismiss = () => {
+  emit('update:notification', null)
 }
 
-const onCtaClick = (notification: ToastNotification, e: MouseEvent) => {
-  notification.cta?.onClick?.(e)
-  dismiss(notification)
+const onCtaClick = (e: MouseEvent) => {
+  props.notification?.cta?.onClick?.(e)
+  dismiss()
 }
 </script>

--- a/packages/ui-components/src/stories/components/GlobalToast.vue
+++ b/packages/ui-components/src/stories/components/GlobalToast.vue
@@ -1,18 +1,18 @@
 <template>
-  <ToastRenderer v-model:notifications="notifications" @dismiss="dismiss" />
+  <ToastRenderer v-model:notification="notification" />
 </template>
 <script setup lang="ts">
 import { computed } from 'vue'
 import ToastRenderer from '~~/src/components/global/ToastRenderer.vue'
 import { useGlobalToastManager } from '~~/src/stories/composables/toast'
 
-const { currentNotifications, dismissAll, dismiss } = useGlobalToastManager()
+const { currentNotification, dismiss } = useGlobalToastManager()
 
-const notifications = computed({
-  get: () => currentNotifications.value,
+const notification = computed({
+  get: () => currentNotification.value,
   set: (newVal) => {
     if (!newVal) {
-      dismissAll()
+      dismiss()
     }
   }
 })


### PR DESCRIPTION
- Revert back to old notification system of only triggering one notification at the time
- Add option to hide toasts in compostables, and handle them in the parent in the case of server invites