### PR TITLE
fix(frontend): Check for showControls from useEmbed in Viewer

### DIFF
--- a/packages/frontend-2/components/viewer/PreSetupWrapper.vue
+++ b/packages/frontend-2/components/viewer/PreSetupWrapper.vue
@@ -54,12 +54,7 @@
           />
 
           <!-- Sidebar controls -->
-          <Transition
-            enter-from-class="opacity-0"
-            enter-active-class="transition duration-1000"
-          >
-            <ViewerControls class="relative z-20" />
-          </Transition>
+          <ViewerControls v-if="showControls" class="relative z-20" />
 
           <!-- Viewer Object Selection Info Display -->
           <Transition
@@ -135,7 +130,12 @@ const state = useSetupViewer({
 const {
   filters: { hasAnyFiltersApplied }
 } = useFilterUtilities({ state })
-const { isEnabled: isEmbedEnabled, hideSelectionInfo, isTransparent } = useEmbed()
+const {
+  isEnabled: isEmbedEnabled,
+  hideSelectionInfo,
+  isTransparent,
+  showControls
+} = useEmbed()
 
 emit('setup', state)
 


### PR DESCRIPTION
We have an option in embed to toggle controls. The condition for this was removed at some point. I'm re-adding it here. 