### PR TITLE
feat(fe): Improve ViewerExplorerFilters to show full property name and shortened name

### DIFF
--- a/packages/frontend-2/components/viewer/explorer/Filters.vue
+++ b/packages/frontend-2/components/viewer/explorer/Filters.vue
@@ -63,17 +63,21 @@
         <div
           v-for="(filter, index) in relevantFiltersLimited"
           :key="index"
+          v-tippy="filter.key"
           class="text-xs"
         >
           <button
-            class="block w-full text-left hover:bg-primary-muted truncate rounded-md py-1 px-2 mx-2"
+            class="flex w-full text-left hover:bg-primary-muted truncate rounded-md py-1 px-2 mx-2 text-[10px] text-foreground-3 gap-1 items-center"
             @click="
               ;(showAllFilters = false),
                 setPropertyFilter(filter),
                 refreshColorsIfSetOrActiveFilterIsNumeric()
             "
           >
-            {{ getPropertyName(filter.key) }}
+            <span class="text-foreground text-body-2xs">
+              {{ getPropertyName(filter.key) }}
+            </span>
+            <span class="">{{ filter.key }}</span>
           </button>
         </div>
         <div v-if="itemCount < relevantFiltersSearched.length" class="mb-2">
@@ -265,11 +269,11 @@ const getPropertyName = (key: string): string => {
       (f) => f.key === key.replace('.value', '.name')
     )
     if (correspondingProperty && isStringPropertyInfo(correspondingProperty)) {
-      return correspondingProperty.valueGroups[0]?.value || key
+      return correspondingProperty.valueGroups[0]?.value || key.split('.').pop() || key
     }
   }
 
-  // Return the key as is for non-Revit properties
-  return key
+  // For all other properties, just return the last part of the path
+  return key.split('.').pop() || key
 }
 </script>


### PR DESCRIPTION
Current:
![image](https://github.com/user-attachments/assets/34a993e2-2c77-47d9-a718-4949dfcb2172)

With change:
![image](https://github.com/user-attachments/assets/50451df4-3ca0-42ad-99b4-a38251f790cd)

See discord thread here:
https://discord.com/channels/726756379083145269/850367221482258463/1346400124175384607