### PR TITLE
chore(authz): hoist authorizeresolver

### DIFF
--- a/packages/server/modules/core/domain/streams/operations.ts
+++ b/packages/server/modules/core/domain/streams/operations.ts
@@ -292,8 +292,7 @@ export type DeleteStream = (streamId: string, deleterId: string) => Promise<bool
 
 export type UpdateStream = (
   update: StreamUpdateInput | ProjectUpdateInput,
-  updaterId: string,
-  updaterResourceAccessRules: ContextResourceAccessRules
+  updaterId: string
 ) => Promise<Stream>
 
 export type LegacyUpdateStream = (

--- a/packages/server/modules/core/domain/streams/operations.ts
+++ b/packages/server/modules/core/domain/streams/operations.ts
@@ -288,14 +288,7 @@ export type LegacyCreateStream = (
   params: StreamCreateInput & { ownerId: string }
 ) => Promise<string>
 
-export type DeleteStream = (
-  streamId: string,
-  deleterId: string,
-  deleterResourceAccessRules: ContextResourceAccessRules,
-  options?: {
-    skipAccessChecks?: boolean
-  }
-) => Promise<boolean>
+export type DeleteStream = (streamId: string, deleterId: string) => Promise<boolean>
 
 export type UpdateStream = (
   update: StreamUpdateInput | ProjectUpdateInput,

--- a/packages/server/modules/core/graph/resolvers/projects.ts
+++ b/packages/server/modules/core/graph/resolvers/projects.ts
@@ -218,30 +218,32 @@ export = {
             deleteStream: deleteStreamFactory({
               db: projectDb
             }),
-            authorizeResolver,
             emitEvent: getEventBus().emit,
             deleteAllResourceInvites: deleteAllResourceInvitesFactory({ db }),
             getStream: getStreamFactory({ db: projectDb })
           })
-          return deleteStreamAndNotify(id, ctx.userId!, ctx.resourceAccessRules, {
-            skipAccessChecks: true
-          })
+          return deleteStreamAndNotify(id, ctx.userId!)
         })
       )
       return results.every((res) => res === true)
     },
-    async delete(_parent, { id }, { userId, resourceAccessRules }) {
-      const projectDb = await getProjectDbClient({ projectId: id })
+    async delete(_parent, { id: projectId }, { userId, resourceAccessRules }) {
+      await authorizeResolver(
+        userId,
+        projectId,
+        Roles.Stream.Owner,
+        resourceAccessRules
+      )
+      const projectDb = await getProjectDbClient({ projectId })
       const deleteStreamAndNotify = deleteStreamAndNotifyFactory({
         deleteStream: deleteStreamFactory({
           db: projectDb
         }),
-        authorizeResolver,
         emitEvent: getEventBus().emit,
         deleteAllResourceInvites: deleteAllResourceInvitesFactory({ db }),
         getStream: getStreamFactory({ db: projectDb })
       })
-      return await deleteStreamAndNotify(id, userId!, resourceAccessRules)
+      return await deleteStreamAndNotify(projectId, userId!)
     },
     async createForOnboarding(_parent, _args, { userId, resourceAccessRules, log }) {
       return await createOnboardingStream({

--- a/packages/server/modules/core/graph/resolvers/projects.ts
+++ b/packages/server/modules/core/graph/resolvers/projects.ts
@@ -253,14 +253,19 @@ export = {
       })
     },
     async update(_parent, { update }, { userId, resourceAccessRules }) {
+      await authorizeResolver(
+        userId,
+        update.id,
+        Roles.Stream.Owner,
+        resourceAccessRules
+      )
       const projectDB = await getProjectDbClient({ projectId: update.id })
       const updateStreamAndNotify = updateStreamAndNotifyFactory({
-        authorizeResolver,
         getStream: getStreamFactory({ db: projectDB }),
         updateStream: updateStreamFactory({ db: projectDB }),
         emitEvent: getEventBus().emit
       })
-      return await updateStreamAndNotify(update, userId!, resourceAccessRules)
+      return await updateStreamAndNotify(update, userId!)
     },
     // This one is only used outside of a workspace, so the project is always created in the main db
     async create(_parent, args, context) {

--- a/packages/server/modules/core/graph/resolvers/streams.ts
+++ b/packages/server/modules/core/graph/resolvers/streams.ts
@@ -115,7 +115,6 @@ const deleteStreamAndNotify = deleteStreamAndNotifyFactory({
   getStream
 })
 const updateStreamAndNotify = updateStreamAndNotifyFactory({
-  authorizeResolver,
   getStream,
   updateStream: updateStreamFactory({ db }),
   emitEvent: getEventBus().emit
@@ -428,11 +427,13 @@ export = {
     },
 
     async streamUpdate(_, args, context) {
-      await updateStreamAndNotify(
-        args.stream,
-        context.userId!,
+      await authorizeResolver(
+        context.userId,
+        args.stream.id,
+        Roles.Stream.Owner,
         context.resourceAccessRules
       )
+      await updateStreamAndNotify(args.stream, context.userId!)
       return true
     },
 

--- a/packages/server/modules/core/services/streams/management.ts
+++ b/packages/server/modules/core/services/streams/management.ts
@@ -115,30 +115,11 @@ export const legacyCreateStreamFactory =
 export const deleteStreamAndNotifyFactory =
   (deps: {
     deleteStream: DeleteStreamRecord
-    authorizeResolver: AuthorizeResolver
     deleteAllResourceInvites: DeleteAllResourceInvites
     getStream: GetStream
     emitEvent: EventBusEmit
   }): DeleteStream =>
-  async (
-    streamId: string,
-    deleterId: string,
-    deleterResourceAccessRules: ContextResourceAccessRules,
-    options?: {
-      skipAccessChecks?: boolean
-    }
-  ) => {
-    const { skipAccessChecks = false } = options || {}
-
-    if (!skipAccessChecks) {
-      await deps.authorizeResolver(
-        deleterId,
-        streamId,
-        Roles.Stream.Owner,
-        deleterResourceAccessRules
-      )
-    }
-
+  async (streamId: string, deleterId: string) => {
     const stream = await deps.getStream({ streamId })
     if (!stream)
       throw new LogicError('Unexpectedly stream that should exist is not found...')

--- a/packages/server/modules/core/services/streams/management.ts
+++ b/packages/server/modules/core/services/streams/management.ts
@@ -12,10 +12,7 @@ import {
 } from '@/modules/core/errors/stream'
 import { isProjectCreateInput } from '@/modules/core/helpers/stream'
 import { has } from 'lodash'
-import {
-  ContextResourceAccessRules,
-  isNewResourceAllowed
-} from '@/modules/core/helpers/token'
+import { isNewResourceAllowed } from '@/modules/core/helpers/token'
 import {
   TokenResourceIdentifier,
   TokenResourceIdentifierType
@@ -39,7 +36,6 @@ import {
   UpdateStreamRole
 } from '@/modules/core/domain/streams/operations'
 import { StoreBranch } from '@/modules/core/domain/branches/operations'
-import { AuthorizeResolver } from '@/modules/shared/domain/operations'
 import { DeleteAllResourceInvites } from '@/modules/serverinvites/domain/operations'
 import { LogicError } from '@/modules/shared/errors'
 import { EventBusEmit } from '@/modules/shared/services/eventBus'
@@ -154,23 +150,12 @@ export const deleteStreamAndNotifyFactory =
  */
 export const updateStreamAndNotifyFactory =
   (deps: {
-    authorizeResolver: AuthorizeResolver
+    // authorizeResolver: AuthorizeResolver
     getStream: GetStream
     updateStream: UpdateStreamRecord
     emitEvent: EventBusEmit
   }): UpdateStream =>
-  async (
-    update: StreamUpdateInput | ProjectUpdateInput,
-    updaterId: string,
-    updaterResourceAccessRules: ContextResourceAccessRules
-  ) => {
-    await deps.authorizeResolver(
-      updaterId,
-      update.id,
-      Roles.Stream.Owner,
-      updaterResourceAccessRules
-    )
-
+  async (update: StreamUpdateInput | ProjectUpdateInput, updaterId: string) => {
     const oldStream = await deps.getStream({ streamId: update.id, userId: updaterId })
     if (!oldStream) {
       throw new StreamUpdateError('Stream not found', {

--- a/packages/server/modules/core/services/streams/management.ts
+++ b/packages/server/modules/core/services/streams/management.ts
@@ -150,7 +150,6 @@ export const deleteStreamAndNotifyFactory =
  */
 export const updateStreamAndNotifyFactory =
   (deps: {
-    // authorizeResolver: AuthorizeResolver
     getStream: GetStream
     updateStream: UpdateStreamRecord
     emitEvent: EventBusEmit

--- a/packages/server/modules/core/tests/integration/subs.graph.spec.ts
+++ b/packages/server/modules/core/tests/integration/subs.graph.spec.ts
@@ -107,12 +107,11 @@ const buildDeleteProject = async (params: { projectId: string; ownerId: string }
     deleteStream: deleteStreamFactory({
       db: projectDb
     }),
-    authorizeResolver,
     emitEvent: getEventBus().emit,
     deleteAllResourceInvites: deleteAllResourceInvitesFactory({ db }),
     getStream: getStreamFactory({ db: projectDb })
   })
-  return async () => deleteStreamAndNotify(projectId, ownerId, null)
+  return async () => deleteStreamAndNotify(projectId, ownerId)
 }
 
 const buildUpdateProject = async (params: { projectId: string }) => {

--- a/packages/server/modules/core/tests/integration/subs.graph.spec.ts
+++ b/packages/server/modules/core/tests/integration/subs.graph.spec.ts
@@ -118,7 +118,6 @@ const buildUpdateProject = async (params: { projectId: string }) => {
   const { projectId } = params
   const projectDB = await getProjectDbClient({ projectId })
   const updateStreamAndNotify = updateStreamAndNotifyFactory({
-    authorizeResolver,
     getStream: getStreamFactory({ db: projectDB }),
     updateStream: updateStreamFactory({ db: projectDB }),
     emitEvent: getEventBus().emit
@@ -284,8 +283,7 @@ describe('Core GraphQL Subscriptions (New)', () => {
             const updateProject = await buildUpdateProject({ projectId })
             await updateProject(
               { id: projectId, name: new Date().toISOString() },
-              me.id,
-              null
+              me.id
             )
           }
 
@@ -591,11 +589,7 @@ describe('Core GraphQL Subscriptions (New)', () => {
             }
           )
           await meSubClient.waitForReadiness()
-          await updateProject(
-            { id: myProj.id, name: 'Updated Project Name' },
-            me.id,
-            null
-          )
+          await updateProject({ id: myProj.id, name: 'Updated Project Name' }, me.id)
 
           await Promise.all([
             onUserProjectsUpdated.waitForMessage(),
@@ -636,11 +630,7 @@ describe('Core GraphQL Subscriptions (New)', () => {
             }
           )
           await meSubClient.waitForReadiness()
-          await updateProject(
-            { id: myProj.id, name: 'Updated Project Name' },
-            me.id,
-            null
-          )
+          await updateProject({ id: myProj.id, name: 'Updated Project Name' }, me.id)
 
           await Promise.all([
             onUserProjectsUpdated.waitForTimeout(),

--- a/packages/server/modules/core/tests/streams.spec.ts
+++ b/packages/server/modules/core/tests/streams.spec.ts
@@ -164,7 +164,6 @@ const deleteStream = deleteStreamAndNotifyFactory({
 })
 
 const updateStream = updateStreamAndNotifyFactory({
-  authorizeResolver,
   getStream,
   updateStream: updateStreamFactory({ db }),
   emitEvent: getEventBus().emit
@@ -276,8 +275,7 @@ describe('Streams @core-streams', () => {
           name: 'Modified Name',
           description: 'Wooot'
         },
-        userOne.id,
-        null
+        userOne.id
       )
       const stream = await getStream({ streamId: testStream.id })
       expect(stream?.name).to.equal('Modified Name')
@@ -438,7 +436,7 @@ describe('Streams @core-streams', () => {
     })
 
     it('Should update stream updatedAt on stream update ', async () => {
-      await updateStream({ id: updatableStream.id, name: 'TU1' }, userOne.id, null)
+      await updateStream({ id: updatableStream.id, name: 'TU1' }, userOne.id)
       const su = await getStream({ streamId: updatableStream.id })
 
       expect(su?.updatedAt).to.be.ok

--- a/packages/server/modules/core/tests/streams.spec.ts
+++ b/packages/server/modules/core/tests/streams.spec.ts
@@ -158,7 +158,6 @@ const createStream = legacyCreateStreamFactory({
 })
 const deleteStream = deleteStreamAndNotifyFactory({
   deleteStream: deleteStreamFactory({ db }),
-  authorizeResolver,
   getStream,
   emitEvent: getEventBus().emit,
   deleteAllResourceInvites: deleteAllResourceInvitesFactory({ db })
@@ -310,7 +309,7 @@ describe('Streams @core-streams', () => {
         ownerId: userOne.id
       })
 
-      await deleteStream(id, userOne.id, null)
+      await deleteStream(id, userOne.id)
       const stream = await getStream({ streamId: id })
 
       expect(stream).to.not.be.ok


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- WIP auth work is complicated by `authorizeResolver` calls "buried" in services.
- Some of these are easy to hoist, some of these are in use in what are effectively "policies" already.

## Changes:

- Hoists easy-to-remove calls into resolvers
- Leaves "policy-like" calls for when we write those particular policies.
