### PR TITLE
fix(fe2): admin project list comment threads authorization

### DIFF
--- a/packages/server/modules/comments/services/management.ts
+++ b/packages/server/modules/comments/services/management.ts
@@ -67,13 +67,16 @@ export const authorizeProjectCommentsAccessFactory =
       throw new StreamInvalidAccessError('Stream not found')
     }
 
+    // Check admin access first
+    if (deps.adminOverrideEnabled() && authCtx.role === Roles.Server.Admin) {
+      return project
+    }
+
     let success = true
     if (!project.isPublic && !authCtx.auth) success = false
     if (!project.isPublic && !project.role) success = false
     if (requireProjectRole && !project.role && !project.allowPublicComments)
       success = false
-    if (deps.adminOverrideEnabled() && authCtx.role === Roles.Server.Admin)
-      success = true
 
     if (!success) {
       throw new StreamInvalidAccessError('You are not authorized')


### PR DESCRIPTION
[DISCORD THREAD 
](https://discord.com/channels/726756379083145269/1327282803909591093)

![image](https://github.com/user-attachments/assets/c2107baa-1023-4cf4-a51f-83145b29c2f4)
![image](https://github.com/user-attachments/assets/8526add9-f077-487b-810e-3d8eca07040a)
<img width="877" alt="image" src="https://github.com/user-attachments/assets/5a87a66c-2caa-4bd2-9302-ef181dc75da2" />

I noticed this was also happening on latest. Looking at the network tab, the GQL error `STREAM_INVALID_ACCESS_ERROR` happens when trying to fetch `commentThreads` in the admin project list.

The issue seems to be in `authorizeProjectCommentsAccessFactory` where the admin authorisation check happens after other permission checks, overriding the admin access. 

I've made a fix and opened a PR, but since it's backend code I'd appreciate if @iamcgi , @fabiansgeikinsspeckle or anyone with knowledge on this could sense check this for me.