### PR TITLE
feat(server): Sanitize nested model names

### DIFF
--- a/packages/frontend-2/lib/projects/helpers/models.ts
+++ b/packages/frontend-2/lib/projects/helpers/models.ts
@@ -22,5 +22,6 @@ export function sanitizeModelName(name: string): string {
   return name
     .split('/')
     .map((part) => part.trim())
+    .filter((part) => part.length > 0)
     .join('/')
 }

--- a/packages/server/modules/core/graph/resolvers/models.ts
+++ b/packages/server/modules/core/graph/resolvers/models.ts
@@ -310,6 +310,17 @@ export = {
         ctx.resourceAccessRules
       )
       const projectDB = await getProjectDbClient({ projectId: args.input.projectId })
+
+      // Sanitize model name by trimming spaces around slashes
+      const sanitizedInput = {
+        ...args.input,
+        name: args.input.name
+          .split('/')
+          .map((part) => part.trim())
+          .filter((part) => part.length > 0)
+          .join('/')
+      }
+
       const createBranchAndNotify = createBranchAndNotifyFactory({
         getStreamBranchByName: getStreamBranchByNameFactory({ db: projectDB }),
         createBranch: createBranchFactory({ db: projectDB }),
@@ -318,7 +329,7 @@ export = {
           publish
         })
       })
-      return await createBranchAndNotify(args.input, ctx.userId!)
+      return await createBranchAndNotify(sanitizedInput, ctx.userId!)
     },
     async update(_parent, args, ctx) {
       await authorizeResolver(


### PR DESCRIPTION
Claire noticed a problem where models with spaces around slashes (e.g., "folder / subfolder") weren't displaying correctly in the tree view, though they appeared fine in card view.

My assumption is that this occurs when models are created through connectors/API, bypassing frontend sanitization.

I added model name sanitization to the backend for consistent handling of nested model names regardless of creation source.

I also added to the frontend sanitization to handle empty segments between slashes.