### PR TITLE
Fix(dui3): revit when moving between documents cards can get lost

### DIFF
--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -218,7 +218,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         idMap
       }
 
-      await patchModel(modelCardId, { sendFilter: newFilter })
+      await patchModel(modelCardId, { sendFilter: newFilter }, false) // we do not necessarily need to updateModel in revit bc we already do it on .NET - otherwise it is leading cleanup on document store bc of deferred action when we switched to the another doc
     }
   )
 


### PR DESCRIPTION
Previosly we were losing the model cards on the document that we switched while operation is happening

![isr9ros2i9](https://github.com/user-attachments/assets/3d6d4575-bd6e-40cd-a40c-fd8de48183e2)