### PR TITLE
chore(automate): track usage of test automations

### DIFF
--- a/packages/frontend-2/components/project/page/automation/Runs.vue
+++ b/packages/frontend-2/components/project/page/automation/Runs.vue
@@ -22,7 +22,6 @@
 import { usePaginatedQuery } from '~/lib/common/composables/graphql'
 import { graphql } from '~/lib/common/generated/gql'
 import type { ProjectPageAutomationRuns_AutomationFragment } from '~/lib/common/generated/gql/graphql'
-import { useMixpanel } from '~/lib/core/composables/mp'
 import { useTriggerAutomation } from '~/lib/projects/composables/automationManagement'
 import { projectAutomationPagePaginatedRunsQuery } from '~/lib/projects/graphql/queries'
 
@@ -66,18 +65,8 @@ const { identifier, onInfiniteLoad } = usePaginatedQuery({
   resolveCursorFromVariables: (vars) => vars.cursor
 })
 const triggerAutomation = useTriggerAutomation()
-const mixpanel = useMixpanel()
 
 const onTrigger = async () => {
-  const res = await triggerAutomation(props.projectId, props.automation.id)
-  if (res) {
-    mixpanel.track('Automation Run Triggered', {
-      automationId: props.automation.id,
-      automationName: props.automation.name,
-      automationRunId: res,
-      projectId: props.projectId,
-      source: 'manual'
-    })
-  }
+  await triggerAutomation(props.projectId, props.automation.id)
 }
 </script>

--- a/packages/server/modules/automate/domain/operations.ts
+++ b/packages/server/modules/automate/domain/operations.ts
@@ -202,5 +202,5 @@ export type TriggerAutomationRevisionRun = <
 >(params: {
   revisionId: string
   manifest: M
-  source?: RunTriggerSource
+  source: RunTriggerSource
 }) => Promise<{ automationRunId: string }>

--- a/packages/server/modules/automate/graph/resolvers/automate.ts
+++ b/packages/server/modules/automate/graph/resolvers/automate.ts
@@ -718,6 +718,7 @@ export = (FF_AUTOMATE_MODULE_ENABLED
             getBranchLatestCommits: getBranchLatestCommitsFactory({
               db: projectDb
             }),
+            emitEvent: getEventBus().emit,
             validateStreamAccess
           })
 

--- a/packages/server/modules/automate/helpers/types.ts
+++ b/packages/server/modules/automate/helpers/types.ts
@@ -74,8 +74,12 @@ export type AutomateRevisionFunctionRecord = {
 }
 
 export enum RunTriggerSource {
+  /** Triggered in response to an external event like a new version. */
   Automatic = 'automatic',
-  Manual = 'manual'
+  /** Requested directly by the user in-app. */
+  Manual = 'manual',
+  /** Requested as part of a test automation. */
+  Test = 'test'
 }
 
 export const VersionCreationTriggerType = <const>'versionCreation'

--- a/packages/server/modules/automate/index.ts
+++ b/packages/server/modules/automate/index.ts
@@ -14,7 +14,7 @@ import {
   getFullAutomationRunByIdFactory,
   upsertAutomationRunFactory
 } from '@/modules/automate/repositories/automations'
-import { isNonNullable, Scopes, throwUncoveredError } from '@speckle/shared'
+import { isNonNullable, Scopes } from '@speckle/shared'
 import { registerOrUpdateScopeFactory } from '@/modules/shared/repositories/scopes'
 import {
   getFunction,
@@ -49,7 +49,6 @@ import {
 } from '@/modules/core/graph/generated/graphql'
 import {
   isVersionCreatedTriggerManifest,
-  RunTriggerSource,
   VersionCreationTriggerType
 } from '@/modules/automate/helpers/types'
 import { isFinished } from '@/modules/automate/domain/logic'
@@ -338,36 +337,27 @@ const initializeEventListeners = () => {
           projectId: manifest.projectId
         })
 
-        // all triggers, that are automatic result of an action are in a need to be tracked
-        switch (source) {
-          case RunTriggerSource.Automatic: {
-            const userEmail = await getUserEmailFromAutomationRunFactory({
-              getFullAutomationRevisionMetadata:
-                getFullAutomationRevisionMetadataFactory({ db: projectDb }),
-              getFullAutomationRunById: getFullAutomationRunByIdFactory({
-                db: projectDb
-              }),
-              getCommit: getCommitFactory({ db: projectDb }),
-              getUser: legacyGetUserFactory({ db: projectDb })
-            })(automationRun, automation.projectId)
-            const mp = mixpanel({ userEmail, req: undefined })
-            await mp.track('Automation Run Triggered', {
-              automationId: automation.id,
-              automationName: automation.name,
-              automationRunId: automationRun.id,
-              projectId: automation.projectId,
-              source,
-              /* eslint-disable-next-line camelcase */
-              workspace_id: project?.workspaceId
-            })
-            break
-          }
-          // runs created from a user interaction are tracked in the frontend
-          case RunTriggerSource.Manual:
-            return
-          default:
-            throwUncoveredError(source)
-        }
+        const userEmail = await getUserEmailFromAutomationRunFactory({
+          getFullAutomationRevisionMetadata: getFullAutomationRevisionMetadataFactory({
+            db: projectDb
+          }),
+          getFullAutomationRunById: getFullAutomationRunByIdFactory({
+            db: projectDb
+          }),
+          getCommit: getCommitFactory({ db: projectDb }),
+          getUser: legacyGetUserFactory({ db: projectDb })
+        })(automationRun, automation.projectId)
+
+        const mp = mixpanel({ userEmail, req: undefined })
+        await mp.track('Automation Run Triggered', {
+          automationId: automation.id,
+          automationName: automation.name,
+          automationRunId: automationRun.id,
+          projectId: automation.projectId,
+          source,
+          /* eslint-disable-next-line camelcase */
+          workspace_id: project?.workspaceId
+        })
       }
     )
   ]

--- a/packages/server/modules/automate/services/trigger.ts
+++ b/packages/server/modules/automate/services/trigger.ts
@@ -105,7 +105,8 @@ export const onModelVersionCreateFactory =
               projectId,
               modelId: triggeringId,
               triggerType
-            }
+            },
+            source: RunTriggerSource.Automatic
           })
         } catch (error) {
           // TODO: this error should be persisted for automation status display somehow
@@ -226,7 +227,7 @@ export const triggerAutomationRevisionRunFactory =
   async <M extends BaseTriggerManifest = BaseTriggerManifest>(params: {
     revisionId: string
     manifest: M
-    source?: RunTriggerSource
+    source: RunTriggerSource
   }): Promise<{ automationRunId: string }> => {
     const {
       automateRunTrigger,
@@ -237,7 +238,7 @@ export const triggerAutomationRevisionRunFactory =
       getFullAutomationRevisionMetadata,
       getCommit
     } = deps
-    const { revisionId, manifest, source = RunTriggerSource.Automatic } = params
+    const { revisionId, manifest, source } = params
 
     if (!isVersionCreatedTriggerManifest(manifest)) {
       throw new AutomateInvalidTriggerError(


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Tried to check how test automations have been used, turns out we weren't tracking them explicitly.

## Changes:

- Adds `test` to possible sources for "Automation Run Triggered"
- Consolidates all mixpanel calls of this event to backend (removes single call from FE)
- Requires `source` type on backend service to make this possible
