### PR TITLE
fix(fe2): Add loading indicator to workspace projects table

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/Projects.vue
+++ b/packages/frontend-2/components/settings/workspaces/Projects.vue
@@ -5,7 +5,11 @@
         title="Projects"
         text="Manage projects in your workspace"
       />
+      <div v-if="loading && !projects.length" class="flex justify-center py-8">
+        <CommonLoadingIcon />
+      </div>
       <SettingsSharedProjects
+        v-else
         v-model:search="search"
         :projects="projects"
         :workspace-id="workspaceId"
@@ -50,7 +54,7 @@ const search = ref('')
 const {
   identifier,
   onInfiniteLoad,
-  query: { result }
+  query: { result, loading }
 } = usePaginatedQuery({
   query: settingsWorkspacesProjectsQuery,
   baseVariables: computed(() => ({


### PR DESCRIPTION
Bug reported by Matteo in Discord. During a server slowdown, it showed no projects, but it was actually loading.