### PR TITLE
Fix(dui3): unnecessary upgrade prompt for next gen connector after

### DIFF
--- a/packages/dui3/app.vue
+++ b/packages/dui3/app.vue
@@ -11,7 +11,6 @@ import { useMixpanel } from '~/lib/core/composables/mixpanel'
 import { useConfigStore } from '~/store/config'
 import { useAccountStore } from '~/store/accounts'
 import { storeToRefs } from 'pinia'
-import { useUpdateConnector } from '~/lib/core/composables/updateConnector'
 
 const uiConfigStore = useConfigStore()
 const { isDarkTheme } = storeToRefs(uiConfigStore)
@@ -31,15 +30,12 @@ useHead({
   script: import.meta.dev ? ['http://localhost:8098'] : []
 })
 
-onMounted(async () => {
+onMounted(() => {
   const { trackEvent, addConnectorToProfile, identifyProfile } = useMixpanel()
-  const { checkUpdate } = useUpdateConnector()
+  // const { checkUpdate } = useUpdateConnector()
   // TODO: some host apps can open DUI3 automatically, with this case we shouldn't mark track event as `"type": "action"`,
   // we need to get this info from source app. (TBD which apps: Rhino opens automatically, not sure acad, sketchup and revit needs trigger button to init)
   trackEvent('DUI3 Action', { name: 'Launch' })
-
-  // Checks whether new version available for the connector or not and throws a toast notification if any.
-  await checkUpdate()
 
   const { accounts } = useAccountStore()
 

--- a/packages/dui3/app.vue
+++ b/packages/dui3/app.vue
@@ -32,7 +32,6 @@ useHead({
 
 onMounted(() => {
   const { trackEvent, addConnectorToProfile, identifyProfile } = useMixpanel()
-  // const { checkUpdate } = useUpdateConnector()
   // TODO: some host apps can open DUI3 automatically, with this case we shouldn't mark track event as `"type": "action"`,
   // we need to get this info from source app. (TBD which apps: Rhino opens automatically, not sure acad, sketchup and revit needs trigger button to init)
   trackEvent('DUI3 Action', { name: 'Launch' })

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -18,7 +18,10 @@ import type { ConversionResult } from 'lib/conversions/conversionResult'
 import { defineStore } from 'pinia'
 import type { CardSetting } from '~/lib/models/card/setting'
 import { useAccountStore } from '~/store/accounts'
-import type { Version } from '~/lib/core/composables/updateConnector'
+import {
+  useUpdateConnector,
+  type Version
+} from '~/lib/core/composables/updateConnector'
 
 export type ProjectModelGroup = {
   projectId: string
@@ -33,6 +36,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   const { trackEvent } = useMixpanel()
   const { $openUrl } = useNuxtApp()
   const accountsStore = useAccountStore()
+  const { checkUpdate } = useUpdateConnector()
 
   const latestAvailableVersion = ref<Version | null>(null)
 
@@ -461,8 +465,11 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   const getHostAppVersion = async () =>
     (hostAppVersion.value = await app.$baseBinding.getSourceApplicationVersion())
 
-  const getConnectorVersion = async () =>
-    (connectorVersion.value = await app.$baseBinding.getConnectorVersion())
+  const getConnectorVersion = async () => {
+    connectorVersion.value = await app.$baseBinding.getConnectorVersion()
+    // Checks whether new version available for the connector or not and throws a toast notification if any.
+    await checkUpdate()
+  }
 
   /**
    * Used internally in this store store only for initialisation. Refreshed the document info from the host app. Should be called on document changed events.


### PR DESCRIPTION
In some cases in Revit, update notification is triggered and my guess on race condition since we were checking updates `onMounted` of `app.vue`. now it is safer and could fix the same issue in archicad