### PR TITLE
feat(server): wrapWithCache improved caching w/ shared promises

### DIFF
--- a/packages/server/modules/shared/utils/caching.ts
+++ b/packages/server/modules/shared/utils/caching.ts
@@ -64,6 +64,7 @@ export const wrapWithCache = <Args extends Array<any>, Results>(
 ) => {
   const cacheProvider = params.cacheProvider
   const { name, resolver, options } = params
+  const cachePromises = params.options?.cachePromises ?? true
   const { argsKey = (...args: Args) => JSON.stringify(args) } = options || {}
   const key = (...args: Args) => `wrapWithCache:${name}:${argsKey(...args)}`
 
@@ -103,7 +104,7 @@ export const wrapWithCache = <Args extends Array<any>, Results>(
   const freshResolver = buildResolver({ skipCache: true })
 
   const promiseCache = new Map<string, Promise<Results>>()
-  const mainResolver = options?.cachePromises
+  const mainResolver = cachePromises
     ? async (...args: Args) => {
         const cacheKey = key(...args)
         if (promiseCache.has(cacheKey)) {


### PR DESCRIPTION
Added a new option to wrapWithCache:
```
    /**
     * Whether to always return the same promise instead of creating a new one for each call when the args are the same.
     * This will avoid multiple calls to the resolver function on empty cache when they're invoked in short succession - the 2nd call
     * will just await the 1st call's promise.
     * Default: true
     */
```

Without this setting, assuming an empty cache, if you'd do a Promise.all() with multiple invocations of the same function with same args or (more realistically) if you'd have multiple GQL fields resolving the same fn with same args concurrently, each invocation would end up triggering the underlying resolver because there hasn't been enough time to cache the result yet.

With this setting, all of those invocations end up sharing the same Promise instance so the underlying resolver is still only invoked once