### PR TITLE
fix(fe2): Fix allowed email deletion cache update

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/security/DomainRemoveDialog.vue
+++ b/packages/frontend-2/components/settings/workspaces/security/DomainRemoveDialog.vue
@@ -17,11 +17,12 @@
 import type { LayoutDialogButton } from '@speckle/ui-components'
 import { useApolloClient } from '@vue/apollo-composable'
 import { graphql } from '~/lib/common/generated/gql'
+import { type SettingsWorkspacesSecurityDomainRemoveDialog_WorkspaceDomainFragment } from '~/lib/common/generated/gql/graphql'
 import {
-  type Workspace,
-  type SettingsWorkspacesSecurityDomainRemoveDialog_WorkspaceDomainFragment
-} from '~/lib/common/generated/gql/graphql'
-import { getCacheId, getFirstErrorMessage } from '~/lib/common/helpers/graphql'
+  getCacheId,
+  getFirstErrorMessage,
+  modifyObjectField
+} from '~/lib/common/helpers/graphql'
 import { settingsDeleteWorkspaceDomainMutation } from '~/lib/settings/graphql/mutations'
 import { useMixpanel } from '~/lib/core/composables/mp'
 import type { MaybeNullOrUndefined } from '@speckle/shared'
@@ -69,16 +70,16 @@ const handleRemove = async () => {
         const { data } = res
         if (!data?.workspaceMutations || !props.workspaceId) return
 
-        cache.modify<Workspace>({
-          id: getCacheId('Workspace', props.workspaceId),
-          fields: {
-            domains(currentDomains, { isReference }) {
-              return [...(currentDomains ?? [])].filter((domain) =>
-                isReference(domain) ? false : domain.id !== props.domain.id
-              )
-            }
+        modifyObjectField(
+          cache,
+          getCacheId('Workspace', props.workspaceId),
+          'domains',
+          ({ value, helpers }) => {
+            return value?.filter(
+              (domain) => helpers.readField(domain, 'id') !== props.domain.id
+            )
           }
-        })
+        )
       }
     })
     .catch(convertThrowIntoFetchResult)


### PR DESCRIPTION
A bug reported by Jonathon in Discord.

https://github.com/user-attachments/assets/e51640f8-c7d5-4184-bad7-ac635537ec45

I wasn't able to recreate the bug where adding a domain adds both from a fresh browser session. I could only recreate it, when I had previously deleted an item. 

This caused both items to be removed from the cache, but only 1 item was actually deleted. A refresh at this point would bring back the other domain. Instead, if you try to add another domain, the new will be added, and the old will reappear.
