### PR TITLE
Feat(dui3) send filter form select

### DIFF
--- a/packages/dui3/components/filter/ListSelect.vue
+++ b/packages/dui3/components/filter/ListSelect.vue
@@ -109,6 +109,8 @@ watch(selectedFilterName, (newValue) => {
 })
 
 watch(selectedFilter, (newValue) => {
+  console.log(selectedFilter)
+
   emit('update:filter', newValue)
 })
 </script>

--- a/packages/dui3/components/filter/ListSelect.vue
+++ b/packages/dui3/components/filter/ListSelect.vue
@@ -109,8 +109,6 @@ watch(selectedFilterName, (newValue) => {
 })
 
 watch(selectedFilter, (newValue) => {
-  console.log(selectedFilter)
-
   emit('update:filter', newValue)
 })
 </script>

--- a/packages/dui3/components/filter/ListSelect.vue
+++ b/packages/dui3/components/filter/ListSelect.vue
@@ -44,6 +44,7 @@
       <div v-else-if="selectedFilter.id === 'layers'">TODO</div>
       <div v-else-if="selectedFilter.id === 'revitViews'">
         <FilterFormSelect
+          label="Views"
           :items="(store.revitAvailableViews as ISendFilterSelectItem[])"
           :filter="(selectedFilter as SendFilterSelect)"
           @update:filter="(filter : ISendFilter) => (selectedFilter = filter)"
@@ -57,6 +58,7 @@
       </div>
       <div v-else-if="selectedFilter.id === 'navisworksSavedSets'">
         <FilterFormSelect
+          label="Saved Sets"
           :items="(store.navisworksAvailableSavedSets as ISendFilterSelectItem[])"
           :filter="(selectedFilter as SendFilterSelect)"
           @update:filter="(filter : ISendFilter) => (selectedFilter = filter)"

--- a/packages/dui3/components/filter/ListSelect.vue
+++ b/packages/dui3/components/filter/ListSelect.vue
@@ -55,7 +55,13 @@
           @update:filter="(filter : ISendFilter) => (selectedFilter = filter)"
         />
       </div>
-      <div v-else-if="selectedFilter.id === 'navisworksSavedSets'"></div>
+      <div v-else-if="selectedFilter.id === 'navisworksSavedSets'">
+        <FilterFormSelect
+          :items="(store.navisworksAvailableSavedSets as ISendFilterSelectItem[])"
+          :filter="(selectedFilter as SendFilterSelect)"
+          @update:filter="(filter : ISendFilter) => (selectedFilter = filter)"
+        />
+      </div>
     </div>
     <div v-if="!!filter" class="text-xs caption rounded p-2 bg-orange-500/10">
       This action will replace the existing

--- a/packages/dui3/components/filter/ListSelect.vue
+++ b/packages/dui3/components/filter/ListSelect.vue
@@ -43,8 +43,9 @@
       </div>
       <div v-else-if="selectedFilter.id === 'layers'">TODO</div>
       <div v-else-if="selectedFilter.id === 'revitViews'">
-        <FilterRevitViews
-          :filter="(selectedFilter as RevitViewsSendFilter)"
+        <FilterFormSelect
+          :items="(store.revitAvailableViews as ISendFilterSelectItem[])"
+          :filter="(selectedFilter as SendFilterSelect)"
           @update:filter="(filter : ISendFilter) => (selectedFilter = filter)"
         />
       </div>
@@ -54,6 +55,7 @@
           @update:filter="(filter : ISendFilter) => (selectedFilter = filter)"
         />
       </div>
+      <div v-else-if="selectedFilter.id === 'navisworksSavedSets'"></div>
     </div>
     <div v-if="!!filter" class="text-xs caption rounded p-2 bg-orange-500/10">
       This action will replace the existing
@@ -66,9 +68,10 @@
 import type {
   ISendFilter,
   IDirectSelectionSendFilter,
-  RevitViewsSendFilter,
-  RevitCategoriesSendFilter
-} from 'lib/models/card/send'
+  RevitCategoriesSendFilter,
+  ISendFilterSelectItem,
+  SendFilterSelect
+} from '~/lib/models/card/send'
 import { useHostAppStore } from '~~/store/hostApp'
 import { storeToRefs } from 'pinia'
 

--- a/packages/dui3/components/filter/ListSelect.vue
+++ b/packages/dui3/components/filter/ListSelect.vue
@@ -43,10 +43,8 @@
       </div>
       <div v-else-if="selectedFilter.id === 'layers'">TODO</div>
       <div v-else-if="selectedFilter.id === 'revitViews'">
-        <FilterFormSelect
-          label="Views"
-          :items="(store.revitAvailableViews as ISendFilterSelectItem[])"
-          :filter="(selectedFilter as SendFilterSelect)"
+        <FilterRevitViews
+          :filter="(selectedFilter as RevitViewsSendFilter)"
           @update:filter="(filter : ISendFilter) => (selectedFilter = filter)"
         />
       </div>
@@ -78,7 +76,8 @@ import type {
   IDirectSelectionSendFilter,
   RevitCategoriesSendFilter,
   ISendFilterSelectItem,
-  SendFilterSelect
+  SendFilterSelect,
+  RevitViewsSendFilter
 } from '~/lib/models/card/send'
 import { useHostAppStore } from '~~/store/hostApp'
 import { storeToRefs } from 'pinia'

--- a/packages/dui3/components/filter/form/Select.vue
+++ b/packages/dui3/components/filter/form/Select.vue
@@ -6,8 +6,8 @@
     :search="true"
     :search-placeholder="''"
     :filter-predicate="searchFilterPredicate"
-    name="view"
-    label="View"
+    :label="label"
+    :name="label"
     placeholder="Nothing selected"
     class="w-full"
     fixed-height
@@ -20,7 +20,13 @@
       <span class="text-base text-sm">{{ item.name }}</span>
     </template>
     <template #something-selected="{ value }">
-      <span class="text-primary text-base text-sm">{{ value.name }}</span>
+      <span class="text-primary text-base text-sm">
+        {{
+          filter.isMultiSelectable
+            ? (value as ISendFilterSelectItem[]).map((v) => v.name).join(', ')
+            : (value as ISendFilterSelectItem).name
+        }}
+      </span>
     </template>
   </FormSelectBase>
 </template>
@@ -37,6 +43,7 @@ const emit = defineEmits<{
 }>()
 
 const props = defineProps<{
+  label: string
   filter: SendFilterSelect
   items: ISendFilterSelectItem[]
 }>()

--- a/packages/dui3/components/filter/form/Select.vue
+++ b/packages/dui3/components/filter/form/Select.vue
@@ -1,0 +1,78 @@
+<template>
+  <FormSelectBase
+    key="id"
+    v-model="selectedItems"
+    :items="items"
+    :search="true"
+    :search-placeholder="''"
+    :filter-predicate="searchFilterPredicate"
+    name="view"
+    label="View"
+    placeholder="Nothing selected"
+    class="w-full"
+    fixed-height
+    show-label
+    :allow-unset="false"
+    mount-menu-on-body
+    :multiple="filter.isMultiSelectable"
+  >
+    <template #option="{ item }">
+      <span class="text-base text-sm">{{ item.name }}</span>
+    </template>
+    <template #something-selected="{ value }">
+      <span class="text-primary text-base text-sm">{{ value.name }}</span>
+    </template>
+  </FormSelectBase>
+</template>
+
+<script setup lang="ts">
+import type {
+  ISendFilter,
+  SendFilterSelect,
+  ISendFilterSelectItem
+} from '~/lib/models/card/send'
+
+const emit = defineEmits<{
+  (e: 'update:filter', filter: ISendFilter): void
+}>()
+
+const props = defineProps<{
+  filter: SendFilterSelect
+  items: ISendFilterSelectItem[]
+}>()
+
+const selectedItems = ref<ISendFilterSelectItem[]>(props.filter.selectedItems)
+
+const searchFilterPredicate = (item: ISendFilterSelectItem, search: string) =>
+  item.name.toLocaleLowerCase().includes(search.toLocaleLowerCase())
+
+watch(
+  selectedItems,
+  (newValue) => {
+    // At first it trigger undefined change
+    if (!newValue) {
+      return
+    }
+    // unless isMultiSelectable, newValue arrives as ISendFilterSelectItem
+    if (!Array.isArray(newValue)) {
+      console.log(newValue)
+
+      const filter = { ...props.filter } as SendFilterSelect
+      filter.selectedItems = [newValue]
+      filter.summary = (newValue as ISendFilterSelectItem).name
+      emit('update:filter', filter)
+      return
+    }
+
+    // if isMultiSelectable, newValue arrives as ISendFilterSelectItem[]
+    const filter = { ...props.filter } as SendFilterSelect
+    filter.selectedItems = newValue as ISendFilterSelectItem[]
+    filter.summary = props.filter.isMultiSelectable
+      ? newValue.map((v) => v.name).join(', ')
+      : newValue[0].name
+
+    emit('update:filter', filter)
+  },
+  { deep: true, immediate: true }
+)
+</script>

--- a/packages/dui3/components/filter/form/Select.vue
+++ b/packages/dui3/components/filter/form/Select.vue
@@ -62,8 +62,6 @@ watch(
     }
     // unless isMultiSelectable, newValue arrives as ISendFilterSelectItem
     if (!Array.isArray(newValue)) {
-      console.log(newValue)
-
       const filter = { ...props.filter } as SendFilterSelect
       filter.selectedItems = [newValue]
       filter.summary = (newValue as ISendFilterSelectItem).name

--- a/packages/dui3/components/filter/form/Select.vue
+++ b/packages/dui3/components/filter/form/Select.vue
@@ -1,6 +1,5 @@
 <template>
   <FormSelectBase
-    key="id"
     v-model="selectedItems"
     :items="items"
     :search="true"
@@ -15,6 +14,7 @@
     :allow-unset="false"
     mount-menu-on-body
     :multiple="filter.isMultiSelectable"
+    by="id"
   >
     <template #option="{ item }">
       <span class="text-base text-sm">{{ item.name }}</span>

--- a/packages/dui3/components/filter/revit/Views.vue
+++ b/packages/dui3/components/filter/revit/Views.vue
@@ -12,7 +12,7 @@
       class="w-full"
       fixed-height
       show-label
-      :items="store.revitAvailableViews?.map((v) => v.name)"
+      :items="store.availableViews"
       :allow-unset="false"
       mount-menu-on-body
     >

--- a/packages/dui3/components/filter/revit/Views.vue
+++ b/packages/dui3/components/filter/revit/Views.vue
@@ -12,7 +12,7 @@
       class="w-full"
       fixed-height
       show-label
-      :items="store.availableViews"
+      :items="store.revitAvailableViews?.map((v) => v.name)"
       :allow-unset="false"
       mount-menu-on-body
     >

--- a/packages/dui3/lib/models/card/send.ts
+++ b/packages/dui3/lib/models/card/send.ts
@@ -26,7 +26,7 @@ export interface ISendFilter extends IDiscriminatedObject {
 
 export interface IDirectSelectionSendFilter extends ISendFilter {}
 
-export interface RevitViewsSendFilter extends SendFilterSelect {
+export interface RevitViewsSendFilter extends ISendFilter {
   selectedView: string
   availableViews: string[]
 }
@@ -36,8 +36,10 @@ export type ISendFilterSelectItem = {
   id: string
 }
 
-export interface CategoriesData extends ISendFilterSelectItem {}
-export interface NavisworksSavedSetsData extends ISendFilterSelectItem {} // TODO: check type names are important or not? Previously it was with Discriminated object
+export type CategoriesData = {
+  name: string
+  id: string
+}
 
 export interface RevitCategoriesSendFilter extends ISendFilter {
   selectedCategories: string[]
@@ -49,8 +51,6 @@ export interface SendFilterSelect extends ISendFilter {
   selectedItems: ISendFilterSelectItem[]
   items: ISendFilterSelectItem[]
 }
-
-export interface NavisworksSavedSetsSendFilter extends SendFilterSelect {}
 
 export class SenderModelCard extends ModelCard implements ISenderModelCard {
   sendFilter?: ISendFilter | undefined

--- a/packages/dui3/lib/models/card/send.ts
+++ b/packages/dui3/lib/models/card/send.ts
@@ -26,19 +26,33 @@ export interface ISendFilter extends IDiscriminatedObject {
 
 export interface IDirectSelectionSendFilter extends ISendFilter {}
 
-export interface RevitViewsSendFilter extends ISendFilter {
+export interface RevitViewsSendFilter extends SendFilterSelect {
   selectedView: string
   availableViews: string[]
 }
 
-export interface CategoriesData {
+export type ISendFilterSelectItem = {
   name: string
   id: string
 }
 
+export interface CategoriesData extends ISendFilterSelectItem {}
+export interface NavisworksSavedSetsData extends ISendFilterSelectItem {} // TODO: check type names are important or not? Previously it was with Discriminated object
+
 export interface RevitCategoriesSendFilter extends ISendFilter {
   selectedCategories: string[]
   availableCategories: CategoriesData[]
+}
+
+export interface SendFilterSelect extends ISendFilter {
+  isMultiSelectable: boolean
+  selectedItems: ISendFilterSelectItem[]
+  items: ISendFilterSelectItem[]
+}
+
+export interface NavisworksSavedSetsSendFilter extends ISendFilter {
+  selectedSavedSet: string
+  availableCategories: NavisworksSavedSetsData[]
 }
 
 export class SenderModelCard extends ModelCard implements ISenderModelCard {

--- a/packages/dui3/lib/models/card/send.ts
+++ b/packages/dui3/lib/models/card/send.ts
@@ -50,10 +50,7 @@ export interface SendFilterSelect extends ISendFilter {
   items: ISendFilterSelectItem[]
 }
 
-export interface NavisworksSavedSetsSendFilter extends ISendFilter {
-  selectedSavedSet: string
-  availableCategories: NavisworksSavedSetsData[]
-}
+export interface NavisworksSavedSetsSendFilter extends SendFilterSelect {}
 
 export class SenderModelCard extends ModelCard implements ISenderModelCard {
   sendFilter?: ISendFilter | undefined

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -8,6 +8,7 @@ import type { IReceiverModelCard } from '~/lib/models/card/receiver'
 import type {
   IDirectSelectionSendFilter,
   ISendFilter,
+  ISendFilterSelectItem,
   ISenderModelCard,
   RevitViewsSendFilter
 } from 'lib/models/card/send'
@@ -53,7 +54,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   const documentInfo = ref<DocumentInfo>()
   const documentModelStore = ref<DocumentModelStore>({ models: [] })
 
-  const availableViews = ref<string[]>()
+  const revitAvailableViews = ref<ISendFilterSelectItem[]>()
 
   const dismissNotification = () => {
     currentNotification.value = null
@@ -532,7 +533,9 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
       (f) => f.id === 'revitViews'
     ) as RevitViewsSendFilter
     if (revitViews) {
-      availableViews.value = revitViews.availableViews
+      revitAvailableViews.value = revitViews.availableViews.map(
+        (v) => ({ id: v, name: v } as ISendFilterSelectItem) // this is shit backward compatibility...
+      )
     }
   }
 
@@ -639,7 +642,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     currentNotification,
     showErrorDialog,
     hostAppError,
-    availableViews,
+    revitAvailableViews,
     setNotification,
     setModelError,
     setLatestAvailableVersion,

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -55,7 +55,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   const documentInfo = ref<DocumentInfo>()
   const documentModelStore = ref<DocumentModelStore>({ models: [] })
 
-  const revitAvailableViews = ref<ISendFilterSelectItem[]>()
+  const availableViews = ref<string[]>() // TODO: later we can align views with -> const revitAvailableViews = ref<ISendFilterSelectItem[]>()
   const navisworksAvailableSavedSets = ref<ISendFilterSelectItem[]>()
 
   const dismissNotification = () => {
@@ -535,9 +535,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
       (f) => f.id === 'revitViews'
     ) as RevitViewsSendFilter
     if (revitViews) {
-      revitAvailableViews.value = revitViews.availableViews.map(
-        (v) => ({ id: v, name: v } as ISendFilterSelectItem) // this is shit backward compatibility...
-      )
+      availableViews.value = revitViews.availableViews
     }
 
     const navisworksSavedSetsFromSendFilters = sendFilters.value.find(
@@ -651,7 +649,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     currentNotification,
     showErrorDialog,
     hostAppError,
-    revitAvailableViews,
+    availableViews,
     navisworksAvailableSavedSets,
     setNotification,
     setModelError,

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -10,8 +10,8 @@ import type {
   ISendFilter,
   ISendFilterSelectItem,
   ISenderModelCard,
-  NavisworksSavedSetsSendFilter,
-  RevitViewsSendFilter
+  RevitViewsSendFilter,
+  SendFilterSelect
 } from 'lib/models/card/send'
 import type { ToastNotification } from '@speckle/ui-components'
 import type { Nullable } from '@speckle/shared'
@@ -540,7 +540,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
 
     const navisworksSavedSetsFromSendFilters = sendFilters.value.find(
       (f) => f.id === 'navisworksSavedSets'
-    ) as NavisworksSavedSetsSendFilter
+    ) as SendFilterSelect
     if (navisworksSavedSetsFromSendFilters) {
       navisworksAvailableSavedSets.value = navisworksSavedSetsFromSendFilters.items
     }

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -10,6 +10,7 @@ import type {
   ISendFilter,
   ISendFilterSelectItem,
   ISenderModelCard,
+  NavisworksSavedSetsSendFilter,
   RevitViewsSendFilter
 } from 'lib/models/card/send'
 import type { ToastNotification } from '@speckle/ui-components'
@@ -55,6 +56,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   const documentModelStore = ref<DocumentModelStore>({ models: [] })
 
   const revitAvailableViews = ref<ISendFilterSelectItem[]>()
+  const navisworksAvailableSavedSets = ref<ISendFilterSelectItem[]>()
 
   const dismissNotification = () => {
     currentNotification.value = null
@@ -537,6 +539,13 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         (v) => ({ id: v, name: v } as ISendFilterSelectItem) // this is shit backward compatibility...
       )
     }
+
+    const navisworksSavedSetsFromSendFilters = sendFilters.value.find(
+      (f) => f.id === 'navisworksSavedSets'
+    ) as NavisworksSavedSetsSendFilter
+    if (navisworksSavedSetsFromSendFilters) {
+      navisworksAvailableSavedSets.value = navisworksSavedSetsFromSendFilters.items
+    }
   }
 
   const getSendSettings = async () => {
@@ -643,6 +652,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     showErrorDialog,
     hostAppError,
     revitAvailableViews,
+    navisworksAvailableSavedSets,
     setNotification,
     setModelError,
     setLatestAvailableVersion,


### PR DESCRIPTION
Well, we should have done this at the first place. I am triggered by navis saved sets and there will be more (in navis) single dropdown kind of send filters.

**Important note: I initially was testing with RevitViews. It works OK but I need to deal with backward compatibility etc to make sure it will work nicely with existing model cards.**

No more Revit Views changes

Related sharp connectors PR -> https://github.com/specklesystems/speckle-sharp-connectors/pull/619

![image](https://github.com/user-attachments/assets/c3d8de00-ffdf-4782-ae91-2ae363d5b09a)

![image](https://github.com/user-attachments/assets/bf7c411f-b93b-45ba-9226-6bb08f9f677e)

![image](https://github.com/user-attachments/assets/f55cfae2-e19b-45d6-80de-44fb4662546c)

