### PR TITLE
chore(tests): multiregion test config waits

### DIFF
--- a/packages/server/test/hooks.ts
+++ b/packages/server/test/hooks.ts
@@ -22,7 +22,8 @@ import {
   MaybeAsync,
   MaybeNullOrUndefined,
   Nullable,
-  Optional
+  Optional,
+  wait
 } from '@speckle/shared'
 import * as mocha from 'mocha'
 import {
@@ -198,6 +199,8 @@ export const resetPubSubFactory = (deps: { db: Knex }) => async () => {
     await deps.db.raw(
       `SELECT * FROM aiven_extras.pg_alter_subscription_disable('${info.subname}');`
     )
+    // If we do not wait, the following call occasionally fails because a replication slot is still in use.
+    await wait(250)
     await deps.db.raw(
       `SELECT * FROM aiven_extras.pg_drop_subscription('${info.subname}');`
     )


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Current multiregion test config appears to be a bit flaky during setup

## Changes:

- Re-introduces manual wait during setup/teardown processes