### PR TITLE
Fix: Settings workspace sidebar groups styling

### DIFF
--- a/packages/frontend-2/components/settings/Sidebar.vue
+++ b/packages/frontend-2/components/settings/Sidebar.vue
@@ -81,6 +81,7 @@
                   ? 'TRIAL'
                   : undefined
               "
+              nested
             >
               <template #title-icon>
                 <WorkspaceAvatar

--- a/packages/ui-components/src/components/layout/sidebar/menu/group/Group.vue
+++ b/packages/ui-components/src/components/layout/sidebar/menu/group/Group.vue
@@ -28,8 +28,8 @@
         </div>
         <div class="flex flex-1 items-center truncate justify-between">
           <h6
-            class="font-semibold text-foreground-2 truncate text-body-2xs pr-2"
-            :class="titleClasses"
+            class="truncate text-body-2xs pr-2"
+            :class="[nested ? 'text-foreground' : 'font-semibold text-foreground-2']"
           >
             {{ title }}
           </h6>
@@ -71,7 +71,7 @@ defineProps<{
   iconText?: string
   iconClick?: () => void
   noHover?: boolean
-  titleClasses?: string[]
+  nested?: boolean
 }>()
 
 const isCollapsed = defineModel<boolean>('collapsed')

--- a/packages/ui-components/src/components/layout/sidebar/menu/group/Group.vue
+++ b/packages/ui-components/src/components/layout/sidebar/menu/group/Group.vue
@@ -5,44 +5,39 @@
       class="h-8 flex items-center justify-between select-none rounded-md"
       :class="[collapsible && !noHover && 'hover:bg-highlight-1']"
     >
-      <button
-        v-if="collapsible"
-        class="group flex items-center w-full rounded-md gap-x-1"
-        :class="noHover ? '' : 'py-0.5 px-2'"
-        @click="isCollapsed = !isCollapsed"
+      <component
+        :is="collapsible ? 'button' : 'div'"
+        class="flex items-center w-full"
+        :class="[
+          collapsible ? 'group rounded-md gap-x-1' : 'space-x-1 p-1 text-foreground-2',
+          collapsible && !noHover ? 'py-0.5 px-2' : 'pl-2'
+        ]"
+        @click="collapsible ? (isCollapsed = !isCollapsed) : undefined"
       >
         <ArrowFilled
+          v-if="collapsible"
           :class="[isCollapsed ? '-rotate-90' : '', noHover ? '-ml-1' : '']"
           class="text-foreground-2 shrink-0"
         />
         <div
           v-if="$slots['title-icon']"
-          class="flex items-center justify-center ml-1 mr-2"
+          class="flex items-center justify-center"
+          :class="[collapsible ? 'ml-1 mr-2' : '']"
         >
           <slot name="title-icon"></slot>
         </div>
         <div class="flex flex-1 items-center truncate justify-between">
-          <h6 class="font-semibold text-foreground-2 truncate text-body-2xs pr-2">
+          <h6
+            class="font-semibold text-foreground-2 truncate text-body-2xs pr-2"
+            :class="titleClasses"
+          >
             {{ title }}
           </h6>
           <CommonBadge v-if="tag" rounded>
             {{ tag }}
           </CommonBadge>
         </div>
-      </button>
-      <div v-else class="flex space-x-1 items-center w-full p-1 text-foreground-2 pl-2">
-        <div v-if="$slots['title-icon']" class="flex items-center justify-center">
-          <slot name="title-icon"></slot>
-        </div>
-        <div class="flex flex-1 items-center justify-between truncate">
-          <h6 class="font-semibold text-foreground-2 truncate text-body-2xs pr-2">
-            {{ title }}
-          </h6>
-          <CommonBadge v-if="tag" rounded>
-            {{ tag }}
-          </CommonBadge>
-        </div>
-      </div>
+      </component>
       <button
         v-if="iconClick"
         v-tippy="iconText ? iconText : undefined"
@@ -76,6 +71,7 @@ defineProps<{
   iconText?: string
   iconClick?: () => void
   noHover?: boolean
+  titleClasses?: string[]
 }>()
 
 const isCollapsed = defineModel<boolean>('collapsed')


### PR DESCRIPTION
Adds support for nested groups items, also combines some of the template to avoid duplication

<img width="262" alt="Screenshot 2025-02-17 at 08 20 14" src="https://github.com/user-attachments/assets/731c4def-e6ae-481d-adeb-61bb8de67a49" />
