### PR TITLE
chore(sso): clearer sso user taken error

### DIFF
--- a/packages/server/modules/workspaces/errors/sso.ts
+++ b/packages/server/modules/workspaces/errors/sso.ts
@@ -1,3 +1,5 @@
+import { UserEmail } from '@/modules/core/domain/userEmails/types'
+import { User } from '@/modules/core/domain/users/types'
 import { BaseError } from '@/modules/shared/errors/base'
 
 export class SsoSessionMissingOrExpiredError extends BaseError {
@@ -69,6 +71,22 @@ export class SsoUserClaimedError extends BaseError {
   static defaultMessage =
     'OIDC provider user already associated with another Speckle account.'
   static code = 'SSO_USER_ALREADY_CLAIMED_ERROR'
+  constructor(params: {
+    currentUser: User
+    currentUserEmails: UserEmail[]
+    existingUser: User
+    existingUserEmails: UserEmail[]
+  }) {
+    super(
+      [
+        'User from SSO provider already exists as another Speckle user.',
+        `Currently signed in as ${params.currentUser.name}`,
+        `(${params.currentUserEmails.map((record) => record.email).join(',')})`,
+        `but attempted to sign in as ${params.existingUser.name}`,
+        `(${params.existingUserEmails.map((record) => record.email).join(',')})`
+      ].join(' ')
+    )
+  }
 }
 
 export class SsoUserInviteRequiredError extends BaseError {

--- a/packages/server/modules/workspaces/errors/sso.ts
+++ b/packages/server/modules/workspaces/errors/sso.ts
@@ -75,7 +75,7 @@ export class SsoUserClaimedError extends BaseError {
     currentUser: User
     currentUserEmails: UserEmail[]
     existingUser: User
-    existingUserEmails: UserEmail[]
+    existingUserEmail: string
   }) {
     super(
       [
@@ -83,7 +83,7 @@ export class SsoUserClaimedError extends BaseError {
         `Currently signed in as ${params.currentUser.name}`,
         `(${params.currentUserEmails.map((record) => record.email).join(',')})`,
         `but attempted to sign in as ${params.existingUser.name}`,
-        `(${params.existingUserEmails.map((record) => record.email).join(',')})`
+        `(${params.existingUserEmail})`
       ].join(' ')
     )
   }

--- a/packages/server/modules/workspaces/rest/sso.ts
+++ b/packages/server/modules/workspaces/rest/sso.ts
@@ -719,14 +719,12 @@ const tryGetSpeckleUserDataFactory =
         const currentSessionUserEmails = await getUserEmails({
           userId: currentSessionUser.id
         })
-        const existingSpeckleUserEmails = await getUserEmails({
-          userId: existingSpeckleUser.id
-        })
+
         throw new SsoUserClaimedError({
           currentUser: currentSessionUser,
           currentUserEmails: currentSessionUserEmails,
           existingUser: existingSpeckleUser,
-          existingUserEmails: existingSpeckleUserEmails
+          existingUserEmail: providerEmail
         })
       }
     }


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- When using workspace SSO, if the provider user already exists on the Speckle server, we cannot sign you in as them.
- The current error does not provide enough information.

## Changes:

- Tells user (post successful SSO auth flow) more specifically what has happened:
  - Who they are currently signed in as
  - Who they attempted to sign in as

![Screen Shot 2025-02-24 at 10 51 48](https://github.com/user-attachments/assets/36bc1a93-cd56-4f61-894b-e2bc9b639d98)
