### PR TITLE
refactor(fe): Update onboarding middleware to not run on auth pages

### DIFF
--- a/packages/frontend-2/middleware/005-onboarding.global.ts
+++ b/packages/frontend-2/middleware/005-onboarding.global.ts
@@ -14,6 +14,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
     })
     .catch(convertThrowIntoFetchResult)
 
+  const isAuthPage = to.path.startsWith('/authn/')
+  if (isAuthPage) return
+
   // Ignore if not logged in
   if (!data?.activeUser?.id) return
 


### PR DESCRIPTION
We should return from onboarding middleware early if on an authn page, incase it caused problems with auth flow. 