### PR TITLE
Feat: Show workspace ID for server admins

### DIFF
--- a/packages/frontend-2/pages/settings/user/profile.vue
+++ b/packages/frontend-2/pages/settings/user/profile.vue
@@ -9,7 +9,7 @@
         <hr class="my-6 md:my-8 border-outline-2" />
         <SettingsUserProfileDeleteAccount :user="user" />
         <hr class="my-6 md:my-8 border-outline-2" />
-        <div class="text-xs text-foreground-2 w-full flex flex-col space-y-2">
+        <div class="text-body-2xs text-foreground-2 w-full flex flex-col space-y-2">
           <div class="flex">
             User ID: #{{ user.id }}
             <ClipboardIcon

--- a/packages/frontend-2/pages/settings/workspaces/[slug]/general.vue
+++ b/packages/frontend-2/pages/settings/workspaces/[slug]/general.vue
@@ -126,6 +126,12 @@
           </div>
         </div>
       </template>
+      <template v-if="isServerAdmin">
+        <hr class="mb-6 mt-8 border-outline-2" />
+        <p class="text-body-2xs text-foreground-2">
+          Workspace ID: #{{ workspaceResult?.workspaceBySlug?.id }}
+        </p>
+      </template>
     </div>
 
     <SettingsWorkspacesGeneralLeaveDialog
@@ -221,6 +227,7 @@ const config = useRuntimeConfig()
 const { hasSsoEnabled, needsSsoLogin } = useWorkspaceSsoStatus({
   workspaceSlug: computed(() => workspaceResult.value?.workspaceBySlug?.slug || '')
 })
+const { isAdmin: isServerAdmin } = useActiveUser()
 
 const name = ref('')
 const slug = ref('')


### PR DESCRIPTION
Add the workspace ID to general settings, only for server admins, similar to how we show to user ID on the profile page. This will make live a lot easier when debugging or looking into issues.

<img width="1459" alt="Screenshot 2025-02-04 at 09 13 49" src="https://github.com/user-attachments/assets/8fa8fca5-8d3a-45b5-acec-b70504f1b868" />
