### PR TITLE
fix(fe) Temporarily revert email image changes

### DIFF
--- a/packages/server/assets/emails/templates/components/footer.mjml
+++ b/packages/server/assets/emails/templates/components/footer.mjml
@@ -28,58 +28,6 @@
       <a href="https://speckle.community/" target="_blank">Community forum</a>
       <br />
       <br />
-      <span style="display: block; margin-bottom: 5px">Follow us</span>
-      <a
-        href="https://www.linkedin.com/company/specklesystems/"
-        target="_blank"
-        style="display: inline-block; vertical-align: middle"
-      >
-        <img
-          src="<%- params.serverInfo.canonicalUrl -%>/static/social/linkedin.svg"
-          width="16"
-          height="16"
-          alt="LinkedIn"
-        />
-      </a>
-      &nbsp;&nbsp;&nbsp;
-      <a
-        href="https://x.com/SpeckleSystems"
-        target="_blank"
-        style="display: inline-block; vertical-align: middle"
-      >
-        <img
-          src="<%- params.serverInfo.canonicalUrl -%>/static/social/x.svg"
-          width="16"
-          height="16"
-          alt="X"
-        />
-      </a>
-      &nbsp;&nbsp;&nbsp;
-      <a
-        href="https://www.instagram.com/specklesystems/"
-        target="_blank"
-        style="display: inline-block; vertical-align: middle"
-      >
-        <img
-          src="<%- params.serverInfo.canonicalUrl -%>/static/social/instagram.svg"
-          width="16"
-          height="16"
-          alt="Instagram"
-        />
-      </a>
-      &nbsp;&nbsp;&nbsp;
-      <a
-        href="https://www.youtube.com/c/SpeckleSystems"
-        target="_blank"
-        style="display: inline-block; vertical-align: middle"
-      >
-        <img
-          src="<%- params.serverInfo.canonicalUrl -%>/static/social/youtube.svg"
-          width="16"
-          height="16"
-          alt="YouTube"
-        />
-      </a>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/server/assets/emails/templates/components/headerLogo.mjml
+++ b/packages/server/assets/emails/templates/components/headerLogo.mjml
@@ -1,7 +1,7 @@
 <mj-section padding-bottom="0">
   <mj-column>
     <mj-image
-      width="40px"
+      width="150px"
       src="<%- params.serverInfo.canonicalUrl -%>/static/speckle-email-logo.png"
       alt="Speckle"
     />


### PR DESCRIPTION
The changes to email images didn't work on app. The urls work, but the email doesn't resolve them. 

I've done this branch to revert the header logo, and remove the social links. 

I'll get to the bottom of the problem on Monday, but this keeps it tidy over the weekend. 