### PR TITLE
Feat(dui3): Remove account functionality

### DIFF
--- a/packages/dui3/components/accounts/Item.vue
+++ b/packages/dui3/components/accounts/Item.vue
@@ -27,20 +27,54 @@
           </span>
         </div>
       </div>
+      <button
+        class="flex hidden group-hover:block px-2 py-1 text-danger"
+        @click.stop="showRemoveAccountDialog = true"
+      >
+        <TrashIcon class="w-4 h-4" />
+      </button>
     </div>
   </button>
+  <CommonDialog v-model:open="showRemoveAccountDialog" fullscreen="none">
+    <template #header>Remove Account</template>
+    <div class="text-xs mb-4">
+      Removing the account will remove the related model cards from your file. Do you
+      want to remove the account?
+    </div>
+    <div class="flex justify-between center py-2 space-x-3">
+      <FormButton
+        size="sm"
+        color="outline"
+        full-width
+        @click="showRemoveAccountDialog = false"
+      >
+        No
+      </FormButton>
+      <FormButton size="sm" full-width @click="handleRemove(account)">
+        Remove
+      </FormButton>
+    </div>
+  </CommonDialog>
 </template>
 <script setup lang="ts">
 import type { DUIAccount } from '~~/store/accounts'
+import { TrashIcon } from '@heroicons/vue/24/outline'
 
 const props = defineProps<{
   account: DUIAccount
   currentSelectedAccountId?: string
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'select', account: DUIAccount): void
+  (e: 'remove', account: DUIAccount): void
 }>()
+
+const showRemoveAccountDialog = ref(false)
+
+const handleRemove = (account: DUIAccount) => {
+  emit('remove', account)
+}
 
 const userAvatar = computed(() => {
   return {

--- a/packages/dui3/components/accounts/Menu.vue
+++ b/packages/dui3/components/accounts/Menu.vue
@@ -20,6 +20,7 @@
           :account="(acc as DUIAccount)"
           class="rounded-lg mb-2"
           @select="selectAccount(acc as DUIAccount)"
+          @remove="removeAccount(acc as DUIAccount)"
         />
         <div class="mt-4">
           <FormButton
@@ -67,7 +68,7 @@ const app = useNuxtApp()
 const { $openUrl } = useNuxtApp()
 const { pingDesktopService } = useDesktopService()
 
-const props = defineProps<{
+defineProps<{
   currentSelectedAccountId?: string
 }>()
 
@@ -91,7 +92,7 @@ watch(showAccountsDialog, (newVal) => {
 })
 
 const accountStore = useAccountStore()
-const { accounts, defaultAccount, userSelectedAccount, isLoading } =
+const { accounts, activeAccount, userSelectedAccount, isLoading } =
   storeToRefs(accountStore)
 
 watch(accounts, (newVal, oldVal) => {
@@ -107,17 +108,27 @@ const selectAccount = (acc: DUIAccount) => {
   void trackEvent('DUI3 Action', { name: 'Account change' })
 }
 
+const removeAccount = async (acc: DUIAccount) => {
+  await accountStore.removeAccount(acc)
+  void trackEvent('DUI3 Action', { name: 'Account removed' })
+}
+
 const user = computed(() => {
-  if (!defaultAccount.value) return undefined
-  let acc = defaultAccount.value
-  if (props.currentSelectedAccountId) {
-    acc = accounts.value.find(
-      (acc) => acc.accountInfo.id === props.currentSelectedAccountId
-    ) as DUIAccount
-  }
+  // if (!defaultAccount.value) return undefined
+  // let acc = defaultAccount.value
+  // if (props.currentSelectedAccountId) {
+  //   const currentSelectedAccount = accounts.value.find(
+  //     (acc) => acc.accountInfo.id === props.currentSelectedAccountId
+  //   ) as DUIAccount
+  //   // currentSelectedAccount could be removed by user
+  //   if (currentSelectedAccount) {
+  //     acc = currentSelectedAccount
+  //   }
+  // }
+
   return {
-    name: acc.accountInfo.userInfo.name,
-    avatar: acc.accountInfo.userInfo.avatar
+    name: activeAccount.value.accountInfo.userInfo.name,
+    avatar: activeAccount.value.accountInfo.userInfo.avatar
   }
 })
 

--- a/packages/dui3/lib/bindings/definitions/IAccountBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IAccountBinding.ts
@@ -4,6 +4,7 @@ export const IAccountBindingKey = 'accountsBinding'
 
 export interface IAccountBinding extends IBinding<IAccountBindingEvents> {
   getAccounts: () => Promise<Account[]>
+  removeAccount: (accountId: string) => Promise<void>
 }
 
 // An almost 1-1 mapping of what we need from the Core accounts class.

--- a/packages/dui3/lib/bindings/definitions/IBasicConnectorBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IBasicConnectorBinding.ts
@@ -25,6 +25,7 @@ export interface IBasicConnectorBinding
   highlightModel: (modelCardId: string) => Promise<void>
   highlightObjects: (objectIds: string[]) => Promise<void>
   removeModel: (model: IModelCard) => Promise<void>
+  removeModels: (models: IModelCard[]) => Promise<void>
 }
 
 export interface IBasicConnectorBindingHostEvents

--- a/packages/dui3/store/accounts.ts
+++ b/packages/dui3/store/accounts.ts
@@ -57,8 +57,15 @@ export const useAccountStore = defineStore('accountStore', () => {
    * Returns either the default account or the last account the user has selected.
    */
   const activeAccount = computed(() => {
-    return userSelectedAccount.value || defaultAccount.value
+    return userSelectedAccount.value || accounts.value[0]
   })
+
+  const removeAccount = async (acc: DUIAccount) => {
+    await $accountBinding.removeAccount(acc.accountInfo.id)
+    await hostAppStore.removeAccountModels(acc.accountInfo.id)
+    // TODO: post clean up for model cards that belongs to that account
+    await refreshAccounts()
+  }
 
   const setUserSelectedAccount = (acc: DUIAccount) => {
     userSelectedAccount.value = acc
@@ -290,6 +297,7 @@ export const useAccountStore = defineStore('accountStore', () => {
     activeAccount,
     userSelectedAccount,
     setUserSelectedAccount,
+    removeAccount,
     accountByServerUrl,
     isAccountExistsById,
     isAccountExistsByServer,

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -165,13 +165,25 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     )
   }
 
+  const removeAccountModels = async (accountId: string) => {
+    const modelsToRemove = documentModelStore.value.models.filter(
+      (item) => item.accountId === accountId
+    )
+    documentModelStore.value.models = documentModelStore.value.models.filter(
+      (item) => item.accountId !== accountId
+    )
+
+    if (modelsToRemove.length !== 0) {
+      await app.$baseBinding.removeModels(modelsToRemove)
+    }
+  }
+
   const removeProjectModels = async (projectId: string) => {
     const modelsToRemove = documentModelStore.value.models.filter(
       (item) => item.projectId === projectId
     )
-
-    for (const modelToRemove of modelsToRemove) {
-      await removeModel(modelToRemove)
+    if (modelsToRemove.length !== 0) {
+      await app.$baseBinding.removeModels(modelsToRemove)
     }
   }
 
@@ -660,6 +672,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     addModel,
     patchModel,
     removeModel,
+    removeAccountModels,
     removeProjectModels,
     sendModel,
     receiveModel,


### PR DESCRIPTION
There are some cases/facts that we need to test carefully
- I would like to get rid of from `defaultAccount`, previously we were relying on it but i wanna rely on `activeAccount` and did some changes for it
- What will happen once removed the only account we have
- Connectors should have this PR in -> https://github.com/specklesystems/speckle-sharp-connectors/pull/680
- There are some vue warns which i am curious I introduced them or not. Need to check later
![image](https://github.com/user-attachments/assets/2031e62e-62c9-4459-992f-67b5f8ec330f)
