### PR TITLE
Fix: Remove wrong mutateActiveWorkspaceSlug call

### DIFF
--- a/packages/frontend-2/lib/workspaces/composables/wizard.ts
+++ b/packages/frontend-2/lib/workspaces/composables/wizard.ts
@@ -192,7 +192,6 @@ export const useWorkspacesWizard = () => {
 
   const finalizeWizard = async (state: WorkspaceWizardState, workspaceId: string) => {
     isLoading.value = true
-    mutateActiveWorkspaceSlug(workspaceId)
 
     if (state.region?.key && state.plan === PaidWorkspacePlans.Business) {
       await updateWorkspaceDefaultRegion({


### PR DESCRIPTION
This incorrectly uses the workspace ID but it also redudant