### PR TITLE
feat: adds a first party app for the desktop auth service

### DIFF
--- a/packages/server/modules/auth/defaultApps.ts
+++ b/packages/server/modules/auth/defaultApps.ts
@@ -83,7 +83,8 @@ const SpeckleDesktopAuthService = {
   id: DefaultAppIds.SpeckleDesktopAuthService,
   secret: DefaultAppIds.SpeckleDesktopAuthService,
   name: 'Speckle Connector',
-  description: 'Speckle host application conntectors.',
+  description:
+    'Speckle desktop authentication service. This application helps link your Speckle account with all host application connectors, like Revit, Rhino etc.',
   trustByDefault: true,
   public: true,
   redirectUrl: 'http://localhost:29364',

--- a/packages/server/modules/auth/defaultApps.ts
+++ b/packages/server/modules/auth/defaultApps.ts
@@ -12,6 +12,7 @@ export enum DefaultAppIds {
   Explorer = 'explorer',
   DesktopManager = 'sdm',
   Connector = 'sca',
+  SpeckleDesktopAuthService = 'sdas',
   Excel = 'spklexcel',
   PowerBI = 'spklpwerbi',
   Automate = 'spklautoma'
@@ -67,6 +68,25 @@ const SpeckleConnectorApp = {
   trustByDefault: true,
   public: true,
   redirectUrl: 'http://localhost:29363',
+  scopes: [
+    Scopes.Streams.Read,
+    Scopes.Streams.Write,
+    Scopes.Profile.Read,
+    Scopes.Profile.Email,
+    Scopes.Users.Read,
+    Scopes.Users.Invite
+  ]
+}
+
+/** Next gen connectors */
+const SpeckleDesktopAuthService = {
+  id: DefaultAppIds.SpeckleDesktopAuthService,
+  secret: DefaultAppIds.SpeckleDesktopAuthService,
+  name: 'Speckle Connector',
+  description: 'Speckle host application conntectors.',
+  trustByDefault: true,
+  public: true,
+  redirectUrl: 'http://localhost:29364',
   scopes: [
     Scopes.Streams.Read,
     Scopes.Streams.Write,
@@ -140,6 +160,7 @@ const defaultApps = [
   SpeckleApiExplorer,
   SpeckleDesktopApp,
   SpeckleConnectorApp,
+  SpeckleDesktopAuthService,
   SpeckleExcel,
   SpecklePowerBi,
   SpeckleAutomate

--- a/packages/server/modules/auth/tests/apps.graphql.spec.js
+++ b/packages/server/modules/auth/tests/apps.graphql.spec.js
@@ -232,7 +232,7 @@ describe('GraphQL @apps-api', () => {
     expect(res).to.be.json
     expect(res.body.errors).to.not.exist
     expect(res.body.data.apps).to.be.an('array')
-    expect(res.body.data.apps.length).to.equal(8)
+    expect(res.body.data.apps.length).to.equal(9)
   })
 
   it('Should get app info without secret if not authenticated and owner', async () => {

--- a/packages/server/modules/auth/tests/apps.spec.js
+++ b/packages/server/modules/auth/tests/apps.spec.js
@@ -189,7 +189,7 @@ describe('Services @apps-services', () => {
   it('Should get all the public apps on this server', async () => {
     const apps = await getAllPublicApps()
     expect(apps).to.be.an('array')
-    expect(apps.length).to.equal(8)
+    expect(apps.length).to.equal(9)
   })
 
   it('Should fail to register an app with no scopes', async () => {


### PR DESCRIPTION
This pr adds a new first party app that will manage redirects for the new desktop authentication service. We cannot use the old port because manager needs it - therefore a new first party app is born. 