### PR TITLE
feat(viewer): disable disconnect-on-blur in development mode

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/activity.ts
+++ b/packages/frontend-2/lib/viewer/composables/activity.ts
@@ -296,7 +296,11 @@ export function useViewerUserActivityTracking(params: {
 
   const focused = useWindowFocus()
 
+  // Disable disconnect-on-blur behavior in development mode only
+  // For testing multi-user interactions (like follow mode)
   watch(focused, async (newVal) => {
+    if (import.meta.dev) return
+
     if (!newVal) {
       await sendUpdate.emitDisconnected()
     } else {

--- a/packages/frontend-2/lib/viewer/composables/activity.ts
+++ b/packages/frontend-2/lib/viewer/composables/activity.ts
@@ -296,7 +296,7 @@ export function useViewerUserActivityTracking(params: {
 
   const focused = useWindowFocus()
 
-  // Disable disconnect-on-blur behavior in development mode only
+  // Disable disconnect-on-blur behaviour in development mode only
   // For testing multi-user interactions (like follow mode)
   watch(focused, async (newVal) => {
     if (import.meta.dev) return


### PR DESCRIPTION
When testing multi-user interactions locally (like follow mode), the viewer would disconnect users as soon as their browser window lost focus. This made it difficult to test with multiple browser windows on the same machine.

This disables the disconnect-on-blur behaviour in development mode only, with no change to production. 

@fabis94 @Mikehrn I did this so Alex could test some things locally. It doesn't need to actually be merged unless you think it adds value. 