### PR TITLE
fix(gatekeeper): missing priceId-s should stop the server from booting

### DIFF
--- a/packages/server/app.ts
+++ b/packages/server/app.ts
@@ -197,7 +197,7 @@ export function buildApolloSubscriptionServer(params: {
         try {
           const headers = getHeaders({ connContext, connectionParams })
           const buildCtx = await buildContext({ token })
-          buildCtx.log.info(
+          buildCtx.log.debug(
             {
               userId: buildCtx.userId,
               ws_protocol: webSocket.protocol,

--- a/packages/server/modules/gatekeeper/stripe.ts
+++ b/packages/server/modules/gatekeeper/stripe.ts
@@ -22,44 +22,48 @@ export const getStripeClient = () => {
   return stripeClient
 }
 
-export const getWorkspacePlanProductAndPriceIds: GetWorkspacePlanProductAndPriceIds =
-  () => ({
-    // old
-    guest: {
-      productId: getStringFromEnv('WORKSPACE_GUEST_SEAT_STRIPE_PRODUCT_ID'),
-      monthly: getStringFromEnv('WORKSPACE_MONTHLY_GUEST_SEAT_STRIPE_PRICE_ID'),
-      yearly: getStringFromEnv('WORKSPACE_YEARLY_GUEST_SEAT_STRIPE_PRICE_ID')
-    },
-    starter: {
-      productId: getStringFromEnv('WORKSPACE_STARTER_SEAT_STRIPE_PRODUCT_ID'),
-      monthly: getStringFromEnv('WORKSPACE_MONTHLY_STARTER_SEAT_STRIPE_PRICE_ID'),
-      yearly: getStringFromEnv('WORKSPACE_YEARLY_STARTER_SEAT_STRIPE_PRICE_ID')
-    },
-    plus: {
-      productId: getStringFromEnv('WORKSPACE_PLUS_SEAT_STRIPE_PRODUCT_ID'),
-      monthly: getStringFromEnv('WORKSPACE_MONTHLY_PLUS_SEAT_STRIPE_PRICE_ID'),
-      yearly: getStringFromEnv('WORKSPACE_YEARLY_PLUS_SEAT_STRIPE_PRICE_ID')
-    },
-    business: {
-      productId: getStringFromEnv('WORKSPACE_BUSINESS_SEAT_STRIPE_PRODUCT_ID'),
-      monthly: getStringFromEnv('WORKSPACE_MONTHLY_BUSINESS_SEAT_STRIPE_PRICE_ID'),
-      yearly: getStringFromEnv('WORKSPACE_YEARLY_BUSINESS_SEAT_STRIPE_PRICE_ID')
-    },
-    // new
-    ...(FF_WORKSPACES_NEW_PLANS_ENABLED
-      ? {
-          team: {
-            productId: getStringFromEnv('WORKSPACE_TEAM_SEAT_STRIPE_PRODUCT_ID'),
-            monthly: getStringFromEnv('WORKSPACE_MONTHLY_TEAM_SEAT_STRIPE_PRICE_ID')
-          },
-          pro: {
-            productId: getStringFromEnv('WORKSPACE_PRO_SEAT_STRIPE_PRODUCT_ID'),
-            monthly: getStringFromEnv('WORKSPACE_MONTHLY_PRO_SEAT_STRIPE_PRICE_ID'),
-            yearly: getStringFromEnv('WORKSPACE_YEARLY_PRO_SEAT_STRIPE_PRICE_ID')
-          }
+const loadProductAndPriceIds: GetWorkspacePlanProductAndPriceIds = () => ({
+  // old
+  guest: {
+    productId: getStringFromEnv('WORKSPACE_GUEST_SEAT_STRIPE_PRODUCT_ID'),
+    monthly: getStringFromEnv('WORKSPACE_MONTHLY_GUEST_SEAT_STRIPE_PRICE_ID'),
+    yearly: getStringFromEnv('WORKSPACE_YEARLY_GUEST_SEAT_STRIPE_PRICE_ID')
+  },
+  starter: {
+    productId: getStringFromEnv('WORKSPACE_STARTER_SEAT_STRIPE_PRODUCT_ID'),
+    monthly: getStringFromEnv('WORKSPACE_MONTHLY_STARTER_SEAT_STRIPE_PRICE_ID'),
+    yearly: getStringFromEnv('WORKSPACE_YEARLY_STARTER_SEAT_STRIPE_PRICE_ID')
+  },
+  plus: {
+    productId: getStringFromEnv('WORKSPACE_PLUS_SEAT_STRIPE_PRODUCT_ID'),
+    monthly: getStringFromEnv('WORKSPACE_MONTHLY_PLUS_SEAT_STRIPE_PRICE_ID'),
+    yearly: getStringFromEnv('WORKSPACE_YEARLY_PLUS_SEAT_STRIPE_PRICE_ID')
+  },
+  business: {
+    productId: getStringFromEnv('WORKSPACE_BUSINESS_SEAT_STRIPE_PRODUCT_ID'),
+    monthly: getStringFromEnv('WORKSPACE_MONTHLY_BUSINESS_SEAT_STRIPE_PRICE_ID'),
+    yearly: getStringFromEnv('WORKSPACE_YEARLY_BUSINESS_SEAT_STRIPE_PRICE_ID')
+  },
+  // new
+  ...(FF_WORKSPACES_NEW_PLANS_ENABLED
+    ? {
+        team: {
+          productId: getStringFromEnv('WORKSPACE_TEAM_SEAT_STRIPE_PRODUCT_ID'),
+          monthly: getStringFromEnv('WORKSPACE_MONTHLY_TEAM_SEAT_STRIPE_PRICE_ID')
+        },
+        pro: {
+          productId: getStringFromEnv('WORKSPACE_PRO_SEAT_STRIPE_PRODUCT_ID'),
+          monthly: getStringFromEnv('WORKSPACE_MONTHLY_PRO_SEAT_STRIPE_PRICE_ID'),
+          yearly: getStringFromEnv('WORKSPACE_YEARLY_PRO_SEAT_STRIPE_PRICE_ID')
         }
-      : {})
-  })
+      }
+    : {})
+})
+
+const priceIds = loadProductAndPriceIds()
+
+export const getWorkspacePlanProductAndPriceIds: GetWorkspacePlanProductAndPriceIds =
+  () => priceIds
 
 export const getWorkspacePlanPriceId: GetWorkspacePlanPriceId = ({
   workspacePlan,

--- a/packages/server/observability/components/apollo/apolloSubscriptions.ts
+++ b/packages/server/observability/components/apollo/apolloSubscriptions.ts
@@ -35,7 +35,7 @@ export const onOperationHandlerFactory = (deps: {
     }
 
     const logger = ctx.log || subscriptionLogger
-    logger.info(
+    logger.debug(
       {
         graphql_operation_name: baseParams.operationName,
         userId: baseParams.context.userId,

--- a/packages/server/observability/components/knex/knexMonitoring.ts
+++ b/packages/server/observability/components/knex/knexMonitoring.ts
@@ -260,7 +260,7 @@ const initKnexPrometheusMetricsForRegionEvents = async (params: {
     }
 
     const trace = stackTrace || collectLongTrace()
-    params.logger.info(
+    params.logger.debug(
       {
         region,
         sql: data.sql,


### PR DESCRIPTION
The missing env vars were only validated at request time, not at server startup time.

Also included some log level lowerings, they are not relevant right now.