### PR TITLE
fix(ui-components): stop keyboard event propagation in textarea/textinput to prevent triggering viewer controls

### DIFF
--- a/packages/ui-components/src/components/form/TextArea.vue
+++ b/packages/ui-components/src/components/form/TextArea.vue
@@ -37,6 +37,7 @@
         v-bind="$attrs"
         @change="$emit('change', { event: $event, value })"
         @input="$emit('input', { event: $event, value })"
+        @keydown.stop
       />
       <a
         v-if="shouldShowClear"

--- a/packages/ui-components/src/components/form/TextInput.vue
+++ b/packages/ui-components/src/components/form/TextInput.vue
@@ -63,6 +63,7 @@
           @input="$emit('input', { event: $event, value })"
           @focus="$emit('focus')"
           @blur="$emit('blur')"
+          @keydown.stop
         />
       </div>
       <slot name="input-right">


### PR DESCRIPTION
It was reported that the new WASD changes to the viewer were being triggered when users where trying to type in a text area or text input. 

Added `@keydown.stop` to inputs to prevent this. 