### PR TITLE
fix(server): Object.children() query data values missing sometimes

### DIFF
--- a/packages/server/modules/core/repositories/objects.ts
+++ b/packages/server/modules/core/repositories/objects.ts
@@ -507,7 +507,7 @@ export const getObjectChildrenQueryFactory =
         let k = 0
         for (const field of select || []) {
           const val =
-            o[k++] ?? (uniqueObjs.get(o.id) as Optional<typeof no>)?.data[field]
+            o[k++] ?? (uniqueObjs.get(o.id) as Optional<typeof no>)?.data[field] ?? null
           set(no.data, field, val)
         }
 

--- a/packages/server/modules/core/repositories/objects.ts
+++ b/packages/server/modules/core/repositories/objects.ts
@@ -491,6 +491,9 @@ export const getObjectChildrenQueryFactory =
     if (totalCount === 0) return { totalCount, objects: [], cursor: null }
 
     // Reconstruct the object based on the provided select paths.
+    // Whenever the paths return arrays, the non-array fields end up being null, so we need to reconstruct
+    // them from previous rows, hence the map
+    const uniqueObjs = new Map<string, Record<string, unknown>>()
     if (!fullObjectSelect) {
       rows.forEach((o, i, arr) => {
         const no = {
@@ -498,15 +501,21 @@ export const getObjectChildrenQueryFactory =
           createdAt: o.createdAt,
           speckleType: o.speckleType,
           totalChildrenCount: o.totalChildrenCount,
-          data: {}
+          data: {} as Record<string, unknown>
         }
+
         let k = 0
         for (const field of select || []) {
-          set(no.data, field, o[k++])
+          const val =
+            o[k++] ?? (uniqueObjs.get(o.id) as Optional<typeof no>)?.data[field]
+          set(no.data, field, val)
         }
+
         arr[i] = no
+        uniqueObjs.set(o.id, no)
       })
     }
+    uniqueObjs.clear()
 
     // Assemble the cursor for an eventual next call
     const cursorObj: typeof cursor = {


### PR DESCRIPTION
Nikos reported this issue: https://www.notion.so/speckle/GQL-Material-Quantities-19db78fc7aa6800bbbfadc2a709bdb46

Given this kind of query:
```graphql
query Query($projectId: String!, $objectId: String!, $select: [String], $limit: Int!, $query: [JSONObject!] ) {
  project(id: $projectId) {
    object(id: $objectId) {
      children(select: $select, limit: $limit, query: $query) {
        totalCount
        objects {
          data
        }
      }
    }
  }
}
```

With these kind of params:
```json
{
  "projectId": "e505b3cff9",
  "objectId": "e2f99859d4f112d47e806fad6e6b94fc",
  "select": [
    "category",
    "type",
    "properties.\"Material Quantities\".*.materialName"

  ],
  "limit": 2000,
  "query": [
        {
            "field":"category",
            "value":"Walls",
            "operator":"="
        }
    ],
}
```

If one of the selected fields ( "properties.\"Material Quantities\".*.materialName" in this case) resolves to multiple values, the results will be exploded into multiple SQL rows. But the subsequent rows will not repeat the values of the other fields, the ones that were not an array:

![image](https://github.com/user-attachments/assets/0febafe0-ab15-4b24-8999-6d429aca31a6)

This caused the GQL response to have missing data for those other fields.
![image](https://github.com/user-attachments/assets/fb3c7120-e2b0-45bd-9fe2-2b9fab8573d1)

I fixed this by ensuring these values are copied over from previous entries relating to the same object.