### PR TITLE
Feat(dui3): trigger create version event

### DIFF
--- a/packages/dui3/lib/bindings/definitions/ISendBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/ISendBinding.ts
@@ -6,6 +6,7 @@ import type {
 import type { CardSetting } from '~/lib/models/card/setting'
 import type { IModelCardSharedEvents } from '~/lib/models/card'
 import type { ConversionResult } from 'lib/conversions/conversionResult'
+import type { CreateVersionArgs } from '~/lib/bridge/server'
 
 export const ISendBindingKey = 'sendBinding'
 
@@ -35,4 +36,5 @@ export interface ISendBindingEvents
    * Use whenever want to cancel model card progress, it is used on Archicad so far since send operation blocks the UI thread.
    */
   triggerCancel: (modelCardId: string) => void
+  triggerCreateVersion: (args: CreateVersionArgs) => void
 }


### PR DESCRIPTION
It is needed for the connectors that send objects via REST API on connector side but do not have graphql logic on its SDK such as C++. It is asked by Ralph for Vectorworks