### PR TITLE
Fix(dui3): catch apollo error on initial workspaces enabled query

### DIFF
--- a/packages/dui3/store/accounts.ts
+++ b/packages/dui3/store/accounts.ts
@@ -156,15 +156,22 @@ export const useAccountStore = defineStore('accountStore', () => {
         }
       })
 
-      // get workspace enabled flag and store it in account
-      const res = await client.query({ query: serverInfoQuery })
+      let workspacesEnabled = false
+      try {
+        // get workspace enabled flag and store it in account
+        const res = await client.query({ query: serverInfoQuery })
+        workspacesEnabled = !!res.data.serverInfo.workspaces.workspacesEnabled
+      } catch (err) {
+        // probably having some local account or client could not established well for some reason!
+        console.log(err)
+      }
 
       apolloClients[acc.id] = client
       newAccs.push({
         accountInfo: acc,
         client,
         isValid: true,
-        workspacesEnabled: !!res.data.serverInfo.workspaces.workspacesEnabled
+        workspacesEnabled
       })
     }
 


### PR DESCRIPTION
I missed to cover this scenario

Tested the main functionality too, all good

BEFORE
![image](https://github.com/user-attachments/assets/b1047412-88ce-46ae-b4f9-643f401661c0)

AFTER - we have good old error properly without borking UI
![image](https://github.com/user-attachments/assets/171b92f7-379c-4cb9-8914-eaf212cde1ba)
