### PR TITLE
Chore(connectors): change url to legacy

### DIFF
--- a/packages/frontend-2/components/connectors/Page.vue
+++ b/packages/frontend-2/components/connectors/Page.vue
@@ -15,7 +15,7 @@
             Looking for V2 connectors? Get them
             <NuxtLink
               class="text-foreground-3 hover:text-foreground-2 underline"
-              to="https://releases.speckle.systems"
+              to="https://releases.speckle.systems/legacy-connectors"
             >
               here.
             </NuxtLink>


### PR DESCRIPTION
We have swapped the `/` for next gen connectors and v2 connectors will be in `/legacy-connectors`