### PR TITLE
feat: reverts removal of theme toggle

### DIFF
--- a/packages/dui3/layouts/default.vue
+++ b/packages/dui3/layouts/default.vue
@@ -6,15 +6,32 @@
     </main>
     <div
       v-if="hasNoModelCards"
-      class="px-3 pt-1 text-tiny text-foreground-2 text-center"
+      class="px-3 text-body-3xs text-foreground-2 justify-center bg-red-200/1 py-2 flex items-center w-full space-x-2"
     >
-      Version {{ hostApp.connectorVersion }}
+      <span>Version {{ hostApp.connectorVersion }}</span>
+      <FormButton
+        size="sm"
+        text
+        color="subtle"
+        :icon-right="isDarkTheme ? SunIcon : MoonIcon"
+        hide-text
+        @click="toggleTheme()"
+      >
+        Toggle theme
+      </FormButton>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import { useHostAppStore } from '~/store/hostApp'
+import { useConfigStore } from '~/store/config'
+import { MoonIcon, SunIcon } from '@heroicons/vue/24/outline'
+
+const uiConfigStore = useConfigStore()
+const { isDarkTheme } = storeToRefs(uiConfigStore)
+const { toggleTheme } = uiConfigStore
 
 const hostApp = useHostAppStore()
 const hasNoModelCards = computed(() => hostApp.projectModelGroups.length === 0)


### PR DESCRIPTION
Adds back a theme toggle in empty states: 

<img width="223" alt="image" src="https://github.com/user-attachments/assets/139e1825-4683-4847-acb9-555a45ba51f3" />