### PR TITLE
feat(workspaces): remove regular workspace metrics tracking

### DIFF
--- a/packages/server/modules/workspaces/events/eventListener.ts
+++ b/packages/server/modules/workspaces/events/eventListener.ts
@@ -372,7 +372,6 @@ export const workspaceTrackingFactory =
         })
         break
       case 'workspace.updated':
-      case 'workspace.metrics':
         // just updating workspace props
         mixpanel.groups.set(
           'workspace_id',

--- a/packages/server/modules/workspaces/index.ts
+++ b/packages/server/modules/workspaces/index.ts
@@ -1,4 +1,3 @@
-import cron from 'node-cron'
 import { moduleLogger } from '@/logging/logging'
 import { getFeatureFlags } from '@/modules/shared/helpers/envHelper'
 import { registerOrUpdateScopeFactory } from '@/modules/shared/repositories/scopes'
@@ -11,39 +10,9 @@ import { initializeEventListenersFactory } from '@/modules/workspaces/events/eve
 import { validateModuleLicense } from '@/modules/gatekeeper/services/validateLicense'
 import { getSsoRouter } from '@/modules/workspaces/rest/sso'
 import { InvalidLicenseError } from '@/modules/gatekeeper/errors/license'
-import { ScheduleExecution } from '@/modules/core/domain/scheduledTasks/operations'
-import { getWorkspacesFactory } from '@/modules/workspaces/repositories/workspaces'
-import { EventBusEmit, getEventBus } from '@/modules/shared/services/eventBus'
-import { scheduleExecutionFactory } from '@/modules/core/services/taskScheduler'
-import {
-  acquireTaskLockFactory,
-  releaseTaskLockFactory
-} from '@/modules/core/repositories/scheduledTasks'
-import { GetWorkspaces } from '@/modules/workspaces/domain/operations'
 
 const { FF_WORKSPACES_MODULE_ENABLED, FF_WORKSPACES_SSO_ENABLED } = getFeatureFlags()
 
-const scheduleWorkspaceMetricsUpdate = ({
-  scheduleExecution,
-  getWorkspaces,
-  emit
-}: {
-  scheduleExecution: ScheduleExecution
-  getWorkspaces: GetWorkspaces
-  emit: EventBusEmit
-}) => {
-  // run this every hour
-  // but its ok, we're removing this code after the first run
-  const cronExpression = '0 * * * *'
-  return scheduleExecution(cronExpression, 'WorkspaceMetricsUpdate', async () => {
-    const workspaces = await getWorkspaces({ workspaceIds: undefined })
-    for (const workspace of workspaces) {
-      await emit({ eventName: 'workspace.metrics', payload: { workspace } })
-    }
-  })
-}
-
-let scheduledTasks: cron.ScheduledTask[] = []
 let quitListeners: Optional<() => void> = undefined
 
 const initScopes = async () => {
@@ -73,27 +42,12 @@ const workspacesModule: SpeckleModule = {
 
     if (isInitial) {
       quitListeners = initializeEventListenersFactory({ db })()
-      const scheduleExecution = scheduleExecutionFactory({
-        acquireTaskLock: acquireTaskLockFactory({ db }),
-        releaseTaskLock: releaseTaskLockFactory({ db })
-      })
-
-      scheduledTasks = [
-        scheduleWorkspaceMetricsUpdate({
-          scheduleExecution,
-          getWorkspaces: getWorkspacesFactory({ db }),
-          emit: getEventBus().emit
-        })
-      ]
     }
     await Promise.all([initScopes(), initRoles()])
   },
   shutdown() {
     if (!FF_WORKSPACES_MODULE_ENABLED) return
     quitListeners?.()
-    scheduledTasks.forEach((task) => {
-      task.stop()
-    })
   }
 }
 

--- a/packages/server/modules/workspacesCore/domain/events.ts
+++ b/packages/server/modules/workspacesCore/domain/events.ts
@@ -6,7 +6,6 @@ export const workspaceEventNamespace = 'workspace' as const
 const eventPrefix = `${workspaceEventNamespace}.` as const
 
 export const WorkspaceEvents = {
-  Metrics: `${eventPrefix}metrics`,
   Authorized: `${eventPrefix}authorized`,
   Created: `${eventPrefix}created`,
   Updated: `${eventPrefix}updated`,
@@ -39,7 +38,6 @@ type WorkspaceJoinedFromDiscoveryPayload = {
 }
 
 export type WorkspaceEventsPayloads = {
-  [WorkspaceEvents.Metrics]: { workspace: Workspace }
   [WorkspaceEvents.Authorized]: WorkspaceAuthorizedPayload
   [WorkspaceEvents.Created]: WorkspaceCreatedPayload
   [WorkspaceEvents.Updated]: WorkspaceUpdatedPayload


### PR DESCRIPTION
This removes the regular emit of workspace.metrics event for all workspaces. It has done its job, getting all existing ws states into mixpanel, so its not needed any more.