### PR TITLE
chore(objectloader): add more context to error when loading

### DIFF
--- a/packages/objectloader/src/index.js
+++ b/packages/objectloader/src/index.js
@@ -197,12 +197,14 @@ class ObjectLoader {
   }
 
   async getTotalObjectCount() {
+    const rootObj = await this.getRootObject()
+    const totalChildrenCount = Object.keys(rootObj?.__closure || {}).length
+    return totalChildrenCount
+  }
+
+  async getRootObject() {
     /** This is fine, because it gets cached */
     const rootObjJson = await this.getRawRootObject()
-    /** Ideally we shouldn't to a `parse` here since it's going to pointlessly allocate
-     *  But doing string gymnastics in order to get closure length is going to be the same
-     *  if not even more memory constly
-     */
     let rootObj
     try {
       rootObj = JSON.parse(rootObjJson)
@@ -211,13 +213,7 @@ class ObjectLoader {
         `Error parsing root object. "${e.message}". Root object: '${rootObjJson}'`
       )
     }
-    const totalChildrenCount = Object.keys(rootObj?.__closure || {}).length
-    return totalChildrenCount
-  }
-
-  async getRootObject() {
-    const rootObjJson = await this.getRawRootObject()
-    return JSON.parse(rootObjJson)
+    return rootObj
   }
 
   /**


### PR DESCRIPTION
## Description & motivation

Preview service is throwing a lot of errors in this `JSON.parse` line. We need more detail as to the failure.
Suspect it may be an issue in the prior request call.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
