### PR TITLE
fix(fe2): Ensure onboarding is still shown when no force FF is set

### DIFF
--- a/packages/frontend-2/components/onboarding/questions/Form.vue
+++ b/packages/frontend-2/components/onboarding/questions/Form.vue
@@ -15,7 +15,7 @@
           link
           color="subtle"
           full-width
-          @click="setUserOnboardingComplete"
+          @click="setUserOnboardingComplete()"
         >
           Skip
         </FormButton>

--- a/packages/frontend-2/lib/auth/composables/onboarding.ts
+++ b/packages/frontend-2/lib/auth/composables/onboarding.ts
@@ -107,6 +107,7 @@ export const useProcessOnboarding = () => {
         }
       })
       .catch(convertThrowIntoFetchResult)
+    goHome()
   }
 
   /**

--- a/packages/frontend-2/middleware/005-onboarding.global.ts
+++ b/packages/frontend-2/middleware/005-onboarding.global.ts
@@ -7,8 +7,6 @@ import { homeRoute, onboardingRoute } from '~~/lib/common/helpers/route'
  * Redirect user to /onboarding, if they haven't done it yet
  */
 export default defineNuxtRouteMiddleware(async (to) => {
-  const isOnboardingForced = useIsOnboardingForced()
-
   const client = useApolloClientFromNuxt()
   const { data } = await client
     .query({
@@ -18,9 +16,6 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
   // Ignore if not logged in
   if (!data?.activeUser?.id) return
-
-  // Ignore if force onboarding ff is false
-  if (!isOnboardingForced.value) return
 
   // Ignore if user has not verified their email yet
   if (!data?.activeUser?.verified) return


### PR DESCRIPTION
We should still show onboarding during signup flow. We just need to make sure it is skippable. 