### PR TITLE
refactor(fe): Improve webhooks ux

### DIFF
--- a/packages/frontend-2/components/project/page/settings/webhooks/CreateOrEditDialog.vue
+++ b/packages/frontend-2/components/project/page/settings/webhooks/CreateOrEditDialog.vue
@@ -20,6 +20,32 @@
           type="text"
           color="foundation"
         />
+        <FormSelectMulti
+          v-model="triggers"
+          name="triggers"
+          label="Events"
+          placeholder="Choose events"
+          help="Choose what events will trigger this webhook."
+          :rules="[isMultiItemSelected]"
+          show-label
+          :items="webhookTriggerItems"
+          mount-menu-on-body
+          :label-id="badgesLabelId"
+          :button-id="badgesButtonId"
+          by="id"
+        >
+          <template #something-selected="{ value }">
+            <template v-if="value.length === 1">
+              {{ value[0].text }}
+            </template>
+            <template v-else>{{ value.length }} items selected</template>
+          </template>
+          <template #option="{ item }">
+            <div class="flex items-center w-full">
+              <span class="text-xs text-foreground-2">{{ item.text }}</span>
+            </div>
+          </template>
+        </FormSelectMulti>
         <FormTextInput
           v-model="description"
           label="Webhook name"
@@ -41,21 +67,6 @@
           type="text"
           color="foundation"
         />
-        <FormSelectBadges
-          v-model="triggers"
-          multiple
-          name="triggers"
-          label="Events"
-          placeholder="Choose events"
-          mount-menu-on-body
-          help="Choose what events will trigger this webhook."
-          :rules="[isItemSelected]"
-          show-label
-          :items="webhookTriggerItems"
-          :label-id="badgesLabelId"
-          :button-id="badgesButtonId"
-          by="id"
-        />
       </div>
     </form>
   </LayoutDialog>
@@ -66,7 +77,7 @@ import { useMutation } from '@vue/apollo-composable'
 import { WebhookTriggers } from '@speckle/shared'
 import {
   LayoutDialog,
-  FormSelectBadges,
+  FormSelectMulti,
   type LayoutDialogButton
 } from '@speckle/ui-components'
 import type { WebhookItem, WebhookFormValues } from '~~/lib/projects/helpers/types'
@@ -77,7 +88,7 @@ import {
 import {
   isRequired,
   isUrl,
-  isItemSelected,
+  isMultiItemSelected,
   fullyResetForm
 } from '~~/lib/common/helpers/validation'
 import { useForm } from 'vee-validate'
@@ -88,6 +99,7 @@ import {
 } from '~~/lib/common/helpers/graphql'
 import { useGlobalToast, ToastNotificationType } from '~~/lib/common/composables/toast'
 import type { ValueOf } from 'type-fest'
+import { webhookTriggerDisplayNames } from '~~/lib/projects/composables/webhooks'
 
 const props = defineProps<{
   webhook?: WebhookItem | null
@@ -115,7 +127,7 @@ const badgesButtonId = useId()
 const webhookTriggerItems = computed(() => {
   return Object.values(WebhookTriggers).map((value) => ({
     id: value,
-    text: value
+    text: webhookTriggerDisplayNames[value]
   }))
 })
 

--- a/packages/frontend-2/components/project/page/settings/webhooks/Webhooks.vue
+++ b/packages/frontend-2/components/project/page/settings/webhooks/Webhooks.vue
@@ -136,6 +136,7 @@ import {
   getFirstErrorMessage
 } from '~~/lib/common/helpers/graphql'
 import type { Optional } from '@speckle/shared'
+import { webhookTriggerDisplayNames } from '~~/lib/projects/composables/webhooks'
 
 const projectId = computed(() => route.params.id as string)
 const route = useRoute()
@@ -178,7 +179,11 @@ const getHistoryStatusInfo = (item: WebhookItem) => {
 
 const formatTriggers = (item: WebhookItem): string => {
   return item.triggers
-    .map((event, index, array) => `"${event}"${index < array.length - 1 ? ',' : ''}`)
+    .map((event, index, array) => {
+      const displayName =
+        webhookTriggerDisplayNames[event as keyof typeof webhookTriggerDisplayNames]
+      return `"${displayName}"${index < array.length - 1 ? ',' : ''}`
+    })
     .join(' ')
 }
 

--- a/packages/frontend-2/lib/projects/composables/webhooks.ts
+++ b/packages/frontend-2/lib/projects/composables/webhooks.ts
@@ -1,0 +1,29 @@
+/**
+ * Maps internal webhook trigger names to user-friendly display names.
+ * This maintains the snake_case format but updates terminology:
+ * - 'stream' -> 'project'
+ * - 'branch' -> 'model'
+ * - 'commit' -> 'version'
+ * The original trigger values are preserved for functionality.
+ */
+import { WebhookTriggers } from '@speckle/shared'
+
+export const webhookTriggerDisplayNames: Record<
+  (typeof WebhookTriggers)[keyof typeof WebhookTriggers],
+  string
+> = {
+  [WebhookTriggers.StreamUpdate]: 'project_update',
+  [WebhookTriggers.StreamDelete]: 'project_delete',
+  [WebhookTriggers.BranchCreate]: 'model_create',
+  [WebhookTriggers.BranchUpdate]: 'model_update',
+  [WebhookTriggers.BranchDelete]: 'model_delete',
+  [WebhookTriggers.CommitCreate]: 'version_create',
+  [WebhookTriggers.CommitUpdate]: 'version_update',
+  [WebhookTriggers.CommitReceive]: 'version_receive',
+  [WebhookTriggers.CommitDelete]: 'version_delete',
+  [WebhookTriggers.CommentCreated]: 'comment_created',
+  [WebhookTriggers.CommentArchived]: 'comment_archived',
+  [WebhookTriggers.CommentReplied]: 'comment_replied',
+  [WebhookTriggers.StreamPermissionsAdd]: 'project_permissions_add',
+  [WebhookTriggers.StreamPermissionsRemove]: 'project_permissions_remove'
+}

--- a/packages/ui-components/src/components/form/select/Multi.vue
+++ b/packages/ui-components/src/components/form/select/Multi.vue
@@ -133,6 +133,7 @@
                 </label>
 
                 <div
+                  ref="optionsContainer"
                   class="overflow-auto simple-scrollbar max-h-60 gap-1 flex flex-col"
                 >
                   <div v-if="isAsyncSearchMode && isAsyncLoading" class="px-1">
@@ -220,7 +221,7 @@ import {
 } from '@heroicons/vue/20/solid'
 import { debounce, isArray, isObjectLike } from 'lodash'
 import type { CSSProperties, PropType, Ref } from 'vue'
-import { computed, onMounted, ref, unref, watch } from 'vue'
+import { computed, onMounted, ref, unref, watch, nextTick } from 'vue'
 import type { MaybeAsync, Nullable, Optional } from '@speckle/shared'
 import { useField } from 'vee-validate'
 import type { RuleExpression } from 'vee-validate'
@@ -763,9 +764,14 @@ const isSelected = (item: SingleItem) => {
   return wrappedValue.value.some((v) => itemKey(v) === itemKey(item))
 }
 
+const optionsContainer = ref<HTMLDivElement | null>(null)
+const scrollPosition = ref(0)
+
 const selectItem = (item: SingleItem, event?: Event) => {
   if (props.disabledItemPredicate?.(item)) return
   event?.stopPropagation()
+
+  scrollPosition.value = optionsContainer.value?.scrollTop || 0
 
   const currentValue = wrappedValue.value
   const itemExists = currentValue.some((v) => itemKey(v) === itemKey(item))
@@ -773,6 +779,12 @@ const selectItem = (item: SingleItem, event?: Event) => {
   wrappedValue.value = itemExists
     ? currentValue.filter((v) => itemKey(v) !== itemKey(item))
     : [...currentValue, item]
+
+  void nextTick(() => {
+    if (optionsContainer.value) {
+      optionsContainer.value.scrollTop = scrollPosition.value
+    }
+  })
 }
 
 onClickOutside(


### PR DESCRIPTION
- Reorder items in CreateOrEditDialog so triggers is higher, meaning there is less chance of the dropdown overflowing the dialog
- Use new FormSelectMulti
- Prevent the FormSelectMulti from jumping to the top of the option list on each selection
- Add a mapping function to map the old webhooks names to their new equivalent, without affecting functionality