### PR TITLE
Bump IFC nuget

### DIFF
--- a/packages/fileimport-service/ifc-dotnet/ifc-converter.csproj
+++ b/packages/fileimport-service/ifc-dotnet/ifc-converter.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-      <PackageReference Include="Speckle.Importers.Ifc" Version="3.1.0-nuget-wip.1" />
+      <PackageReference Include="Speckle.Importers.Ifc" Version="3.0.2-adam.3-38-gbdabd10b" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 


### PR DESCRIPTION
Bumped the IFC importer nuget

We're having some fun re-designing the speckle-sharp-connectors CI right now, so the semver is a bit funky 😁 but I (and sourcelink) assure you its a newer version  