### PR TITLE
fix(fe2): Fix wording of SSO session error page

### DIFF
--- a/packages/frontend-2/pages/workspaces/[slug]/sso/session-error.vue
+++ b/packages/frontend-2/pages/workspaces/[slug]/sso/session-error.vue
@@ -10,9 +10,7 @@
         :name="workspace.name"
         size="xl"
       />
-      <h1 class="text-heading-xl text-center">
-        SSO is required for {{ workspace?.name }}
-      </h1>
+      <h1 class="text-heading-xl text-center">SSO is required for this workspace</h1>
       <div
         class="p-4 rounded-lg border border-outline-2 bg-foundation text-body-xs mb-2"
       >


### PR DESCRIPTION
<img width="603" alt="image" src="https://github.com/user-attachments/assets/5a2703c6-fe89-418f-a389-c9b8939a94ab" />

The name won't be available here, so lets remove the name and make it more generic. 