### PR TITLE
feat(shared) Update validateWorkspaceSlug to check for blocked words

### DIFF
--- a/packages/shared/src/core/constants.ts
+++ b/packages/shared/src/core/constants.ts
@@ -420,3 +420,5 @@ export const blockedDomains: string[] = [
   'dontreg.com',
   'dontsendmespam.de'
 ]
+
+export const blockedSlugs: string[] = ['create', 'join']

--- a/packages/shared/src/workspaces/errors/index.ts
+++ b/packages/shared/src/workspaces/errors/index.ts
@@ -1,3 +1,5 @@
+import { blockedSlugs } from '../../core/constants.js'
+
 export const VALID_SLUG_CHARACTERS_REGEX = /^[a-z0-9-]+$/
 export const VALID_SLUG_BOUNDARY_REGEX = /^[a-z0-9].*[a-z0-9]$/
 const MIN_SLUG_LENGTH = 3
@@ -39,5 +41,9 @@ export function validateWorkspaceSlug(slug: string): void {
 
   if (!VALID_SLUG_BOUNDARY_REGEX.test(slug)) {
     throw new InvalidWorkspaceSlugError('Short ID cannot start or end with a hyphen.')
+  }
+
+  if (blockedSlugs.includes(slug)) {
+    throw new InvalidWorkspaceSlugError('This Short ID is reserved and cannot be used.')
   }
 }


### PR DESCRIPTION
We use the `workspaces/join` and `workspaces/create` routes in frontend. 

We should block workspaces being created with this slug to avoid conflicts. 