### PR TITLE
Fix(dui3): teleport toast manager to body by default

### DIFF
--- a/packages/dui3/app.vue
+++ b/packages/dui3/app.vue
@@ -3,7 +3,7 @@
     <NuxtLayout>
       <NuxtPage />
     </NuxtLayout>
-    <!-- Teleport is fixing the non-clickable toast notifications if any dialog is active. It was marking div as invert and causing the issue -->
+    <!-- Teleport is fixing the non-clickable toast notifications if any dialog is active. It was marking div as inert and causing the issue -->
     <Teleport to="body">
       <SingletonToastManager />
     </Teleport>

--- a/packages/dui3/app.vue
+++ b/packages/dui3/app.vue
@@ -3,7 +3,10 @@
     <NuxtLayout>
       <NuxtPage />
     </NuxtLayout>
-    <SingletonToastManager />
+    <!-- Teleport is fixing the non-clickable toast notifications if any dialog is active. It was marking div as invert and causing the issue -->
+    <Teleport to="body">
+      <SingletonToastManager />
+    </Teleport>
   </div>
 </template>
 <script setup lang="ts">


### PR DESCRIPTION
to get rid of from "inert" dialog div -> kudos to @andrewwallacespeckle 

![image](https://github.com/user-attachments/assets/50fc41d0-78fb-4dbd-a875-cf00eb3c5959)


https://github.com/user-attachments/assets/9b473ac9-d47d-4bd4-8d09-5351a19b9823
