### PR TITLE
fix(fe): Alignment on connectors page filters

### DIFF
--- a/packages/frontend-2/components/connectors/Page.vue
+++ b/packages/frontend-2/components/connectors/Page.vue
@@ -36,6 +36,8 @@
             class="md:min-w-80"
             allow-unset
             :items="categories"
+            size="base"
+            color="foundation"
           >
             <template #something-selected="{ value }">
               {{ isArray(value) ? value[0].name : value.name }}


### PR DESCRIPTION
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/cbc228c3-185d-484d-91da-ea5c0811c298" />

I noticed a small misalignment on the connectors page between the search and the filter. 

Added size prop so they are both `h-8` and made filter `color=foundation` to match search input