### PR TITLE
feat(server): get request ctx from anywhere + log it w/ db operations

### DIFF
--- a/packages/server/app.ts
+++ b/packages/server/app.ts
@@ -49,7 +49,8 @@ import {
   enableMixpanel,
   getPort,
   getBindAddress,
-  shutdownTimeoutSeconds
+  shutdownTimeoutSeconds,
+  asyncRequestContextEnabled
 } from '@/modules/shared/helpers/envHelper'
 import * as ModulesSetup from '@/modules'
 import { GraphQLContext, Optional } from '@/modules/shared/helpers/typeHelper'
@@ -78,6 +79,7 @@ import type { ReadinessHandler } from '@/healthchecks/types'
 import type ws from 'ws'
 import type { Server as MockWsServer } from 'mock-socket'
 import { SetOptional } from 'type-fest'
+import { initiateRequestContextMiddleware } from '@/logging/requestContext'
 
 const GRAPHQL_PATH = '/graphql'
 
@@ -405,8 +407,13 @@ export async function init() {
 
   app.use(cookieParser())
   app.use(DetermineRequestIdMiddleware)
+  app.use(initiateRequestContextMiddleware)
   app.use(determineClientIpAddressMiddleware)
   app.use(LoggingExpressMiddleware)
+
+  if (asyncRequestContextEnabled()) {
+    startupLogger.info('Async request context tracking enabled 👀')
+  }
 
   if (process.env.COMPRESSION) {
     app.use(compression())

--- a/packages/server/logging/expressLogging.ts
+++ b/packages/server/logging/expressLogging.ts
@@ -10,7 +10,7 @@ import { ensureError, type Optional } from '@speckle/shared'
 import { getRequestParameters, getRequestPath } from '@/modules/core/helpers/server'
 import { get } from 'lodash'
 
-const REQUEST_ID_HEADER = 'x-request-id'
+export const REQUEST_ID_HEADER = 'x-request-id'
 
 const GenerateRequestId: GenReqId = (req: IncomingMessage) => DetermineRequestId(req)
 

--- a/packages/server/logging/requestContext.ts
+++ b/packages/server/logging/requestContext.ts
@@ -1,0 +1,25 @@
+import { REQUEST_ID_HEADER } from '@/logging/expressLogging'
+import { asyncRequestContextEnabled } from '@/modules/shared/helpers/envHelper'
+import type express from 'express'
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+type StorageType = {
+  requestId: string
+}
+
+const storage = asyncRequestContextEnabled()
+  ? new AsyncLocalStorage<StorageType>()
+  : undefined
+
+export const initiateRequestContextMiddleware: express.RequestHandler = (
+  req,
+  _res,
+  next
+) => {
+  const reqId = req.headers[REQUEST_ID_HEADER] || 'unknown'
+  const store: StorageType = { requestId: reqId as string }
+  storage?.enterWith(store)
+  next()
+}
+
+export const getRequestContext = () => storage?.getStore()

--- a/packages/server/modules/shared/helpers/envHelper.ts
+++ b/packages/server/modules/shared/helpers/envHelper.ts
@@ -439,3 +439,7 @@ export const knexAsyncStackTracesEnabled = () => {
   if (!envSet) return undefined
   return getBooleanFromEnv('KNEX_ASYNC_STACK_TRACES_ENABLED')
 }
+
+export const asyncRequestContextEnabled = () => {
+  return getBooleanFromEnv('ASYNC_REQUEST_CONTEXT_ENABLED')
+}

--- a/utils/helm/speckle-server/templates/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/_helpers.tpl
@@ -718,6 +718,11 @@ Generate the environment variables for Speckle server and Speckle objects deploy
   value: {{ .Values.server.migration.movedTo }}
   {{- end }}
 
+{{- if .Values.server.asyncRequestContextEnabled }}
+- name: ASYNC_REQUEST_CONTEXT_ENABLED
+  value: {{ .Values.server.asyncRequestContextEnabled | quote }}
+{{- end}}
+
 # *** No more closures flag - prevents writing to the closure table ***
 - name: FF_NO_CLOSURE_WRITES
   value: {{ .Values.featureFlags.noClosureWrites | quote }}

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -661,6 +661,11 @@
           "description": "The url of the Speckle Automate instance",
           "default": "https://automate.speckle.systems"
         },
+        "asyncRequestContextEnabled": {
+          "type": "boolean",
+          "description": "If enabled, the server will use the async request context for improved log msg correlation",
+          "default": false
+        },
         "gendoAI": {
           "type": "object",
           "properties": {

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -478,6 +478,8 @@ server:
   max_project_models_per_page: 500
   ## @param server.speckleAutomateUrl The url of the Speckle Automate instance
   speckleAutomateUrl: 'https://automate.speckle.systems'
+  ## @param server.asyncRequestContextEnabled If enabled, the server will use the async request context for improved log msg correlation
+  asyncRequestContextEnabled: false
 
   gendoAI:
     ## @param server.gendoAI.apiUrl The url of the Gendo AI application, including protocol.


### PR DESCRIPTION
**Important note:** AsyncLocalStorage will likely cause some kind of performance overhead, but its hard to say how much. Considering the immense benefit this brings I think we should at the very least enable it temporarily when investigating DB & GQL query correlations

![image](https://github.com/user-attachments/assets/eaccbe99-de5b-47d0-a29d-74be9a428c30)
