### PR TITLE
fix(fe): Remove check for force onboarding FF in workspace middleware

### DIFF
--- a/packages/frontend-2/middleware/006-workspace.global.ts
+++ b/packages/frontend-2/middleware/006-workspace.global.ts
@@ -12,7 +12,6 @@ export default defineNuxtRouteMiddleware(async (to) => {
   const isSSOPath = to.path.includes('/sso/')
   if (isAuthPage || isSSOPath) return
 
-  const isOnboardingForced = useIsOnboardingForced()
   const isWorkspaceNewPlansEnabled = useWorkspaceNewPlansEnabled()
   const isWorkspacesEnabled = useIsWorkspacesEnabled()
 
@@ -40,7 +39,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
     return
 
   // Ignore if user has not completed onboarding yet
-  if (isOnboardingForced.value && !data?.activeUser?.isOnboardingFinished) return
+  if (!data?.activeUser?.isOnboardingFinished) return
 
   const isMemberOfWorkspace = (data?.activeUser?.workspaces?.totalCount ?? 0) > 0
   const hasLegacyProjects = (data?.activeUser?.versions?.totalCount ?? 0) > 0


### PR DESCRIPTION
This check is unnecessary. Even if a user skips onboarding, it will set them as onboarded. 