### PR TITLE
chore(server/logging): adds a log line on file upload status change

### DIFF
--- a/packages/server/logging/logging.ts
+++ b/packages/server/logging/logging.ts
@@ -32,6 +32,7 @@ export const automateLogger = extendLoggerComponent(logger, 'automate')
 export const subscriptionLogger = extendLoggerComponent(logger, 'subscription')
 export const healthCheckLogger = extendLoggerComponent(logger, 'healthcheck')
 export const testLogger = extendLoggerComponent(logger, 'test')
+export const fileUploadsLogger = extendLoggerComponent(logger, 'file-uploads')
 
 export type Logger = typeof logger
 export { extendLoggerComponent, Observability }

--- a/packages/server/modules/fileuploads/helpers/errors.ts
+++ b/packages/server/modules/fileuploads/helpers/errors.ts
@@ -1,0 +1,8 @@
+import { BaseError } from '@/modules/shared/errors'
+
+//TODO this represents an internal server error and not a client/user error (e.g. error in a file content)
+export class FileUploadInternalError extends BaseError {
+  static defaultMessage = 'A file upload error occurred.'
+  static code = 'FILE_UPLOAD_ERROR'
+  static statusCode = 500
+}


### PR DESCRIPTION
## Description & motivation

When the server is notified by the file import service that a file upload status has changed, we now log the results of that status change.

## Changes:

- Log the results of file import status change
- Wrap any error changes in a new error type

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
