### PR TITLE
fix(automate): defer showing header until automate tab query finishes

### DIFF
--- a/packages/dui3/lib/common/generated/gql/graphql.ts
+++ b/packages/dui3/lib/common/generated/gql/graphql.ts
@@ -4557,6 +4557,7 @@ export enum WorkspacePlans {
   Academia = 'academia',
   Business = 'business',
   BusinessInvoiced = 'businessInvoiced',
+  Free = 'free',
   Plus = 'plus',
   PlusInvoiced = 'plusInvoiced',
   Starter = 'starter',
@@ -4587,6 +4588,11 @@ export type WorkspaceProjectInviteCreateInput = {
 export type WorkspaceProjectMutations = {
   __typename?: 'WorkspaceProjectMutations';
   create: Project;
+  /**
+   * Update project region and move all regional data to new db.
+   * TODO: Currently performs all operations synchronously in request, should probably be scheduled.
+   */
+  moveToRegion: Project;
   moveToWorkspace: Project;
   updateRole: Project;
 };
@@ -4594,6 +4600,12 @@ export type WorkspaceProjectMutations = {
 
 export type WorkspaceProjectMutationsCreateArgs = {
   input: WorkspaceProjectCreateInput;
+};
+
+
+export type WorkspaceProjectMutationsMoveToRegionArgs = {
+  projectId: Scalars['String']['input'];
+  regionKey: Scalars['String']['input'];
 };
 
 

--- a/packages/frontend-2/components/project/page/automations/Header.vue
+++ b/packages/frontend-2/components/project/page/automations/Header.vue
@@ -3,7 +3,7 @@
     class="flex flex-col gap-y-2 md:gap-y-0 md:flex-row md:justify-between md:items-center"
   >
     <h1 class="block text-heading-xl">Automations</h1>
-    <div v-if="!showEmptyState" class="flex flex-col gap-2 md:flex-row md:items-center">
+    <div v-if="showHeader" class="flex flex-col gap-2 md:flex-row md:items-center">
       <FormTextInput
         name="search"
         color="foundation"
@@ -41,7 +41,7 @@ defineEmits<{
 
 const props = defineProps<{
   workspaceSlug?: string
-  showEmptyState?: boolean
+  showHeader?: boolean
   creationDisabledMessage?: string
 }>()
 

--- a/packages/frontend-2/components/project/page/automations/Tab.vue
+++ b/packages/frontend-2/components/project/page/automations/Tab.vue
@@ -3,7 +3,7 @@
     <ProjectPageAutomationsHeader
       v-model:search="search"
       :workspace-slug="workspace?.slug"
-      :show-empty-state="shouldShowEmptyState"
+      :show-header="!shouldShowEmptyState && !loading"
       :creation-disabled-message="disableCreateAutomationMessage"
       @new-automation="onNewAutomation"
     />

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -4579,6 +4579,7 @@ export enum WorkspacePlans {
   Academia = 'academia',
   Business = 'business',
   BusinessInvoiced = 'businessInvoiced',
+  Free = 'free',
   Plus = 'plus',
   PlusInvoiced = 'plusInvoiced',
   Starter = 'starter',

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -4560,6 +4560,7 @@ export enum WorkspacePlans {
   Academia = 'academia',
   Business = 'business',
   BusinessInvoiced = 'businessInvoiced',
+  Free = 'free',
   Plus = 'plus',
   PlusInvoiced = 'plusInvoiced',
   Starter = 'starter',

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -4561,6 +4561,7 @@ export enum WorkspacePlans {
   Academia = 'academia',
   Business = 'business',
   BusinessInvoiced = 'businessInvoiced',
+  Free = 'free',
   Plus = 'plus',
   PlusInvoiced = 'plusInvoiced',
   Starter = 'starter',


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- The header buttons on the automate tab are useless/confusing while the tab's gql query is loading
- Some users have interacted with it in this state, which leads to even more confusing behavior

## Changes:

- Hides the header until loading is finished

This can be safely tested with gql mocks.