### PR TITLE
fix(fe2): Remove debug loading code

### DIFF
--- a/packages/frontend-2/components/viewer/PreSetupWrapper.vue
+++ b/packages/frontend-2/components/viewer/PreSetupWrapper.vue
@@ -56,9 +56,6 @@
 
           <!-- Global loading bar -->
           <ViewerLoadingBar class="absolute -top-2 left-0 w-full z-40 h-30" />
-          <div class="absolute left-0 w-full z-40 h-30 text-center bg-blue-500">
-            test
-          </div>
 
           <!-- Sidebar controls -->
           <Transition


### PR DESCRIPTION
<img width="304" alt="image" src="https://github.com/user-attachments/assets/76a847f9-057b-4d65-b93f-d9eac60b9af4" />

@didimitrie I noticed this div appearing in embedded models. I'm guessing this shouldn't be here, so I removed it, but let me know if it serves a purpose i missed. 