### PR TITLE
fix(ui-components): Add padding to text input when customIcon is defined

### DIFF
--- a/packages/ui-components/src/components/form/TextInput.vue
+++ b/packages/ui-components/src/components/form/TextInput.vue
@@ -358,6 +358,10 @@ const leadingIconClasses = computed(() => {
 const iconClasses = computed((): string => {
   const classParts: string[] = []
 
+  if (props.customIcon) {
+    classParts.push('pl-8')
+  }
+
   if (!slots['input-right']) {
     if (props.rightIcon || errorMessage.value || shouldShowClear.value) {
       classParts.push('pr-8')


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/75ab9eab-cfa9-4564-bcca-1e0881522be7)
