### PR TITLE
feat(server): ability to set global knex .select() query timeout

### DIFF
--- a/packages/server/bootstrap.js
+++ b/packages/server/bootstrap.js
@@ -30,10 +30,6 @@ if (isApolloMonitoringEnabled() && !getApolloServerVersion()) {
   process.env.APOLLO_SERVER_USER_VERSION = getServerVersion()
 }
 
-//knex is a singleton controlled by module so can't wait til app init
-const { initOpenTelemetry } = require('./otel')
-initOpenTelemetry()
-
 // If running in test env, load .env.test first
 // (appRoot necessary, cause env files aren't loaded through require() calls)
 if (isTestEnv()) {
@@ -48,6 +44,12 @@ if (isTestEnv()) {
 }
 
 dotenv.config({ path: `${packageRoot}/.env` })
+
+//knex is a singleton controlled by module so can't wait til app init
+const { initOpenTelemetry } = require('./otel')
+initOpenTelemetry()
+const { patchKnex } = require('./modules/core/patches/knex')
+patchKnex()
 
 module.exports = {
   appRoot,

--- a/packages/server/modules/core/patches/knex.ts
+++ b/packages/server/modules/core/patches/knex.ts
@@ -14,7 +14,10 @@ export const patchKnex = () => {
   // Add .timeout() to all .select() calls
   if (DEFAULT_QUERY_TIMEOUT_MS) {
     const originalSelect = knexPgQueryBuilder.prototype.select
-    knexPgQueryBuilder.prototype.select = function (...args: any) {
+    const newSelect: typeof originalSelect = function (
+      this: typeof knexPgQueryBuilder.prototype,
+      ...args: any
+    ) {
       let ret = originalSelect.apply(this, args)
       if (!this._timeout) {
         ret = ret.timeout(DEFAULT_QUERY_TIMEOUT_MS, { cancel: true })
@@ -22,5 +25,9 @@ export const patchKnex = () => {
 
       return ret
     }
+
+    // .columns and .select are the same function, they're just aliases
+    knexPgQueryBuilder.prototype.select = newSelect
+    knexPgQueryBuilder.prototype.columns = newSelect
   }
 }

--- a/packages/server/modules/core/patches/knex.ts
+++ b/packages/server/modules/core/patches/knex.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getGlobalKnexSelectTimeout } from '@/modules/shared/helpers/envHelper'
+import knexPgQueryBuilder from 'knex/lib/dialects/postgres/query/pg-querybuilder'
+
+/**
+ * ⚠️ HERE BE DARKNESS! ⚠️
+ * We're monkey patching knex which is pretty cursed, but only because it does not support
+ * obvious features that are critical for ensuring DB connections run smoothly.
+ */
+
+export const patchKnex = () => {
+  const DEFAULT_QUERY_TIMEOUT_MS = getGlobalKnexSelectTimeout()
+
+  // Add .timeout() to all .select() calls
+  if (DEFAULT_QUERY_TIMEOUT_MS) {
+    const originalSelect = knexPgQueryBuilder.prototype.select
+    knexPgQueryBuilder.prototype.select = function (...args: any) {
+      let ret = originalSelect.apply(this, args)
+      if (!this._timeout) {
+        ret = ret.timeout(DEFAULT_QUERY_TIMEOUT_MS, { cancel: true })
+      }
+
+      return ret
+    }
+  }
+}

--- a/packages/server/modules/shared/helpers/envHelper.ts
+++ b/packages/server/modules/shared/helpers/envHelper.ts
@@ -433,3 +433,7 @@ export const shouldRunTestsInMultiregionMode = () =>
 export function shutdownTimeoutSeconds() {
   return getIntFromEnv('SHUTDOWN_TIMEOUT_SECONDS', '300')
 }
+
+export function getGlobalKnexSelectTimeout() {
+  return getIntFromEnv('GLOBAL_KNEX_SELECT_TIMEOUT', '0')
+}

--- a/packages/server/type-augmentations/knex.d.ts
+++ b/packages/server/type-augmentations/knex.d.ts
@@ -1,0 +1,10 @@
+// used in patches/knex.ts
+declare module 'knex/lib/dialects/postgres/query/pg-querybuilder' {
+  const qb: {
+    prototype: {
+      select: import('knex').Knex.QueryBuilder['select']
+      _timeout: number
+    }
+  }
+  export default qb
+}

--- a/packages/server/type-augmentations/knex.d.ts
+++ b/packages/server/type-augmentations/knex.d.ts
@@ -3,6 +3,7 @@ declare module 'knex/lib/dialects/postgres/query/pg-querybuilder' {
   const qb: {
     prototype: {
       select: import('knex').Knex.QueryBuilder['select']
+      columns: import('knex').Knex.QueryBuilder['columns']
       _timeout: number
     }
   }

--- a/utils/helm/speckle-server/templates/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/_helpers.tpl
@@ -771,6 +771,10 @@ Generate the environment variables for Speckle server and Speckle objects deploy
   value: {{ .Values.db.connectionCreateTimeoutMillis | quote }}
 - name: POSTGRES_CONNECTION_ACQUIRE_TIMEOUT_MILLIS
   value: {{ .Values.db.connectionAcquireTimeoutMillis | quote }}
+{{- if .Values.db.globalKnexSelectTimeout }}
+- name: GLOBAL_KNEX_SELECT_TIMEOUT
+  value: {{ .Values.db.globalKnexSelectTimeout | quote }}
+{{- end}}
 
 - name: PGSSLMODE
   value: "{{ .Values.db.PGSSLMODE }}"

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -241,6 +241,11 @@
           "description": "The maximum time in milliseconds to wait for a new connection to be created in the connection pool. Should be less than the acquisition timeout, as a new connection may need to be created then acquired.",
           "default": 5000
         },
+        "globalKnexSelectTimeout": {
+          "type": "number",
+          "description": "The maximum time in milliseconds to wait for a .select() query to be executed. 0 means disabled",
+          "default": 0
+        },
         "databaseName": {
           "type": "string",
           "description": "(Optional) The name of the Postgres database to which Speckle will connect. Only required for the Database Monitoring utility when the connection string is to a database connection pool and multi-region is disabled, otherwise this value is ignored.",

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -194,6 +194,9 @@ db:
   ## @param db.connectionCreationTimeoutMillis The maximum time in milliseconds to wait for a new connection to be created in the connection pool. Should be less than the acquisition timeout, as a new connection may need to be created then acquired.
   ##
   connectionCreationTimeoutMillis: 5000
+  ## @param db.globalKnexSelectTimeout The maximum time in milliseconds to wait for a .select() query to be executed. 0 means disabled
+  ##
+  globalKnexSelectTimeout: 0
 
   ## @param db.databaseName (Optional) The name of the Postgres database to which Speckle will connect. Only required for the Database Monitoring utility when the connection string is to a database connection pool and multi-region is disabled, otherwise this value is ignored.
   databaseName: ''


### PR DESCRIPTION
https://knexjs.org/guide/query-builder.html#timeout

^this, but globally set on all .select() queries

This is an attempt to deal with the issue where DB connections get taken up by long running queries. Timeout is in ms and can be adjusted through the helm chart