### PR TITLE
fix(fe): show discounted monthly price when annual plan selected

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/billing/PricingTable/Plan.vue
+++ b/packages/frontend-2/components/settings/workspaces/billing/PricingTable/Plan.vue
@@ -13,7 +13,7 @@
     </div>
     <p class="text-body mt-1">
       <span class="font-medium">
-        {{ formatPrice(planPrice?.[Roles.Workspace.Member]) }}
+        {{ formatPrice(finalPlanPrice) }}
       </span>
       per seat/month
     </p>
@@ -140,6 +140,15 @@ const planPrice = computed(
   () =>
     prices.value?.[props.plan]?.[props.yearlyIntervalSelected ? 'yearly' : 'monthly']
 )
+
+const finalPlanPrice = computed(() => {
+  const basePrice = prices.value?.[props.plan].monthly?.['workspace:member']
+  if (!basePrice) return undefined
+  return {
+    ...basePrice,
+    amount: props.yearlyIntervalSelected ? basePrice.amount * 0.8 : basePrice.amount
+  }
+})
 
 const hasCta = computed(() => !!slots.cta)
 const canUpgradeToPlan = computed(() => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2fd2d7ae-46e2-4412-bd0e-2c3315c7a153)

From benjamin:
So to be clear: It shouldn't say "per seat/year" like the person writes in the email. We still want to display the monthly price, just with the yearly discount. 