### PR TITLE
chore(helm chart): Stripe ID's are expressed in the values, not in a …

### DIFF
--- a/utils/helm/speckle-server/templates/_helpers.tpl
+++ b/utils/helm/speckle-server/templates/_helpers.tpl
@@ -615,112 +615,58 @@ Generate the environment variables for Speckle server and Speckle objects deploy
       key: {{ .Values.server.billing.stripeEndpointSigningKey.secretKey }}
 
 - name: WORKSPACE_GUEST_SEAT_STRIPE_PRODUCT_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceGuestSeatStripeProductId.secretKey }}
+  value: {{ .Values.server.billing.workspaceGuestSeatStripeProductId }}
 
 - name: WORKSPACE_MONTHLY_GUEST_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceMonthlyGuestSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceMonthlyGuestSeatStripePriceId }}
 
 - name: WORKSPACE_YEARLY_GUEST_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceYearlyGuestSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceYearlyGuestSeatStripePriceId }}
 
 - name: WORKSPACE_STARTER_SEAT_STRIPE_PRODUCT_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceStarterSeatStripeProductId.secretKey }}
+  value: {{ .Values.server.billing.workspaceStarterSeatStripeProductId }}
 
 - name: WORKSPACE_MONTHLY_STARTER_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceMonthlyStarterSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceMonthlyStarterSeatStripePriceId }}
 
 - name: WORKSPACE_YEARLY_STARTER_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceYearlyStarterSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceYearlyStarterSeatStripePriceId }}
 
 - name: WORKSPACE_PLUS_SEAT_STRIPE_PRODUCT_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspacePlusSeatStripeProductId.secretKey }}
+  value: {{ .Values.server.billing.workspacePlusSeatStripeProductId }}
 
 - name: WORKSPACE_MONTHLY_PLUS_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceMonthlyPlusSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceMonthlyPlusSeatStripePriceId }}
 
 - name: WORKSPACE_YEARLY_PLUS_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceYearlyPlusSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceYearlyPlusSeatStripePriceId }}
 
 - name: WORKSPACE_BUSINESS_SEAT_STRIPE_PRODUCT_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceBusinessSeatStripeProductId.secretKey }}
+  value: {{ .Values.server.billing.workspaceBusinessSeatStripeProductId }}
 
 - name: WORKSPACE_MONTHLY_BUSINESS_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceMonthlyBusinessSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceMonthlyBusinessSeatStripePriceId }}
 
 - name: WORKSPACE_YEARLY_BUSINESS_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceYearlyBusinessSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceYearlyBusinessSeatStripePriceId }}
 
 - name: WORKSPACE_TEAM_SEAT_STRIPE_PRODUCT_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceTeamSeatStripeProductId.secretKey }}
+  value: {{ .Values.server.billing.workspaceTeamSeatStripeProductId }}
 
 - name: WORKSPACE_MONTHLY_TEAM_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceMonthlyTeamSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceMonthlyTeamSeatStripePriceId }}
 
 - name: WORKSPACE_YEARLY_TEAM_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceYearlyTeamSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceYearlyTeamSeatStripePriceId }}
 
 - name: WORKSPACE_PRO_SEAT_STRIPE_PRODUCT_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceProSeatStripeProductId.secretKey }}
+  value: {{ .Values.server.billing.workspaceProSeatStripeProductId }}
 
 - name: WORKSPACE_MONTHLY_PRO_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceMonthlyProSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceMonthlyProSeatStripePriceId }}
 
 - name: WORKSPACE_YEARLY_PRO_SEAT_STRIPE_PRICE_ID
-  valueFrom:
-    secretKeyRef:
-      name: "{{ default .Values.secretName .Values.server.billing.secretName }}"
-      key: {{ .Values.server.billing.workspaceYearlyProSeatStripePriceId.secretKey }}
+  value: {{ .Values.server.billing.workspaceYearlyProSeatStripePriceId }}
 
 {{- end }}
 

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -831,184 +831,94 @@
               }
             },
             "workspaceGuestSeatStripeProductId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceGuestSeatStripeProductId secret as its value.",
-                  "default": "workspaceGuestSeatStripeProductId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Guest Seat Product Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceMonthlyGuestSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceMonthlyGuestSeatStripePriceId secret as its value.",
-                  "default": "workspaceMonthlyGuestSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Monthly Guest Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceYearlyGuestSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceYearlyGuestSeatStripePriceId secret as its value.",
-                  "default": "workspaceYearlyGuestSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Yearly Guest Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceStarterSeatStripeProductId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceStarterSeatStripeProductId secret as its value.",
-                  "default": "workspaceStarterSeatStripeProductId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Starter Seat Product Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceMonthlyStarterSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceMonthlyStarterSeatStripePriceId secret as its value.",
-                  "default": "workspaceMonthlyStarterSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Monthly Starter Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceYearlyStarterSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceYearlyStarterSeatStripePriceId secret as its value.",
-                  "default": "workspaceYearlyStarterSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Yearly Starter Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspacePlusSeatStripeProductId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspacePlusSeatStripeProductId secret as its value.",
-                  "default": "workspacePlusSeatStripeProductId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Plus Seat Product Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceMonthlyPlusSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceMonthlyPlusSeatStripePriceId secret as its value.",
-                  "default": "workspaceMonthlyPlusSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Monthly Plus Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceYearlyPlusSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceYearlyPlusSeatStripePriceId secret as its value.",
-                  "default": "workspaceYearlyPlusSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Yearly Plus Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceBusinessSeatStripeProductId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceBusinessSeatStripeProductId secret as its value.",
-                  "default": "workspaceBusinessSeatStripeProductId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Business Seat Product Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceMonthlyBusinessSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceMonthlyBusinessSeatStripePriceId secret as its value.",
-                  "default": "workspaceMonthlyBusinessSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Monthly Business Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceYearlyBusinessSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceYearlyBusinessSeatStripePriceId secret as its value.",
-                  "default": "workspaceYearlyBusinessSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Yearly Business Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceTeamSeatStripeProductId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceTeamSeatStripeProductId secret as its value.",
-                  "default": "workspaceTeamSeatStripeProductId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Team Seat Product Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceMonthlyTeamSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceMonthlyTeamSeatStripePriceId secret as its value.",
-                  "default": "workspaceMonthlyTeamSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Monthly Team Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceYearlyTeamSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceYearlyTeamSeatStripePriceId secret as its value.",
-                  "default": "workspaceYearlyTeamSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Yearly Team Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceProSeatStripeProductId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceProSeatStripeProductId secret as its value.",
-                  "default": "workspaceProSeatStripeProductId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Pro Seat Product Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceMonthlyProSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceMonthlyProSeatStripePriceId secret as its value.",
-                  "default": "workspaceMonthlyProSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Monthly Pro Seat Price Id as configured in Stripe.",
+              "default": ""
             },
             "workspaceYearlyProSeatStripePriceId": {
-              "type": "object",
-              "properties": {
-                "secretKey": {
-                  "type": "string",
-                  "description": "The key within the Kubernetes Secret holding the workspaceYearlyProSeatStripePriceId secret as its value.",
-                  "default": "workspaceYearlyProSeatStripePriceId"
-                }
-              }
+              "type": "string",
+              "description": "The workspace Yearly Pro Seat Price Id as configured in Stripe.",
+              "default": ""
             }
           }
         },

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -559,65 +559,48 @@ server:
     stripeEndpointSigningKey:
       ## @param server.billing.stripeEndpointSigningKey.secretKey The key within the Kubernetes Secret holding the stripeEndpointSigningKey secret as its value.
       secretKey: 'stripeEndpointSigningKey'
-    workspaceGuestSeatStripeProductId:
-      ## @param server.billing.workspaceGuestSeatStripeProductId.secretKey The key within the Kubernetes Secret holding the workspaceGuestSeatStripeProductId secret as its value.
-      secretKey: 'workspaceGuestSeatStripeProductId'
-    workspaceMonthlyGuestSeatStripePriceId:
-      ## @param server.billing.workspaceMonthlyGuestSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceMonthlyGuestSeatStripePriceId secret as its value.
-      secretKey: 'workspaceMonthlyGuestSeatStripePriceId'
-    workspaceYearlyGuestSeatStripePriceId:
-      ## @param server.billing.workspaceYearlyGuestSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceYearlyGuestSeatStripePriceId secret as its value.
-      secretKey: 'workspaceYearlyGuestSeatStripePriceId'
 
-    workspaceStarterSeatStripeProductId:
-      ## @param server.billing.workspaceStarterSeatStripeProductId.secretKey The key within the Kubernetes Secret holding the workspaceStarterSeatStripeProductId secret as its value.
-      secretKey: 'workspaceStarterSeatStripeProductId'
-    workspaceMonthlyStarterSeatStripePriceId:
-      ## @param server.billing.workspaceMonthlyStarterSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceMonthlyStarterSeatStripePriceId secret as its value.
-      secretKey: 'workspaceMonthlyStarterSeatStripePriceId'
-    workspaceYearlyStarterSeatStripePriceId:
-      ## @param server.billing.workspaceYearlyStarterSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceYearlyStarterSeatStripePriceId secret as its value.
-      secretKey: 'workspaceYearlyStarterSeatStripePriceId'
+    ## @param server.billing.workspaceGuestSeatStripeProductId The workspace Guest Seat Product Id as configured in Stripe.
+    workspaceGuestSeatStripeProductId: ''
+    ## @param server.billing.workspaceMonthlyGuestSeatStripePriceId The workspace Monthly Guest Seat Price Id as configured in Stripe.
+    workspaceMonthlyGuestSeatStripePriceId: ''
+    ## @param server.billing.workspaceYearlyGuestSeatStripePriceId The workspace Yearly Guest Seat Price Id as configured in Stripe.
+    workspaceYearlyGuestSeatStripePriceId: ''
 
-    workspacePlusSeatStripeProductId:
-      ## @param server.billing.workspacePlusSeatStripeProductId.secretKey The key within the Kubernetes Secret holding the workspacePlusSeatStripeProductId secret as its value.
-      secretKey: 'workspacePlusSeatStripeProductId'
-    workspaceMonthlyPlusSeatStripePriceId:
-      ## @param server.billing.workspaceMonthlyPlusSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceMonthlyPlusSeatStripePriceId secret as its value.
-      secretKey: 'workspaceMonthlyPlusSeatStripePriceId'
-    workspaceYearlyPlusSeatStripePriceId:
-      ## @param server.billing.workspaceYearlyPlusSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceYearlyPlusSeatStripePriceId secret as its value.
-      secretKey: 'workspaceYearlyPlusSeatStripePriceId'
+    ## @param server.billing.workspaceStarterSeatStripeProductId The workspace Starter Seat Product Id as configured in Stripe.
+    workspaceStarterSeatStripeProductId: ''
+    ## @param server.billing.workspaceMonthlyStarterSeatStripePriceId The workspace Monthly Starter Seat Price Id as configured in Stripe.
+    workspaceMonthlyStarterSeatStripePriceId: ''
+    ## @param server.billing.workspaceYearlyStarterSeatStripePriceId The workspace Yearly Starter Seat Price Id as configured in Stripe.
+    workspaceYearlyStarterSeatStripePriceId: ''
 
-    workspaceBusinessSeatStripeProductId:
-      ## @param server.billing.workspaceBusinessSeatStripeProductId.secretKey The key within the Kubernetes Secret holding the workspaceBusinessSeatStripeProductId secret as its value.
-      secretKey: 'workspaceBusinessSeatStripeProductId'
-    workspaceMonthlyBusinessSeatStripePriceId:
-      ## @param server.billing.workspaceMonthlyBusinessSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceMonthlyBusinessSeatStripePriceId secret as its value.
-      secretKey: 'workspaceMonthlyBusinessSeatStripePriceId'
-    workspaceYearlyBusinessSeatStripePriceId:
-      ## @param server.billing.workspaceYearlyBusinessSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceYearlyBusinessSeatStripePriceId secret as its value.
-      secretKey: 'workspaceYearlyBusinessSeatStripePriceId'
+    ## @param server.billing.workspacePlusSeatStripeProductId The workspace Plus Seat Product Id as configured in Stripe.
+    workspacePlusSeatStripeProductId: ''
+    ## @param server.billing.workspaceMonthlyPlusSeatStripePriceId The workspace Monthly Plus Seat Price Id as configured in Stripe.
+    workspaceMonthlyPlusSeatStripePriceId: ''
+    ## @param server.billing.workspaceYearlyPlusSeatStripePriceId The workspace Yearly Plus Seat Price Id as configured in Stripe.
+    workspaceYearlyPlusSeatStripePriceId: ''
 
-    workspaceTeamSeatStripeProductId:
-      ## @param server.billing.workspaceTeamSeatStripeProductId.secretKey The key within the Kubernetes Secret holding the workspaceTeamSeatStripeProductId secret as its value.
-      secretKey: 'workspaceTeamSeatStripeProductId'
-    workspaceMonthlyTeamSeatStripePriceId:
-      ## @param server.billing.workspaceMonthlyTeamSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceMonthlyTeamSeatStripePriceId secret as its value.
-      secretKey: 'workspaceMonthlyTeamSeatStripePriceId'
-    workspaceYearlyTeamSeatStripePriceId:
-      ## @param server.billing.workspaceYearlyTeamSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceYearlyTeamSeatStripePriceId secret as its value.
-      secretKey: 'workspaceYearlyTeamSeatStripePriceId'
+    ## @param server.billing.workspaceBusinessSeatStripeProductId The workspace Business Seat Product Id as configured in Stripe.
+    workspaceBusinessSeatStripeProductId: ''
+    ## @param server.billing.workspaceMonthlyBusinessSeatStripePriceId The workspace Monthly Business Seat Price Id as configured in Stripe.
+    workspaceMonthlyBusinessSeatStripePriceId: ''
+    ## @param server.billing.workspaceYearlyBusinessSeatStripePriceId The workspace Yearly Business Seat Price Id as configured in Stripe.
+    workspaceYearlyBusinessSeatStripePriceId: ''
 
-    workspaceProSeatStripeProductId:
-      ## @param server.billing.workspaceProSeatStripeProductId.secretKey The key within the Kubernetes Secret holding the workspaceProSeatStripeProductId secret as its value.
-      secretKey: 'workspaceProSeatStripeProductId'
-    workspaceMonthlyProSeatStripePriceId:
-      ## @param server.billing.workspaceMonthlyProSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceMonthlyProSeatStripePriceId secret as its value.
-      secretKey: 'workspaceMonthlyProSeatStripePriceId'
-    workspaceYearlyProSeatStripePriceId:
-      ## @param server.billing.workspaceYearlyProSeatStripePriceId.secretKey The key within the Kubernetes Secret holding the workspaceYearlyProSeatStripePriceId secret as its value.
-      secretKey: 'workspaceYearlyProSeatStripePriceId'
+    ## @param server.billing.workspaceTeamSeatStripeProductId The workspace Team Seat Product Id as configured in Stripe.
+    workspaceTeamSeatStripeProductId: ''
+    ## @param server.billing.workspaceMonthlyTeamSeatStripePriceId The workspace Monthly Team Seat Price Id as configured in Stripe.
+    workspaceMonthlyTeamSeatStripePriceId: ''
+    ## @param server.billing.workspaceYearlyTeamSeatStripePriceId The workspace Yearly Team Seat Price Id as configured in Stripe.
+    workspaceYearlyTeamSeatStripePriceId: ''
+
+    ## @param server.billing.workspaceProSeatStripeProductId The workspace Pro Seat Product Id as configured in Stripe.
+    workspaceProSeatStripeProductId: ''
+    ## @param server.billing.workspaceMonthlyProSeatStripePriceId The workspace Monthly Pro Seat Price Id as configured in Stripe.
+    workspaceMonthlyProSeatStripePriceId: ''
+    ## @param server.billing.workspaceYearlyProSeatStripePriceId The workspace Yearly Pro Seat Price Id as configured in Stripe.
+    workspaceYearlyProSeatStripePriceId: ''
 
   sessionSecret:
     ## @param server.sessionSecret.secretName The name of the Kubernetes Secret containing the Session secret.  This is a unique value (can be generated randomly). This is expected to be provided within the Kubernetes cluster as an opaque Kubernetes Secret. Ref: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets


### PR DESCRIPTION
## Description & motivation

Part of https://linear.app/speckle/issue/WEB-2932/move-stripe-id-s-to-helm-chart-values

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:
- [x] copy all required values from the secrets in to the helm values file for all relevant deployments

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
