### PR TITLE
Fix(dui3): set timeout for autocad receive

### DIFF
--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -373,7 +373,18 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     model.displayReceiveComplete = false
     model.hasDismissedUpdateWarning = true
     model.progress = { status: 'Starting to receive...' }
-    await app.$receiveBinding.receive(modelCardId)
+
+    // You should stop asking why if you saw anything related autocad..
+    // It solves the press "escape" issue.
+    // Because probably we don't give enough time to acad complete it's previos task and it stucks.
+    const shittyHostApps = ['autocad']
+    if (shittyHostApps.includes(hostAppName.value as string)) {
+      setTimeout(async () => {
+        await app.$receiveBinding.receive(modelCardId)
+      }, 500) // I prefer to sacrifice 500ms
+    } else {
+      await app.$receiveBinding.receive(modelCardId)
+    }
   }
 
   const receiveModelCancel = async (modelCardId: string) => {


### PR DESCRIPTION
as same as send, it is a bit random and rare but sometime UI doesn't send command to acad for receive, seems like settimeout helps as it did with send before