### PR TITLE
fix(fe2): prevent duplicate workspace invites during creation

### DIFF
--- a/packages/frontend-2/components/workspace/ProjectList.vue
+++ b/packages/frontend-2/components/workspace/ProjectList.vue
@@ -244,12 +244,17 @@ const onShowSettingsDialog = (target: AvailableSettingsMenuKeys) => {
   settingsDialogTarget.value = target
 }
 
+const hasFinalized = ref(false)
+
 onResult((queryResult) => {
   if (
     queryResult.data?.workspaceBySlug.creationState?.completed === false &&
     queryResult.data.workspaceBySlug.creationState.state
   ) {
     if (import.meta.server) return
+    if (hasFinalized.value) return
+
+    hasFinalized.value = true
     finalizeWizard(
       queryResult.data.workspaceBySlug.creationState.state as WorkspaceWizardState,
       queryResult.data.workspaceBySlug.id


### PR DESCRIPTION
Added a flag to ensure workspace finalisation only occurs once, preventing duplicate invite emails from being sent during the creation flow.