### PR TITLE
fix(automate): fix search param parsing

### DIFF
--- a/packages/server/modules/automate/clients/executionEngine.ts
+++ b/packages/server/modules/automate/clients/executionEngine.ts
@@ -64,7 +64,8 @@ const getApiUrl = (
   const url = new URL(path, automateUrl)
   if (options?.query) {
     Object.entries(options.query).forEach(([key, val]) => {
-      if (isEmpty(val) || isNullOrUndefined(val)) return
+      if (isNullOrUndefined(val)) return
+      if (typeof val === 'object' && isEmpty(val)) return
       try {
         const urlValue = typeof val === 'object' ? val.join(',') : val.toString()
         url.searchParams.append(key, urlValue)


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- In #4085 I made some changes to allow "array" query params. Because of a misunderstanding with lodash `isEmpty`, I was also accidentally omitting most search params.
- Breakage limited to new functions listing (we couldn't provide the `includeFeatured` param)

## Changes:

- Only run `isEmpty` against arrays in `getApiUrl`

Validated on `testing3`.

Before:

![image](https://github.com/user-attachments/assets/6c2b740c-9bcd-47d7-b780-60384094c592)

After:

![image](https://github.com/user-attachments/assets/f55402b7-7ddf-4f5a-b5bc-db421ebafc12)
