### PR TITLE
fix(monitor): amend inactive replication slot query to ignore non-speckle slots

### DIFF
--- a/packages/monitor-deployment/src/observability/metrics/inactiveReplicationSlots.ts
+++ b/packages/monitor-deployment/src/observability/metrics/inactiveReplicationSlots.ts
@@ -16,7 +16,7 @@ export const init: MetricInitializer = (config) => {
         const connectionResults = await client.raw<{
           rows: [{ inactive_replication_slots: string }]
         }>(
-          `SELECT count(*) AS inactive_replication_slots FROM pg_replication_slots WHERE NOT active;`
+          `SELECT count(*) AS inactive_replication_slots FROM pg_replication_slots WHERE slot_type = 'logical' AND (slot_name LIKE 'projectsub_%' OR slot_name LIKE 'userssub_%') AND NOT active;`
         )
         if (!connectionResults.rows.length) {
           logger.error(


### PR DESCRIPTION
## Description & motivation

We have a noisy alert which triggers based on a Postgres internal operation creating a transiently inactive replication slot. The database monitoring metric which tracks inactive replication slots should only focus on slots used by speckle server.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
