### PR TITLE
chore(fileimport service): pin image digest and bump nodejs version

### DIFF
--- a/packages/fileimport-service/Dockerfile
+++ b/packages/fileimport-service/Dockerfile
@@ -20,12 +20,15 @@ RUN apt-get update -y \
      --no-install-recommends \
      ca-certificates=20240203 \
      curl=8.5.0-2ubuntu10.6 \
-    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x -o nodesource_setup.sh \
+    && chmod +x ./nodesource_setup.sh \
+    && ./nodesource_setup.sh \
+    && rm ./nodesource_setup.sh \
     && curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini \
     && chmod +x /usr/bin/tini \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
      --no-install-recommends \
-     nodejs=18.20.6-1nodesource1 \
+     nodejs=22.14.0-1nodesource1 \
     && npm install -g corepack@0.30.0 \
     && corepack enable \
     && DEBIAN_FRONTEND=noninteractive apt-get remove curl -y \


### PR DESCRIPTION
## Description & motivation

The file import service, while running on Kubernetes, experiences a rapid increase in 'process resident memory' allocation (in `top`, this is seen as `RES` memory type) during the download of files . The 'process resident memory'/`RES` increases disproportionately to the file size, and is not correlated to the allocated nodejs heap size.

This might possibly be indicative of a native memory leak. As a possible solution, this PR attempts to increase the node version in case a later version resolves this issue.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
