### PR TITLE
Feat(dui3): feedback survey + better user menu

### DIFF
--- a/packages/dui3/components/feedback/Dialog.vue
+++ b/packages/dui3/components/feedback/Dialog.vue
@@ -1,0 +1,114 @@
+<template>
+  <LayoutDialog
+    v-model:open="isOpen"
+    :title="dialogTitle"
+    :buttons="dialogButtons"
+    :on-submit="onSubmit"
+    max-width="md"
+    fullscreen="none"
+  >
+    <div class="flex flex-col gap-2">
+      <p class="text-body-xs text-foreground font-medium">
+        {{ dialogIntro }}
+      </p>
+      <FormTextArea
+        v-model="feedback"
+        name="feedback"
+        label="Feedback"
+        color="foundation"
+      />
+      <p v-if="!hideSuppport" class="text-body-xs !leading-4">
+        Need help? For support, head over to our
+        <FormButton
+          target="_blank"
+          link
+          text
+          @click="$openUrl(`https://speckle.community/`)"
+        >
+          community forum
+        </FormButton>
+        where we can chat and solve problems together.
+      </p>
+    </div>
+  </LayoutDialog>
+</template>
+
+<script setup lang="ts">
+import { ToastNotificationType, type LayoutDialogButton } from '@speckle/ui-components'
+import { useForm } from 'vee-validate'
+import { useZapier } from '~/lib/core/composables/zapier'
+import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAccountStore } from '~/store/accounts'
+import { useHostAppStore } from '~/store/hostApp'
+
+type FormValues = { feedback: string }
+
+const props = defineProps<{
+  title?: string
+  intro?: string
+  hideSuppport?: boolean
+  metadata?: Record<string, unknown>
+}>()
+
+const isOpen = defineModel<boolean>('open', { required: true })
+
+const { trackEvent } = useMixpanel()
+const { sendWebhook } = useZapier()
+const { handleSubmit } = useForm<FormValues>()
+const accountStore = useAccountStore()
+const hostApp = useHostAppStore()
+
+const feedback = ref('')
+
+const dialogButtons = computed((): LayoutDialogButton[] => [
+  {
+    text: 'Send',
+    props: { color: 'primary' },
+    submit: true,
+    id: 'sendFeedback'
+  }
+])
+
+const dialogTitle = computed(() => props.title || 'Give us feedback')
+
+const dialogIntro = computed(
+  () =>
+    props.intro ||
+    'How can we improve Speckle? If you have a feature request, please also share how you would use it and why its important to you'
+)
+
+const onSubmit = handleSubmit(async () => {
+  if (!feedback.value) return
+
+  isOpen.value = false
+
+  trackEvent('Feedback Sent', {
+    message: feedback.value,
+    feedbackType: 'dui3',
+    ...props.metadata
+  })
+
+  hostApp.setNotification({
+    type: ToastNotificationType.Success,
+    title: 'Thank you for your feedback!'
+  })
+
+  const userId = accountStore.defaultAccount.accountInfo.userInfo.id ?? ''
+
+  await sendWebhook('https://hooks.zapier.com/hooks/catch/12120532/2m4okri/', {
+    userId,
+    feedback: [
+      `**Action:** User Feedback`,
+      `**Type:** dui3`,
+      `**User ID:** ${userId}`,
+      `**Feedback:** ${feedback.value}`
+    ].join('\n')
+  })
+})
+
+watch(isOpen, (newVal) => {
+  if (newVal) {
+    feedback.value = ''
+  }
+})
+</script>

--- a/packages/dui3/components/header/NavBar.vue
+++ b/packages/dui3/components/header/NavBar.vue
@@ -31,86 +31,15 @@
           >
             <span class="">Update</span>
           </FormButton>
-
-          <div v-if="uiConfigStore.isDevMode">
-            <!-- ONLY FOR TESTS FOR NOW-->
-            <div v-if="testSettings && hasConfigBindings" class="flex justify-end">
-              <FormButton
-                v-tippy="'Settings'"
-                class="px-1"
-                text
-                hide-text
-                :icon-left="Cog6ToothIcon"
-                @click="openConfigDialog = true"
-              ></FormButton>
-              <LayoutDialog v-model:open="openConfigDialog" fullscreen="none">
-                <ConfigDialog @close="openConfigDialog = false" />
-              </LayoutDialog>
-            </div>
-            <div>
-              <HeaderUserMenu />
-            </div>
-          </div>
-          <div v-else>
-            <FormButton
-              v-tippy="isDarkTheme ? 'Switch to light theme' : 'Switch to dark theme'"
-              text
-              @click="uiConfigStore.toggleTheme()"
-            >
-              <Component :is="isDarkTheme ? SunIcon : MoonIcon" class="w-4" />
-            </FormButton>
-          </div>
+          <HeaderUserMenu />
         </div>
       </div>
     </div>
   </nav>
-  <div v-else class="fixed top-1 right-2 z-100 flex items-center space-x-2">
-    <FormButton
-      v-tippy="isDarkTheme ? 'Switch to light theme' : 'Switch to dark theme'"
-      text
-      @click="uiConfigStore.toggleTheme()"
-    >
-      <Component :is="isDarkTheme ? SunIcon : MoonIcon" class="w-4" />
-    </FormButton>
-    <div v-if="isDev">
-      <NuxtLink
-        v-tippy="'Test page'"
-        to="test"
-        class="text-xs text-foreground-2 hover:text-primary"
-        exact-active-class="hidden"
-      >
-        <WrenchScrewdriverIcon class="w-4" />
-      </NuxtLink>
-      <NuxtLink
-        v-tippy="'Home'"
-        to="/"
-        class="text-xs text-foreground-2 hover:text-primary"
-        exact-active-class="hidden"
-      >
-        <HomeIcon class="w-4" />
-      </NuxtLink>
-    </div>
-  </div>
 </template>
 <script setup lang="ts">
-import { storeToRefs } from 'pinia'
-import { useConfigStore } from '~/store/config'
-import {
-  Cog6ToothIcon,
-  WrenchScrewdriverIcon,
-  HomeIcon,
-  MoonIcon,
-  SunIcon
-} from '@heroicons/vue/24/solid'
 import { ArrowUpCircleIcon } from '@heroicons/vue/24/outline'
 import { useHostAppStore } from '~/store/hostApp'
-const isDev = ref(import.meta.dev)
-const openConfigDialog = ref(false)
-// NOTE: make it true to test settings, it might be removed later. TBD
-const testSettings = ref(false)
-
-const uiConfigStore = useConfigStore()
-const { isDarkTheme, hasConfigBindings } = storeToRefs(uiConfigStore)
 
 const hostAppStore = useHostAppStore()
 const hasNoModelCards = computed(() => hostAppStore.projectModelGroups.length === 0)

--- a/packages/dui3/components/header/UserMenu.vue
+++ b/packages/dui3/components/header/UserMenu.vue
@@ -19,45 +19,64 @@
         leave-to-class="transform opacity-0 scale-95"
       >
         <MenuItems
-          class="absolute right-0 md:right-4 top-10 md:top-16 w-full md:w-64 origin-top-right bg-foundation sm:rounded-t-md rounded-b-2xl shadow-lg overflow-hidden"
+          class="absolute right-1 top-11 origin-top-right bg-foundation outline outline-1 outline-primary-muted rounded-md shadow-lg overflow-hidden"
         >
-          <MenuItem v-slot="{ close }" as="div">
-            <div class="px-2 py-3 flex flex-col space-y-2 border-t-1 justify-between">
-              <!-- <div class="flex space-x-2"> -->
-              <FormButton
-                size="sm"
-                color="secondary"
-                class="text-xs text-foreground-2 hover:text-primary transition"
-                @click="$showDevTools"
-              >
-                Open Dev Tools
-              </FormButton>
-
-              <FormButton
-                size="sm"
-                color="secondary"
-                class="text-xs text-foreground-2 hover:text-primary transition"
-                to="/test"
-                @click="close()"
-              >
-                Test Page
-              </FormButton>
-              <!-- </div> -->
-              <!-- 
-                NOTE: Here's an example of customising the frontend app based on what bindings we
-                have loaded. E.g., if config bindings are not present, we do not show any button
-                regarding switching themes. 
-              -->
-              <div v-if="hasConfigBindings">
-                <FormButton size="xs" text full-width @click="toggleTheme()">
-                  {{ isDarkTheme ? 'Switch to light theme' : 'Switch to dark theme' }}
-                </FormButton>
-              </div>
+          <MenuItem v-slot="{ active }" @click="showFeedbackDialog = true">
+            <div
+              :class="[
+                active ? 'bg-highlight-1' : '',
+                'my-1 text-body-xs flex px-2 py-1 text-foreground cursor-pointer transition mx-1 rounded'
+              ]"
+            >
+              Feedback
             </div>
           </MenuItem>
+          <MenuItem v-slot="{ active }" @click="toggleTheme">
+            <div
+              :class="[
+                active ? 'bg-highlight-1' : '',
+                'my-1 text-body-xs flex px-2 py-1 text-foreground cursor-pointer transition mx-1 rounded'
+              ]"
+            >
+              {{ isDarkTheme ? 'Light mode' : 'Dark mode' }}
+            </div>
+          </MenuItem>
+          <div v-if="hasConfigBindings && isDevMode">
+            <div class="border-t border-outline-3 py-1 mt-1">
+              <MenuItem v-slot="{ active }" @click="$showDevTools">
+                <div
+                  :class="[
+                    active ? 'bg-highlight-1' : '',
+                    'my-1 text-body-xs flex px-2 py-1 text-foreground cursor-pointer transition mx-1 rounded'
+                  ]"
+                >
+                  Open Dev Tools
+                </div>
+              </MenuItem>
+            </div>
+            <MenuItem v-slot="{ active }">
+              <NuxtLink
+                to="/test"
+                :class="[
+                  active ? 'bg-highlight-1' : '',
+                  'text-body-xs flex px-2 py-1 text-foreground cursor-pointer transition mx-1 rounded'
+                ]"
+              >
+                Test Page
+              </NuxtLink>
+            </MenuItem>
+          </div>
+          <div class="border-t border-outline-3 py-1 mt-1">
+            <MenuItem>
+              <div class="px-3 pt-1 text-tiny text-foreground-2">
+                Version {{ hostApp.connectorVersion }}
+              </div>
+            </MenuItem>
+          </div>
         </MenuItems>
       </Transition>
     </Menu>
+    <FeedbackDialog v-model:open="showFeedbackDialog" />
   </div>
 </template>
 <script setup lang="ts">
@@ -65,10 +84,14 @@ import { storeToRefs } from 'pinia'
 import { XMarkIcon, Bars3Icon } from '@heroicons/vue/20/solid'
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
 import { useConfigStore } from '~/store/config'
+import { useHostAppStore } from '~/store/hostApp'
 
 const uiConfigStore = useConfigStore()
-const { isDarkTheme, hasConfigBindings } = storeToRefs(uiConfigStore)
+const { isDarkTheme, hasConfigBindings, isDevMode } = storeToRefs(uiConfigStore)
 const { toggleTheme } = uiConfigStore
+const hostApp = useHostAppStore()
 
 const { $showDevTools } = useNuxtApp()
+
+const showFeedbackDialog = ref<boolean>(false)
 </script>

--- a/packages/dui3/layouts/default.vue
+++ b/packages/dui3/layouts/default.vue
@@ -1,8 +1,21 @@
 <template>
   <div class="relative min-h-screen flex flex-col">
     <HeaderNavBar />
-    <main class="flex-1 mt-10 px-1 max-[275px]:px-0">
+    <main class="flex-1 px-1 max-[275px]:px-0" :class="hasNoModelCards ? '' : 'mt-10'">
       <slot />
     </main>
+    <div
+      v-if="hasNoModelCards"
+      class="px-3 pt-1 text-tiny text-foreground-2 text-center"
+    >
+      Version {{ hostApp.connectorVersion }}
+    </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import { useHostAppStore } from '~/store/hostApp'
+
+const hostApp = useHostAppStore()
+const hasNoModelCards = computed(() => hostApp.projectModelGroups.length === 0)
+</script>

--- a/packages/dui3/lib/core/composables/zapier.ts
+++ b/packages/dui3/lib/core/composables/zapier.ts
@@ -1,0 +1,21 @@
+export function useZapier() {
+  const sendWebhook = async (
+    webhookUrl: string,
+    data: Record<string, string | number>
+  ) => {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      mode: 'no-cors',
+      body: JSON.stringify(data)
+    })
+
+    return response
+  }
+
+  return {
+    sendWebhook
+  }
+}


### PR DESCRIPTION
- we have user menu by default now and feedback dialog available under it.
- zapier ping is tested https://discord.com/channels/726756379083145269/1292817871340306502/1346116096108789932
- theme switcher on main screen is removed and components vertically centered
- version info added at the bottom on main screen as text-tiny

![image](https://github.com/user-attachments/assets/06b96692-40e0-4bf1-b5e9-7d9b60ccba67)

![image](https://github.com/user-attachments/assets/cf8314db-6e17-4ee7-8fc5-428f26c4105d)

![image](https://github.com/user-attachments/assets/5ee10059-8bb0-467b-8195-cb133e1bd0e5)
