### PR TITLE
feat(helm chart): support image pull secrets

### DIFF
--- a/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/deployment.yml
@@ -139,6 +139,12 @@ spec:
       priorityClassName: low-priority
       {{- if .Values.fileimport_service.serviceAccount.create }}
       serviceAccountName: {{ include "fileimport_service.name" $ }}
+      {{- else }}
+      {{- /* NOTE: If there is a service account, Kubernetes adds the imagePullSecrets to Pods automatically. */}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       # Should be > File import timeout to allow finishing up imports
       terminationGracePeriodSeconds: 610

--- a/utils/helm/speckle-server/templates/fileimport_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/fileimport_service/serviceaccount.yml
@@ -9,6 +9,10 @@ metadata:
   annotations:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 secrets:
   - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
 {{- if .Values.featureFlags.workspacesMultiRegionEnabled }}

--- a/utils/helm/speckle-server/templates/frontend_2/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend_2/deployment.yml
@@ -162,4 +162,10 @@ spec:
       {{- end }}
       {{- if .Values.frontend_2.serviceAccount.create }}
       serviceAccountName: {{ include "frontend_2.name" $ }}
+      {{- else }}
+      {{- /* NOTE: If there is a service account, Kubernetes adds the imagePullSecrets to Pods automatically. */}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}

--- a/utils/helm/speckle-server/templates/frontend_2/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/frontend_2/serviceaccount.yml
@@ -9,6 +9,10 @@ metadata:
   annotations:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 secrets:
   - name: {{ default .Values.secretName .Values.redis.connectionString.secretName }}
 {{- end -}}

--- a/utils/helm/speckle-server/templates/monitoring/deployment.yml
+++ b/utils/helm/speckle-server/templates/monitoring/deployment.yml
@@ -125,6 +125,12 @@ spec:
       priorityClassName: low-priority
       {{- if .Values.monitoring.serviceAccount.create }}
       serviceAccountName: {{ include "monitoring.name" $ }}
+      {{- else }}
+      {{- /* NOTE: If there is a service account, Kubernetes adds the imagePullSecrets to Pods automatically. */}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       terminationGracePeriodSeconds: 10
       securityContext:

--- a/utils/helm/speckle-server/templates/monitoring/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/monitoring/serviceaccount.yml
@@ -9,6 +9,10 @@ metadata:
   annotations:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 secrets:
   - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
 {{- if .Values.featureFlags.workspacesMultiRegionEnabled }}

--- a/utils/helm/speckle-server/templates/objects/deployment.yml
+++ b/utils/helm/speckle-server/templates/objects/deployment.yml
@@ -127,6 +127,12 @@ spec:
 
       {{- if .Values.objects.serviceAccount.create }}
       serviceAccountName: {{ include "objects.name" $ }}
+      {{- else }}
+      {{- /* NOTE: If there is a service account, Kubernetes adds the imagePullSecrets to Pods automatically. */}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       terminationGracePeriodSeconds: 310
       volumes:

--- a/utils/helm/speckle-server/templates/objects/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/objects/serviceaccount.yml
@@ -9,6 +9,10 @@ metadata:
   annotations:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 secrets:
   - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
   - name: {{ default .Values.secretName .Values.redis.connectionString.secretName }}

--- a/utils/helm/speckle-server/templates/preview_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/preview_service/deployment.yml
@@ -109,6 +109,12 @@ spec:
       priorityClassName: low-priority
       {{- if .Values.preview_service.serviceAccount.create }}
       serviceAccountName: {{ include "preview_service.name" $ }}
+      {{- else }}
+      {{- /* NOTE: If there is a service account, Kubernetes adds the imagePullSecrets to Pods automatically. */}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
 
       securityContext:

--- a/utils/helm/speckle-server/templates/preview_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/preview_service/serviceaccount.yml
@@ -10,6 +10,10 @@ metadata:
   annotations:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 secrets:
   - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
 {{- if .Values.featureFlags.workspacesMultiRegionEnabled }}

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -127,6 +127,12 @@ spec:
 
       {{- if .Values.server.serviceAccount.create }}
       serviceAccountName: {{ include "server.name" $ }}
+      {{- else }}
+      {{- /* NOTE: If there is a service account, Kubernetes adds the imagePullSecrets to Pods automatically. */}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       terminationGracePeriodSeconds: 310
       volumes:

--- a/utils/helm/speckle-server/templates/server/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/server/serviceaccount.yml
@@ -9,6 +9,10 @@ metadata:
   annotations:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 secrets:
   - name: {{ default .Values.secretName .Values.db.connectionString.secretName }}
   - name: {{ default .Values.secretName .Values.redis.connectionString.secretName }}

--- a/utils/helm/speckle-server/templates/tests/deployment.yml
+++ b/utils/helm/speckle-server/templates/tests/deployment.yml
@@ -57,5 +57,11 @@ spec:
 
       {{- if .Values.test.serviceAccount.create }}
       serviceAccountName: {{ include "test.name" $ }}
+      {{- else }}
+      {{- /* NOTE: If there is a service account, Kubernetes adds the imagePullSecrets to Pods automatically. */}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
 {{- end }}

--- a/utils/helm/speckle-server/templates/tests/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/tests/serviceaccount.yml
@@ -9,5 +9,9 @@ metadata:
   annotations:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 secrets: [] # does not have access to any secrets
 {{- end -}}

--- a/utils/helm/speckle-server/templates/webhook_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/deployment.yml
@@ -115,6 +115,12 @@ spec:
       priorityClassName: low-priority
       {{- if .Values.webhook_service.serviceAccount.create }}
       serviceAccountName: {{ include "webhook_service.name" $ }}
+      {{- else }}
+      {{- /* NOTE: If there is a service account, Kubernetes adds the imagePullSecrets to Pods automatically. */}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
 
       securityContext:

--- a/utils/helm/speckle-server/templates/webhook_service/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/serviceaccount.yml
@@ -9,6 +9,10 @@ metadata:
   annotations:
     "kubernetes.io/enforce-mountable-secrets": "true"
 automountServiceAccountToken: false
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 secrets:
   - name: {{ ( default .Values.secretName .Values.db.connectionString.secretName ) }}
 {{- if .Values.featureFlags.workspacesMultiRegionEnabled }}

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -608,6 +608,12 @@
         }
       }
     },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "The name of the Kubernetes Secret resource in which the Docker image pull secrets are stored. This is expected to be an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets",
+      "default": [],
+      "items": {}
+    },
     "server": {
       "type": "object",
       "properties": {

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -445,6 +445,10 @@ multiRegion:
     ## @param multiRegion.config.secretKey If workspacesMultiRegionEnabled is enabled, the server will be deployed in a multi-region configuration based on the values in a secret. This allows the default secret key and filename to be overridden.
     secretKey: 'multi-region-config.json'
 
+## @param imagePullSecrets The name of the Kubernetes Secret resource in which the Docker image pull secrets are stored. This is expected to be an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+## This is used to pull the Docker image from a private registry.  If this is not provided, no imagePullSecrets will be used.
+imagePullSecrets: []
+
 ## @section Server
 ## @descriptionStart
 ## Defines parameters related to the backend server component of Speckle.


### PR DESCRIPTION
## Description & motivation

Allows images to be pulled from private registries, or where authentication to a registry is required.

## Changes:

If `imagePullSecrets` are set in `values.yaml` file, the values are added to the `imagePullSecrets` property of either the serviceAccount, if enabled, or the deployment.

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

Ran `helm template` locally with and without image pull secrets, and it rendered correctly.

Have manually triggered the automated helm chart deployment test in CI, and it has passed.

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

- https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
- https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account