### PR TITLE
fix(fe2): Make viewer controls scrollable when they overflow viewport

### DIFF
--- a/packages/frontend-2/components/viewer/Controls.vue
+++ b/packages/frontend-2/components/viewer/Controls.vue
@@ -2,7 +2,7 @@
 <template>
   <div v-if="showControls">
     <div
-      class="absolute z-20 flex max-h-screen simple-scrollbar flex-col space-y-1 md:space-y-2 bg-green-300/0 px-2"
+      class="absolute z-20 flex max-h-screen simple-scrollbar flex-col space-y-1 md:space-y-2 px-2 overflow-y-auto"
       :class="
         showNavbar && !isEmbedEnabled
           ? 'pt-[3.8rem]'


### PR DESCRIPTION
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/fa2c0f8b-eefd-4375-b503-04478826fcf5" />

This is not a perfect solution, but it's better than it is currently. 

Right now, smaller screens clip the bottom of the viewer controls. You can see my screenshot above, and i'm on a decent mac, so others will definitely experience this. 

There was a weird `bg-green/0` class which i removed, and then added `overflow-y-auto` to the same div. 

Now, when the menu overflows the viewport, our custom scrollbar appears. This should have no affect on users with large screens, but allows other users to access lower items. 

@Mikehrn I discussed this one with Benjamin this morning and we talked about a larger rethink on this controls menu in the viewer. It's not worth spending time on a better solution right now, when this is all probably going to change pretty soon. 