### PR TITLE
Comment Bubbles WASD Fix

### DIFF
--- a/packages/viewer/src/modules/queries/PointQuerySolver.ts
+++ b/packages/viewer/src/modules/queries/PointQuerySolver.ts
@@ -1,10 +1,13 @@
-import { Vector3 } from 'three'
+import { Frustum, Vector3 } from 'three'
 import SpeckleRenderer from '../SpeckleRenderer.js'
 import type { PointQuery, PointQueryResult } from './Query.js'
 import Logger from '../utils/Logger.js'
 
+const frustumBuf: Frustum = new Frustum()
+const vec3Buff: Vector3 = new Vector3()
+
 export class PointQuerySolver {
-  private renderer!: SpeckleRenderer
+  private renderer: SpeckleRenderer
 
   public setContext(renderer: SpeckleRenderer) {
     this.renderer = renderer
@@ -25,28 +28,51 @@ export class PointQuerySolver {
   private solveProjection(query: PointQuery): PointQueryResult {
     // WORLD
     const projected = new Vector3(query.point.x, query.point.y, query.point.z)
-    if (this.renderer.renderingCamera) projected.project(this.renderer.renderingCamera)
-    else Logger.error('Could not run query. Camera is null')
+    let inFrustum = false
+
+    if (this.renderer.renderingCamera) {
+      /** We need to check frustum inclusion in view space. */
+      vec3Buff.copy(projected)
+      vec3Buff.applyMatrix4(this.renderer.renderingCamera.matrixWorldInverse)
+
+      /** We check in-frustum *before* projection */
+      inFrustum = frustumBuf
+        .setFromProjectionMatrix(this.renderer.renderingCamera.projectionMatrix)
+        .containsPoint(vec3Buff)
+      projected.project(this.renderer.renderingCamera)
+    } else Logger.error('Could not run query. Camera is null')
 
     return {
       // NDC
       x: projected.x,
       y: projected.y,
-      z: projected.z
+      z: projected.z,
+      inFrustum
     }
   }
 
   private solveUnprojection(query: PointQuery): PointQueryResult {
     // NDC
+    let inFrustum = false
     const unprojected = new Vector3(query.point.x, query.point.y, query.point.z)
-    if (this.renderer.renderingCamera)
+    if (this.renderer.renderingCamera) {
       unprojected.unproject(this.renderer.renderingCamera)
-    else Logger.error('Could not run query. Camera is null')
+
+      /** We need to check frustum inclusion in view space. */
+      vec3Buff.copy(unprojected)
+      vec3Buff.applyMatrix4(this.renderer.renderingCamera.matrixWorldInverse)
+
+      /** We check in-frustum *after* projection */
+      inFrustum = frustumBuf
+        .setFromProjectionMatrix(this.renderer.renderingCamera.projectionMatrix)
+        .containsPoint(vec3Buff)
+    } else Logger.error('Could not run query. Camera is null')
     return {
       // WORLD
       x: unprojected.x,
       y: unprojected.y,
-      z: unprojected.z
+      z: unprojected.z,
+      inFrustum
     }
   }
 }

--- a/packages/viewer/src/modules/queries/Query.ts
+++ b/packages/viewer/src/modules/queries/Query.ts
@@ -23,6 +23,7 @@ export interface PointQueryResult {
   y: number
   z?: number
   w?: number
+  inFrustum?: boolean
 }
 
 export interface IntersectionQueryResult {


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation
Handles https://linear.app/speckle/issue/WEB-2591/comment-bubbles-hang-on-on-the-screen-when-wasd-ing by handling https://linear.app/speckle/issue/WEB-2590/projection-query-should-report-out-of-frustum-somehow

- `PointQueryResult` now has an `inFrustum` property which tells if the result is in the camera's frustum
- The frontend uses this new property to determine if comment bubbles need to be occluded tested and displayed at all
- An extra advantage is that we won't be doing extra intersection tests for comment bubbles that are not in view
<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
