### PR TITLE
Fix: missing model cards on external files

### DIFF
--- a/packages/dui3/pages/index.vue
+++ b/packages/dui3/pages/index.vue
@@ -195,12 +195,12 @@ const hasNoModelCards = computed(
   () => store.projectModelGroups.length === 0 || hasNoValidProjects.value
 )
 const hasNoValidProjects = computed(() => {
-  const accountIds = accounts.value
+  const serverUrls = accounts.value
     .filter((acc) => acc.isValid)
-    .map((acc) => acc.accountInfo.id)
+    .map((acc) => acc.accountInfo.serverInfo.url)
 
   return (
-    store.projectModelGroups.filter((p) => accountIds.includes(p.accountId)).length ===
+    store.projectModelGroups.filter((p) => serverUrls.includes(p.serverUrl)).length ===
     0
   )
 })


### PR DESCRIPTION
It was problematic with the files that someone else shared. Bc we were skipping by looking the accountId. Now we rely on the serverUrl.