### PR TITLE
fix: handling keys with null values in `@speckle/objectsender`

### DIFF
--- a/packages/objectsender/src/examples/browser/main.ts
+++ b/packages/objectsender/src/examples/browser/main.ts
@@ -117,7 +117,8 @@ function generateTestObject() {
         .map(() => new RandomFoo())
     ]),
     '@(10)chunkedArr': times(100, () => 42),
-    some: new RandomJoe()
+    some: new RandomJoe(),
+    nothing: null
   })
 }
 

--- a/packages/objectsender/src/utils/Serializer.ts
+++ b/packages/objectsender/src/utils/Serializer.ts
@@ -57,7 +57,7 @@ export class Serializer implements IDisposable {
       if (value === undefined || propKey === 'id' || propKey.startsWith('_')) continue
 
       // 1. primitives (numbers, bools, strings)
-      if (typeof value !== 'object') {
+      if (value === null || typeof value !== 'object') {
         traversed[propKey] = value
         continue
       }


### PR DESCRIPTION
## Description & motivation

Bug fix to the `@speckle/objectsender` package, when an object key has `null` value.
 
I originally described the bug on the [forum](https://speckle.community/t/typeerror-l-is-null-objectsender/15907/5)

The `#traverse` method was not handling null values are where throwing a `TypeError value is null` when reaching line 107 because `.speckle_type` couldn't be accessed. 

I've changed it so that `null` values now are caught in line 60 together with other primitives.

I have also updated the test/example case to include a null value to verify my implementation.


## Changes:

- Updated line 60.

## Screenshots:

N/A

## Validation of changes:

- Added `nothing: null` to `generateTestObject()`

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

