### PR TITLE
fix(fe2): Up limit on objectKeys in ViewerSelectionObject

### DIFF
--- a/packages/frontend-2/components/viewer/selection/Object.vue
+++ b/packages/frontend-2/components/viewer/selection/Object.vue
@@ -288,8 +288,7 @@ const keyValuePairs = computed(() => {
       arrayLength = arr.length
       if (arr.length > 0) {
         innerType = Array.isArray(arr[0]) ? 'array' : typeof arr[0]
-        arrayPreview = arr.slice(0, 3).join(', ')
-        if (arr.length > 10) arrayPreview += ' ...' // in case truncate doesn't hit
+        arrayPreview = arr.slice(0, 100).join(', ')
       }
     }
 

--- a/packages/frontend-2/components/viewer/selection/Object.vue
+++ b/packages/frontend-2/components/viewer/selection/Object.vue
@@ -288,6 +288,7 @@ const keyValuePairs = computed(() => {
       arrayLength = arr.length
       if (arr.length > 0) {
         innerType = Array.isArray(arr[0]) ? 'array' : typeof arr[0]
+        // We truncate this above with css - but limit to 100 to limit dom size
         arrayPreview = arr.slice(0, 100).join(', ')
       }
     }


### PR DESCRIPTION
We don't want to remove the limit completely, incase there are thousand of items. It will be truncated, but the large item will still be in the dom