### PR TITLE
fix(billing): can't be read only if no billing

### DIFF
--- a/packages/server/modules/gatekeeper/graph/resolvers/index.ts
+++ b/packages/server/modules/gatekeeper/graph/resolvers/index.ts
@@ -36,7 +36,8 @@ import { calculateSubscriptionSeats } from '@/modules/gatekeeper/domain/billing'
 import { WorkspacePaymentMethod } from '@/test/graphql/generated/graphql'
 import { LogicError } from '@/modules/shared/errors'
 
-const { FF_GATEKEEPER_MODULE_ENABLED } = getFeatureFlags()
+const { FF_GATEKEEPER_MODULE_ENABLED, FF_BILLING_INTEGRATION_ENABLED } =
+  getFeatureFlags()
 
 const getWorkspacePlan = getWorkspacePlanFactory({ db })
 
@@ -116,6 +117,7 @@ export = FF_GATEKEEPER_MODULE_ENABLED
           return hasAccess
         },
         readOnly: async (parent) => {
+          if (!FF_BILLING_INTEGRATION_ENABLED) return false
           return await isWorkspaceReadOnlyFactory({ getWorkspacePlan })({
             workspaceId: parent.id
           })


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Project creation was globally disabled in environments where billing was disabled (and some other combination of flags)
- This is only relevant in test environments

## Changes:

- Falls back to `readOnly: false` if billing integration is not enabled (see testing3 for current behavior)
