### PR TITLE
fix(server & preview-service): apply fix #3921 to all db streams

### DIFF
--- a/packages/preview-service/src/server/routes/api.ts
+++ b/packages/preview-service/src/server/routes/api.ts
@@ -38,9 +38,9 @@ const apiRouterFactory = () => {
       })
       // https://knexjs.org/faq/recipes.html#manually-closing-streams
       // https://github.com/knex/knex/issues/2324
-      req.on('close', () => {
-        dbStream.end.bind(dbStream)
-        dbStream.destroy.bind(dbStream)
+      res.on('close', () => {
+        dbStream.end()
+        dbStream.destroy()
       })
 
       const speckleObjStream = new SpeckleObjectsStream(isSimpleTextRequested(req))

--- a/packages/preview-service/src/server/routes/objects.ts
+++ b/packages/preview-service/src/server/routes/objects.ts
@@ -43,9 +43,9 @@ const objectsRouterFactory = () => {
       })
       // https://knexjs.org/faq/recipes.html#manually-closing-streams
       // https://github.com/knex/knex/issues/2324
-      req.on('close', () => {
-        dbStream.end.bind(dbStream)
-        dbStream.destroy.bind(dbStream)
+      res.on('close', () => {
+        dbStream.end()
+        dbStream.destroy()
       })
 
       const speckleObjStream = new SpeckleObjectsStream(isSimpleTextRequested(req))

--- a/packages/server/modules/core/rest/download.ts
+++ b/packages/server/modules/core/rest/download.ts
@@ -65,9 +65,9 @@ export default (app: express.Express) => {
     })
     // https://knexjs.org/faq/recipes.html#manually-closing-streams
     // https://github.com/knex/knex/issues/2324
-    req.on('close', () => {
-      dbStream.end.bind(dbStream)
-      dbStream.destroy.bind(dbStream)
+    res.on('close', () => {
+      dbStream.end()
+      dbStream.destroy()
     })
     const speckleObjStream = new SpeckleObjectsStream(simpleText)
     const gzipStream = zlib.createGzip()


### PR DESCRIPTION
## Description & motivation

Applies https://github.com/specklesystems/speckle-server/pull/3921 to other locations where database streams are present.

## Changes:
- listen to response event, not request event
- `bind` is not required

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
