### PR TITLE
feat(fe2): Add reset date to gendo panel when out of credits

### DIFF
--- a/packages/frontend-2/components/viewer/gendo/Panel.vue
+++ b/packages/frontend-2/components/viewer/gendo/Panel.vue
@@ -20,6 +20,9 @@
         <CommonAlert v-if="!limits" color="danger" size="xs">
           <template #title>No credits available</template>
         </CommonAlert>
+        <CommonAlert v-else-if="isOutOfCredits" color="neutral" size="xs">
+          <template #title>Credits reset on {{ formattedResetDate }}</template>
+        </CommonAlert>
         <div class="flex flex-col gap-y-3">
           <FormTextArea
             v-model="prompt"
@@ -145,6 +148,17 @@ const randomPlaceholder = computed(() => {
 
 const isOutOfCredits = computed(() => {
   return (limits.value?.used || 0) >= (limits.value?.limit || 0)
+})
+
+const formattedResetDate = computed(() => {
+  if (!limits.value?.resetDate) return ''
+
+  const resetDate = new Date(limits.value.resetDate)
+  return resetDate.toLocaleDateString('en-US', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric'
+  })
 })
 
 const enqueMagic = async () => {

--- a/packages/frontend-2/lib/common/generated/gql/graphql.ts
+++ b/packages/frontend-2/lib/common/generated/gql/graphql.ts
@@ -4388,6 +4388,7 @@ export type WorkspaceMutations = {
   join: Workspace;
   leave: Scalars['Boolean']['output'];
   projects: WorkspaceProjectMutations;
+  requestToJoin: Scalars['Boolean']['output'];
   /** Set the default region where project data will be stored. Only available to admins. */
   setDefaultRegion: Workspace;
   update: Workspace;
@@ -4433,6 +4434,11 @@ export type WorkspaceMutationsJoinArgs = {
 
 export type WorkspaceMutationsLeaveArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type WorkspaceMutationsRequestToJoinArgs = {
+  input: WorkspaceRequestToJoinInput;
 };
 
 
@@ -4544,6 +4550,10 @@ export enum WorkspaceProjectsUpdatedMessageType {
   Added = 'ADDED',
   Removed = 'REMOVED'
 }
+
+export type WorkspaceRequestToJoinInput = {
+  workspaceId: Scalars['ID']['input'];
+};
 
 export enum WorkspaceRole {
   Admin = 'ADMIN',
@@ -8133,6 +8143,7 @@ export type WorkspaceMutationsFieldArgs = {
   join: WorkspaceMutationsJoinArgs,
   leave: WorkspaceMutationsLeaveArgs,
   projects: {},
+  requestToJoin: WorkspaceMutationsRequestToJoinArgs,
   setDefaultRegion: WorkspaceMutationsSetDefaultRegionArgs,
   update: WorkspaceMutationsUpdateArgs,
   updateCreationState: WorkspaceMutationsUpdateCreationStateArgs,


### PR DESCRIPTION
Adds a CommonAlert with the reset date when the user is out of credits. 

@benjaminvo I only show this when the user has ran out of credits as the panel is already quite busy, but I can change thsi if you think it should be always shown. 