### PR TITLE
chore(workspaces): drop defaultLogoIndex

### DIFF
--- a/packages/frontend-2/lib/common/generated/gql/graphql.ts
+++ b/packages/frontend-2/lib/common/generated/gql/graphql.ts
@@ -1141,8 +1141,6 @@ export type LimitedUserWorkspaceRoleArgs = {
 /** Workspace metadata visible to non-workspace members. */
 export type LimitedWorkspace = {
   __typename?: 'LimitedWorkspace';
-  /** Index of fallback workspace logo to use */
-  defaultLogoIndex: Scalars['Int']['output'];
   /** Workspace description */
   description?: Maybe<Scalars['String']['output']>;
   /** Workspace id */
@@ -4179,8 +4177,6 @@ export type Workspace = {
   /** Info about the workspace creation state */
   creationState?: Maybe<WorkspaceCreationState>;
   customerPortalUrl?: Maybe<Scalars['String']['output']>;
-  /** Selected fallback when `logo` not set */
-  defaultLogoIndex: Scalars['Int']['output'];
   /** The default role workspace members will receive for workspace projects. */
   defaultProjectRole: Scalars['String']['output'];
   /**
@@ -4300,7 +4296,6 @@ export type WorkspaceCollection = {
 };
 
 export type WorkspaceCreateInput = {
-  defaultLogoIndex?: InputMaybe<Scalars['Int']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   /** Logo image as base64-encoded string */
   logo?: InputMaybe<Scalars['String']['input']>;
@@ -4700,7 +4695,6 @@ export type WorkspaceTeamFilter = {
 };
 
 export type WorkspaceUpdateInput = {
-  defaultLogoIndex?: InputMaybe<Scalars['Int']['input']>;
   defaultProjectRole?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   discoverabilityEnabled?: InputMaybe<Scalars['Boolean']['input']>;
@@ -7450,7 +7444,6 @@ export type LimitedUserFieldArgs = {
   workspaceRole: LimitedUserWorkspaceRoleArgs,
 }
 export type LimitedWorkspaceFieldArgs = {
-  defaultLogoIndex: {},
   description: {},
   id: {},
   logo: {},
@@ -8196,7 +8189,6 @@ export type WorkspaceFieldArgs = {
   createdAt: {},
   creationState: {},
   customerPortalUrl: {},
-  defaultLogoIndex: {},
   defaultProjectRole: {},
   defaultRegion: {},
   description: {},

--- a/packages/server/assets/workspacesCore/typedefs/workspaces.graphql
+++ b/packages/server/assets/workspacesCore/typedefs/workspaces.graphql
@@ -41,7 +41,6 @@ input WorkspaceCreateInput {
   name: String!
   slug: String
   description: String
-  defaultLogoIndex: Int
   """
   Logo image as base64-encoded string
   """
@@ -57,7 +56,6 @@ input WorkspaceUpdateInput {
   Logo image as base64-encoded string
   """
   logo: String
-  defaultLogoIndex: Int
   defaultProjectRole: String
   domainBasedMembershipProtectionEnabled: Boolean
   discoverabilityEnabled: Boolean
@@ -259,10 +257,6 @@ type Workspace {
   """
   logo: String
   """
-  Selected fallback when `logo` not set
-  """
-  defaultLogoIndex: Int!
-  """
   The default role workspace members will receive for workspace projects.
   """
   defaultProjectRole: String!
@@ -373,10 +367,6 @@ type LimitedWorkspace {
   Optional base64 encoded workspace logo image
   """
   logo: String
-  """
-  Index of fallback workspace logo to use
-  """
-  defaultLogoIndex: Int!
 }
 
 type WorkspaceDomain {

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -1163,8 +1163,6 @@ export type LimitedUserWorkspaceRoleArgs = {
 /** Workspace metadata visible to non-workspace members. */
 export type LimitedWorkspace = {
   __typename?: 'LimitedWorkspace';
-  /** Index of fallback workspace logo to use */
-  defaultLogoIndex: Scalars['Int']['output'];
   /** Workspace description */
   description?: Maybe<Scalars['String']['output']>;
   /** Workspace id */
@@ -4201,8 +4199,6 @@ export type Workspace = {
   /** Info about the workspace creation state */
   creationState?: Maybe<WorkspaceCreationState>;
   customerPortalUrl?: Maybe<Scalars['String']['output']>;
-  /** Selected fallback when `logo` not set */
-  defaultLogoIndex: Scalars['Int']['output'];
   /** The default role workspace members will receive for workspace projects. */
   defaultProjectRole: Scalars['String']['output'];
   /**
@@ -4322,7 +4318,6 @@ export type WorkspaceCollection = {
 };
 
 export type WorkspaceCreateInput = {
-  defaultLogoIndex?: InputMaybe<Scalars['Int']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   /** Logo image as base64-encoded string */
   logo?: InputMaybe<Scalars['String']['input']>;
@@ -4722,7 +4717,6 @@ export type WorkspaceTeamFilter = {
 };
 
 export type WorkspaceUpdateInput = {
-  defaultLogoIndex?: InputMaybe<Scalars['Int']['input']>;
   defaultProjectRole?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   discoverabilityEnabled?: InputMaybe<Scalars['Boolean']['input']>;
@@ -5914,7 +5908,6 @@ export type LimitedUserResolvers<ContextType = GraphQLContext, ParentType extend
 };
 
 export type LimitedWorkspaceResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['LimitedWorkspace'] = ResolversParentTypes['LimitedWorkspace']> = {
-  defaultLogoIndex?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   logo?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -6825,7 +6818,6 @@ export type WorkspaceResolvers<ContextType = GraphQLContext, ParentType extends 
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   creationState?: Resolver<Maybe<ResolversTypes['WorkspaceCreationState']>, ParentType, ContextType>;
   customerPortalUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  defaultLogoIndex?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   defaultProjectRole?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   defaultRegion?: Resolver<Maybe<ResolversTypes['ServerRegionItem']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -1144,8 +1144,6 @@ export type LimitedUserWorkspaceRoleArgs = {
 /** Workspace metadata visible to non-workspace members. */
 export type LimitedWorkspace = {
   __typename?: 'LimitedWorkspace';
-  /** Index of fallback workspace logo to use */
-  defaultLogoIndex: Scalars['Int']['output'];
   /** Workspace description */
   description?: Maybe<Scalars['String']['output']>;
   /** Workspace id */
@@ -4182,8 +4180,6 @@ export type Workspace = {
   /** Info about the workspace creation state */
   creationState?: Maybe<WorkspaceCreationState>;
   customerPortalUrl?: Maybe<Scalars['String']['output']>;
-  /** Selected fallback when `logo` not set */
-  defaultLogoIndex: Scalars['Int']['output'];
   /** The default role workspace members will receive for workspace projects. */
   defaultProjectRole: Scalars['String']['output'];
   /**
@@ -4303,7 +4299,6 @@ export type WorkspaceCollection = {
 };
 
 export type WorkspaceCreateInput = {
-  defaultLogoIndex?: InputMaybe<Scalars['Int']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   /** Logo image as base64-encoded string */
   logo?: InputMaybe<Scalars['String']['input']>;
@@ -4703,7 +4698,6 @@ export type WorkspaceTeamFilter = {
 };
 
 export type WorkspaceUpdateInput = {
-  defaultLogoIndex?: InputMaybe<Scalars['Int']['input']>;
   defaultProjectRole?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   discoverabilityEnabled?: InputMaybe<Scalars['Boolean']['input']>;

--- a/packages/server/modules/workspaces/domain/logic.ts
+++ b/packages/server/modules/workspaces/domain/logic.ts
@@ -69,12 +69,5 @@ export const isWorkspaceRole = (role: string): role is WorkspaceRoles => {
 }
 
 export const toLimitedWorkspace = (workspace: Workspace): LimitedWorkspace => {
-  return pick(workspace, [
-    'id',
-    'slug',
-    'name',
-    'description',
-    'logo',
-    'defaultLogoIndex'
-  ])
+  return pick(workspace, ['id', 'slug', 'name', 'description', 'logo'])
 }

--- a/packages/server/modules/workspaces/domain/operations.ts
+++ b/packages/server/modules/workspaces/domain/operations.ts
@@ -38,7 +38,6 @@ export type UpsertWorkspaceArgs = {
       NullableKeysToOptional<Workspace>,
       | 'domainBasedMembershipProtectionEnabled'
       | 'discoverabilityEnabled'
-      | 'defaultLogoIndex'
       | 'defaultProjectRole'
       | 'slug'
     >,
@@ -51,12 +50,7 @@ export type UpsertWorkspace = (args: UpsertWorkspaceArgs) => Promise<void>
 export type GetUserDiscoverableWorkspaces = (args: {
   domains: string[]
   userId: string
-}) => Promise<
-  Pick<
-    Workspace,
-    'id' | 'name' | 'slug' | 'description' | 'logo' | 'defaultLogoIndex'
-  >[]
->
+}) => Promise<Pick<Workspace, 'id' | 'name' | 'slug' | 'description' | 'logo'>[]>
 
 export type GetWorkspace = (args: {
   workspaceId: string

--- a/packages/server/modules/workspaces/graph/mocks/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/mocks/workspaces.ts
@@ -135,7 +135,6 @@ const config: SpeckleModuleMocksConfig = FF_WORKSPACES_MODULE_ENABLED
                 id: faker.string.uuid(),
                 name: workspaceName(),
                 description: faker.lorem.sentence(),
-                defaultLogoIndex: 0,
                 logo: null
               }
             ]),

--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -510,7 +510,7 @@ export = FF_WORKSPACES_MODULE_ENABLED
       },
       WorkspaceMutations: {
         create: async (_parent, args, context) => {
-          const { name, description, defaultLogoIndex, logo, slug } = args.input
+          const { name, description, logo, slug } = args.input
 
           const createWorkspace = createWorkspaceFactory({
             validateSlug: validateSlugFactory({
@@ -530,8 +530,7 @@ export = FF_WORKSPACES_MODULE_ENABLED
               name,
               slug,
               description: description ?? null,
-              logo: logo ?? null,
-              defaultLogoIndex: defaultLogoIndex ?? 0
+              logo: logo ?? null
             },
             userResourceAccessLimits: context.resourceAccessRules
           })

--- a/packages/server/modules/workspaces/repositories/workspaces.ts
+++ b/packages/server/modules/workspaces/repositories/workspaces.ts
@@ -81,14 +81,7 @@ export const getUserDiscoverableWorkspacesFactory =
     }
     return (await tables
       .workspaces(db)
-      .select(
-        'workspaces.id as id',
-        'name',
-        'slug',
-        'description',
-        'logo',
-        'defaultLogoIndex'
-      )
+      .select('workspaces.id as id', 'name', 'slug', 'description', 'logo')
       .distinctOn('workspaces.id')
       .join('workspace_domains', 'workspace_domains.workspaceId', 'workspaces.id')
       .leftJoin(
@@ -111,7 +104,7 @@ export const getUserDiscoverableWorkspacesFactory =
       .where('verified', true)
       .where('role', null)) as Pick<
       Workspace,
-      'id' | 'name' | 'slug' | 'description' | 'logo' | 'defaultLogoIndex'
+      'id' | 'name' | 'slug' | 'description' | 'logo'
     >[]
   }
 
@@ -237,7 +230,6 @@ export const upsertWorkspaceFactory =
         'description',
         'logo',
         'slug',
-        'defaultLogoIndex',
         'defaultProjectRole',
         'name',
         'updatedAt',

--- a/packages/server/modules/workspaces/rest/sso.ts
+++ b/packages/server/modules/workspaces/rest/sso.ts
@@ -378,7 +378,6 @@ const handleGetLimitedWorkspaceRequestFactory =
     const limitedWorkspace = {
       name: workspace.name,
       logo: workspace.logo,
-      defaultLogoIndex: workspace.defaultLogoIndex,
       ssoProviderName: ssoProviderData?.provider?.providerName
     }
 

--- a/packages/server/modules/workspaces/services/management.ts
+++ b/packages/server/modules/workspaces/services/management.ts
@@ -76,7 +76,6 @@ type WorkspaceCreateArgs = {
     slug?: string | null
     description: string | null
     logo: string | null
-    defaultLogoIndex: number
   }
   userResourceAccessLimits: MaybeNullOrUndefined<TokenResourceIdentifier[]>
 }

--- a/packages/server/modules/workspaces/services/retrieval.ts
+++ b/packages/server/modules/workspaces/services/retrieval.ts
@@ -22,10 +22,7 @@ export const getDiscoverableWorkspacesForUserFactory =
   async ({
     userId
   }: GetDiscoverableWorkspaceForUserArgs): Promise<
-    Pick<
-      Workspace,
-      'id' | 'name' | 'slug' | 'description' | 'logo' | 'defaultLogoIndex'
-    >[]
+    Pick<Workspace, 'id' | 'name' | 'slug' | 'description' | 'logo'>[]
   > => {
     const userEmails = await findEmailsByUserId({ userId })
     const userVerifiedDomains = userEmails

--- a/packages/server/modules/workspaces/tests/helpers/creation.ts
+++ b/packages/server/modules/workspaces/tests/helpers/creation.ts
@@ -140,8 +140,7 @@ export const createTestWorkspace = async (
       name: workspace.name,
       slug: workspace.slug || cryptoRandomString({ length: 10 }),
       description: workspace.description || null,
-      logo: workspace.logo || null,
-      defaultLogoIndex: 0
+      logo: workspace.logo || null
     },
     userResourceAccessLimits: null
   })

--- a/packages/server/modules/workspaces/tests/unit/services/domains.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/services/domains.spec.ts
@@ -21,7 +21,6 @@ describe('workspace domain services', () => {
     it('returns null if the workspace is not domain protected', async () => {
       const isCompliant = await isUserWorkspaceDomainPolicyCompliantFactory({
         getWorkspaceWithDomains: async () => ({
-          defaultLogoIndex: 0,
           name: cryptoRandomString({ length: 10 }),
           logo: null,
           slug: cryptoRandomString({ length: 10 }),
@@ -45,7 +44,6 @@ describe('workspace domain services', () => {
       const domain = 'example.com'
       const isCompliant = await isUserWorkspaceDomainPolicyCompliantFactory({
         getWorkspaceWithDomains: async () => ({
-          defaultLogoIndex: 0,
           name: cryptoRandomString({ length: 10 }),
           logo: null,
           slug: cryptoRandomString({ length: 10 }),

--- a/packages/server/modules/workspaces/tests/unit/services/join.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/services/join.spec.ts
@@ -31,8 +31,7 @@ const createTestWorkspaceWithDomains = (
     domains: [],
     discoverabilityEnabled: false,
     domainBasedMembershipProtectionEnabled: false,
-    defaultProjectRole: Roles.Stream.Contributor,
-    defaultLogoIndex: 0
+    defaultProjectRole: Roles.Stream.Contributor
   }
   if (arg) assign(workspace, arg)
   return workspace

--- a/packages/server/modules/workspaces/tests/unit/services/management.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/services/management.spec.ts
@@ -93,8 +93,7 @@ const getCreateWorkspaceInput = () => {
       description: 'foobar',
       slug: cryptoRandomString({ length: 10 }),
       logo: null,
-      name: cryptoRandomString({ length: 6 }),
-      defaultLogoIndex: 0
+      name: cryptoRandomString({ length: 6 })
     }
   }
 }
@@ -258,7 +257,6 @@ describe('Workspace services', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         logo: null,
-        defaultLogoIndex: 0,
         discoverabilityEnabled: false,
         domainBasedMembershipProtectionEnabled: false,
         defaultProjectRole: 'stream:contributor',
@@ -1094,8 +1092,7 @@ describe('Workspace role services', () => {
                   description: null,
                   discoverabilityEnabled: false,
                   domainBasedMembershipProtectionEnabled: false,
-                  defaultProjectRole: 'stream:contributor',
-                  defaultLogoIndex: 0
+                  defaultProjectRole: 'stream:contributor'
                 }
               },
               getDomains: async () => {
@@ -1135,8 +1132,7 @@ describe('Workspace role services', () => {
           description: null,
           discoverabilityEnabled: false,
           domainBasedMembershipProtectionEnabled: false,
-          defaultProjectRole: 'stream:contributor',
-          defaultLogoIndex: 0
+          defaultProjectRole: 'stream:contributor'
         }
 
         await addDomainToWorkspaceFactory({

--- a/packages/server/modules/workspaces/tests/unit/services/sso.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/services/sso.spec.ts
@@ -381,7 +381,6 @@ describe('Workspace SSO services', () => {
               name: '',
               description: '',
               logo: null,
-              defaultLogoIndex: 0,
               defaultProjectRole: 'stream:contributor',
               domainBasedMembershipProtectionEnabled: false,
               discoverabilityEnabled: false,

--- a/packages/server/modules/workspacesCore/domain/types.ts
+++ b/packages/server/modules/workspacesCore/domain/types.ts
@@ -27,7 +27,6 @@ export type Workspace = {
   createdAt: Date
   updatedAt: Date
   logo: string | null
-  defaultLogoIndex: number
   defaultProjectRole: WorkspaceDefaultProjectRole
   domainBasedMembershipProtectionEnabled: boolean
   discoverabilityEnabled: boolean
@@ -35,7 +34,7 @@ export type Workspace = {
 
 export type LimitedWorkspace = Pick<
   Workspace,
-  'id' | 'slug' | 'name' | 'description' | 'logo' | 'defaultLogoIndex'
+  'id' | 'slug' | 'name' | 'description' | 'logo'
 >
 
 export type WorkspaceWithDomains = Workspace & { domains: WorkspaceDomain[] }

--- a/packages/server/modules/workspacesCore/helpers/db.ts
+++ b/packages/server/modules/workspacesCore/helpers/db.ts
@@ -8,7 +8,6 @@ export const Workspaces = buildTableHelper('workspaces', [
   'createdAt',
   'updatedAt',
   'logo',
-  'defaultLogoIndex',
   'defaultProjectRole',
   'domainBasedMembershipProtectionEnabled',
   'discoverabilityEnabled'

--- a/packages/server/modules/workspacesCore/migrations/20250127110735_drop_default_logo_index.ts
+++ b/packages/server/modules/workspacesCore/migrations/20250127110735_drop_default_logo_index.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('workspaces', (table) => {
+    table.dropColumn('defaultLogoIndex')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('workspaces', (table) => {
+    table.integer('defaultLogoIndex').defaultTo(0).notNullable()
+  })
+}

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -1145,8 +1145,6 @@ export type LimitedUserWorkspaceRoleArgs = {
 /** Workspace metadata visible to non-workspace members. */
 export type LimitedWorkspace = {
   __typename?: 'LimitedWorkspace';
-  /** Index of fallback workspace logo to use */
-  defaultLogoIndex: Scalars['Int']['output'];
   /** Workspace description */
   description?: Maybe<Scalars['String']['output']>;
   /** Workspace id */
@@ -4183,8 +4181,6 @@ export type Workspace = {
   /** Info about the workspace creation state */
   creationState?: Maybe<WorkspaceCreationState>;
   customerPortalUrl?: Maybe<Scalars['String']['output']>;
-  /** Selected fallback when `logo` not set */
-  defaultLogoIndex: Scalars['Int']['output'];
   /** The default role workspace members will receive for workspace projects. */
   defaultProjectRole: Scalars['String']['output'];
   /**
@@ -4304,7 +4300,6 @@ export type WorkspaceCollection = {
 };
 
 export type WorkspaceCreateInput = {
-  defaultLogoIndex?: InputMaybe<Scalars['Int']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   /** Logo image as base64-encoded string */
   logo?: InputMaybe<Scalars['String']['input']>;
@@ -4704,7 +4699,6 @@ export type WorkspaceTeamFilter = {
 };
 
 export type WorkspaceUpdateInput = {
-  defaultLogoIndex?: InputMaybe<Scalars['Int']['input']>;
   defaultProjectRole?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   discoverabilityEnabled?: InputMaybe<Scalars['Boolean']['input']>;

--- a/packages/server/test/speckle-helpers/workspaces.ts
+++ b/packages/server/test/speckle-helpers/workspaces.ts
@@ -16,7 +16,6 @@ export const createAndStoreTestWorkspaceFactory =
       logo: null,
       domainBasedMembershipProtectionEnabled: false,
       discoverabilityEnabled: false,
-      defaultLogoIndex: 0,
       defaultProjectRole: Roles.Stream.Contributor,
       ...workspaceOverrides
     }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Field used to drive the default "space invader" logo for new workspaces.
- Has been disused for some time

## Changes:

- Drops it (RIP 🥲)
