### PR TITLE
fix(metrics): pass registry in to modules

### DIFF
--- a/packages/server/app.ts
+++ b/packages/server/app.ts
@@ -350,7 +350,7 @@ export async function init() {
     app.use(mixpanelTrackerHelperMiddlewareFactory({ getUser: getUserFactory({ db }) }))
 
   // Initialize default modules, including rest api handlers
-  await ModulesSetup.init(app)
+  await ModulesSetup.init({ app, metricsRegister: prometheusClient.register })
 
   // Initialize healthchecks
   const healthchecks = await healthchecksInitFactory()(app, true)

--- a/packages/server/modules/accessrequests/index.ts
+++ b/packages/server/modules/accessrequests/index.ts
@@ -9,7 +9,7 @@ import { getEventBus } from '@/modules/shared/services/eventBus'
 let quitListeners: Optional<() => void> = undefined
 
 const ServerAccessRequestsModule: SpeckleModule = {
-  init(_, isInitial) {
+  init({ isInitial }) {
     moduleLogger.info('🔐 Init access request module')
 
     if (isInitial) {

--- a/packages/server/modules/activitystream/index.ts
+++ b/packages/server/modules/activitystream/index.ts
@@ -120,7 +120,7 @@ const scheduleWeeklyActivityNotifications = () => {
 }
 
 const activityModule: SpeckleModule = {
-  init: async (_, isInitial) => {
+  init: async ({ isInitial }) => {
     moduleLogger.info('🤺 Init activity module')
     if (isInitial) {
       quitEventListeners = initializeEventListeners({

--- a/packages/server/modules/apiexplorer/index.ts
+++ b/packages/server/modules/apiexplorer/index.ts
@@ -14,7 +14,7 @@ async function getExplorerHtml() {
   )
 }
 
-export const init: SpeckleModule['init'] = (app) => {
+export const init: SpeckleModule['init'] = ({ app }) => {
   moduleLogger.info('💅 Init graphql api explorer module')
 
   // sweet and simple

--- a/packages/server/modules/auth/index.ts
+++ b/packages/server/modules/auth/index.ts
@@ -143,7 +143,7 @@ const setupStrategies = setupStrategiesFactory({
 
 let authStrategies: AuthStrategyMetadata[]
 
-export const init: SpeckleModule['init'] = async (app, isInitial) => {
+export const init: SpeckleModule['init'] = async ({ app, isInitial }) => {
   moduleLogger.info('🔑 Init auth module')
 
   // Initialize authn strategies

--- a/packages/server/modules/automate/index.ts
+++ b/packages/server/modules/automate/index.ts
@@ -368,7 +368,7 @@ const initializeEventListeners = () => {
 }
 
 const automateModule: SpeckleModule = {
-  async init(app, isInitial) {
+  async init({ app, isInitial }) {
     if (!FF_AUTOMATE_MODULE_ENABLED) return
     moduleLogger.info('⚙️  Init automate module')
 

--- a/packages/server/modules/blobstorage/index.ts
+++ b/packages/server/modules/blobstorage/index.ts
@@ -94,7 +94,7 @@ const errorHandler: ErrorHandler = async (req, res, callback) => {
   }
 }
 
-export const init: SpeckleModule['init'] = async (app) => {
+export const init: SpeckleModule['init'] = async ({ app }) => {
   await ensureConditions()
   const createStreamWritePermissions = () =>
     streamWritePermissionsPipelineFactory({

--- a/packages/server/modules/comments/index.ts
+++ b/packages/server/modules/comments/index.ts
@@ -19,7 +19,7 @@ import { publish } from '@/modules/shared/utils/subscriptions'
 let unsubFromEvents: Optional<() => void> = undefined
 
 const commentsModule: SpeckleModule = {
-  async init(_, isInitial) {
+  async init({ isInitial }) {
     moduleLogger.info('🗣  Init comments module')
 
     if (isInitial) {

--- a/packages/server/modules/core/index.ts
+++ b/packages/server/modules/core/index.ts
@@ -41,7 +41,7 @@ const coreModule: SpeckleModule<{
   async executeHooks(key: keyof HooksConfig, { projectId }: { projectId: string }) {
     return await Promise.all(this.hooks[key].map(async (cb) => await cb({ projectId })))
   },
-  async init(app, isInitial) {
+  async init({ app, isInitial }) {
     moduleLogger.info('💥 Init core module')
 
     // Initialize the static route

--- a/packages/server/modules/emails/index.ts
+++ b/packages/server/modules/emails/index.ts
@@ -5,7 +5,7 @@ import { initializeTransporter } from '@/modules/emails/utils/transporter'
 import { SpeckleModule } from '@/modules/shared/helpers/typeHelper'
 
 const emailsModule: SpeckleModule = {
-  init: async (app) => {
+  init: async ({ app }) => {
     moduleLogger.info('📧 Init emails module')
 
     // init transporter

--- a/packages/server/modules/fileuploads/index.ts
+++ b/packages/server/modules/fileuploads/index.ts
@@ -24,7 +24,7 @@ import { getProjectDbClient } from '@/modules/multiregion/utils/dbSelector'
 import { listenFor } from '@/modules/core/utils/dbNotificationListener'
 import { getEventBus } from '@/modules/shared/services/eventBus'
 
-export const init: SpeckleModule['init'] = async (app, isInitial) => {
+export const init: SpeckleModule['init'] = async ({ app, isInitial }) => {
   if (process.env.DISABLE_FILE_UPLOADS) {
     moduleLogger.warn('📄 FileUploads module is DISABLED')
     return

--- a/packages/server/modules/gatekeeper/index.ts
+++ b/packages/server/modules/gatekeeper/index.ts
@@ -171,7 +171,7 @@ let scheduledTasks: cron.ScheduledTask[] = []
 let quitListeners: (() => void) | undefined = undefined
 
 const gatekeeperModule: SpeckleModule = {
-  async init(app, isInitial) {
+  async init({ app, isInitial }) {
     await initScopes()
     if (!FF_GATEKEEPER_MODULE_ENABLED) return
 

--- a/packages/server/modules/gendo/index.ts
+++ b/packages/server/modules/gendo/index.ts
@@ -6,7 +6,7 @@ import restApi from '@/modules/gendo/rest/index'
 const { FF_GENDOAI_MODULE_ENABLED } = getFeatureFlags()
 
 export = {
-  async init(app) {
+  async init({ app }) {
     if (!FF_GENDOAI_MODULE_ENABLED) return
     moduleLogger.info('🪞 Init Gendo AI render module')
 

--- a/packages/server/modules/index.ts
+++ b/packages/server/modules/index.ts
@@ -13,7 +13,7 @@ import { addMocksToSchema } from '@graphql-tools/mock'
 import { getFeatureFlags } from '@/modules/shared/helpers/envHelper'
 import { isNonNullable } from '@speckle/shared'
 import { SpeckleModule } from '@/modules/shared/helpers/typeHelper'
-import { Express } from 'express'
+import type { Express } from 'express'
 import { RequestDataLoadersBuilder } from '@/modules/shared/helpers/graphqlHelper'
 import { ApolloServerOptions } from '@apollo/server'
 import {
@@ -23,6 +23,7 @@ import {
 import { AppMocksConfig } from '@/modules/mocks'
 import { SpeckleModuleMocksConfig } from '@/modules/shared/helpers/mocks'
 import { LogicError } from '@/modules/shared/errors'
+import type { Registry } from 'prom-client'
 
 /**
  * Cached speckle module requires
@@ -110,18 +111,19 @@ async function getSpeckleModules() {
   return loadedModules
 }
 
-export const init = async (app: Express) => {
+export const init = async (params: { app: Express; metricsRegister: Registry }) => {
+  const { app, metricsRegister } = params
   const modules = await getSpeckleModules()
   const isInitial = !hasInitializationOccurred
 
   // Stage 1: initialise all modules
   for (const module of modules) {
-    await module.init?.(app, isInitial)
+    await module.init?.({ app, isInitial, metricsRegister })
   }
 
   // Stage 2: finalize init all modules
   for (const module of modules) {
-    await module.finalize?.(app, isInitial)
+    await module.finalize?.({ app, isInitial, metricsRegister })
   }
 
   hasInitializationOccurred = true

--- a/packages/server/modules/notifications/index.ts
+++ b/packages/server/modules/notifications/index.ts
@@ -45,7 +45,7 @@ export async function initializeConsumption(
   }
 }
 
-export const init: SpeckleModule['init'] = async (_, isInitial) => {
+export const init: SpeckleModule['init'] = async ({ isInitial }) => {
   moduleLogger.info('📞 Init notifications module')
   if (isInitial) {
     await initializeConsumption()

--- a/packages/server/modules/previews/index.ts
+++ b/packages/server/modules/previews/index.ts
@@ -35,7 +35,7 @@ const httpErrorImage = (httpErrorCode: number) =>
 
 const noPreviewImage = require.resolve('#/assets/previews/images/no_preview.png')
 
-export const init: SpeckleModule['init'] = (app, isInitial) => {
+export const init: SpeckleModule['init'] = ({ app, isInitial }) => {
   if (disablePreviews()) {
     moduleLogger.warn('📸 Object preview module is DISABLED')
   } else {

--- a/packages/server/modules/pwdreset/index.ts
+++ b/packages/server/modules/pwdreset/index.ts
@@ -3,7 +3,7 @@ import RestSetup from '@/modules/pwdreset/rest'
 import { SpeckleModule } from '@/modules/shared/helpers/typeHelper'
 import { noop } from 'lodash'
 
-export const init: SpeckleModule['init'] = (app) => {
+export const init: SpeckleModule['init'] = ({ app }) => {
   moduleLogger.info('♻️  Init pwd reset module')
   RestSetup(app)
 }

--- a/packages/server/modules/serverinvites/index.ts
+++ b/packages/server/modules/serverinvites/index.ts
@@ -17,7 +17,7 @@ const scopes = [
   }
 ]
 
-export const init: SpeckleModule['init'] = async (_app, isInitial) => {
+export const init: SpeckleModule['init'] = async ({ isInitial }) => {
   moduleLogger.info('💌 Init invites module')
 
   const registerFunc = registerOrUpdateScopeFactory({ db })

--- a/packages/server/modules/shared/helpers/typeHelper.ts
+++ b/packages/server/modules/shared/helpers/typeHelper.ts
@@ -1,16 +1,17 @@
-import {
+import type {
   Nullable,
   Optional,
   MaybeNullOrUndefined,
   MaybeAsync,
   MaybeFalsy
 } from '@speckle/shared'
-import { RequestDataLoaders } from '@/modules/core/loaders'
-import { AuthContext } from '@/modules/shared/authz'
-import { Express } from 'express'
-import { ConditionalKeys, SetRequired } from 'type-fest'
-import pino from 'pino'
-import { BaseContext } from '@apollo/server'
+import type { RequestDataLoaders } from '@/modules/core/loaders'
+import type { AuthContext } from '@/modules/shared/authz'
+import type { Express } from 'express'
+import type { ConditionalKeys, SetRequired } from 'type-fest'
+import type { Logger } from 'pino'
+import type { BaseContext } from '@apollo/server'
+import type { Registry } from 'prom-client'
 
 export type MarkNullableOptional<T> = SetRequired<
   Partial<T>,
@@ -25,7 +26,11 @@ export type SpeckleModule<T extends Record<string, unknown> = Record<string, unk
      * @param isInitial Whether this initialization method is being invoked for the first time in this
      * process. In tests modules can be initialized multiple times.
      */
-    init?: (app: Express, isInitial: boolean) => MaybeAsync<void>
+    init?: (params: {
+      app: Express
+      isInitial: boolean
+      metricsRegister?: Registry
+    }) => MaybeAsync<void>
     /**
      * Finalize initialization. This is only invoked once all of the other modules' `init()`
      * hooks are run.
@@ -33,7 +38,11 @@ export type SpeckleModule<T extends Record<string, unknown> = Record<string, unk
      * @param isInitial Whether this initialization method is being invoked for the first time in this
      * process. In tests modules can be initialized multiple times.
      */
-    finalize?: (app: Express, isInitial: boolean) => MaybeAsync<void>
+    finalize?: (params: {
+      app: Express
+      isInitial: boolean
+      metricsRegister?: Registry
+    }) => MaybeAsync<void>
 
     /**
      * Cleanup resources before the server shuts down
@@ -49,7 +58,7 @@ export type GraphQLContext = BaseContext &
      */
     loaders: RequestDataLoaders
 
-    log: pino.Logger
+    log: Logger
   }
 
 export { Nullable, Optional, MaybeNullOrUndefined, MaybeAsync, MaybeFalsy }

--- a/packages/server/modules/workspaces/index.ts
+++ b/packages/server/modules/workspaces/index.ts
@@ -26,7 +26,7 @@ const initRoles = async () => {
 }
 
 const workspacesModule: SpeckleModule = {
-  async init(app, isInitial) {
+  async init({ app, isInitial }) {
     if (!FF_WORKSPACES_MODULE_ENABLED) return
     const isWorkspaceLicenseValid = await validateModuleLicense({
       requiredModules: ['workspaces']


### PR DESCRIPTION
## Description & motivation

Some modules may define metrics.

Currently they retrieve the default prometheus registry from the imported module.

In a previously resolved bug it was discovered that this was not sufficient to ensure the correct registry was used in all cases. By passing the configured registry in to the module initialization by parameter, we can ensure metrics are added to the correct registry.

Follows on from https://github.com/specklesystems/speckle-server/pull/4106

NB, at present no modules initialize metrics. This PR prepares for the new preview service which does initialize metrics.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
