### PR TITLE
fix(fe2): resolve PortalTarget SSR attribute inheritance warning

### DIFF
--- a/packages/frontend-2/layouts/withRightSidebar.vue
+++ b/packages/frontend-2/layouts/withRightSidebar.vue
@@ -17,11 +17,13 @@
         <div
           class="hidden lg:flex h-full w-[17rem] shrink-0 border-l border-outline-3 bg-foundation-page"
         >
-          <PortalTarget name="right-sidebar">
-            <div class="h-full w-full flex items-center justify-center">
-              <CommonLoadingIcon />
-            </div>
-          </PortalTarget>
+          <ClientOnly>
+            <PortalTarget name="right-sidebar">
+              <div class="h-full w-full flex items-center justify-center">
+                <CommonLoadingIcon />
+              </div>
+            </PortalTarget>
+          </ClientOnly>
         </div>
       </div>
     </div>


### PR DESCRIPTION
I noticed a hydration warning in console, so wrapped PortalTarget with ClientOnly to prevent SSR-related issues.

<img width="871" alt="image" src="https://github.com/user-attachments/assets/dc3d8ea0-cf17-45ee-bcc1-68fe2011962b" />
