### PR TITLE
Feat(dui3): upgrade select send filters

### DIFF
--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -569,6 +569,45 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     if (navisworksSavedSetsFromSendFilters) {
       navisworksAvailableSavedSets.value = navisworksSavedSetsFromSendFilters.items
     }
+
+    tryToUpgradeSelectSendFilters() // in rhino we trigger refresh send filters whenever layer name has changed, this should be done for navis too!
+  }
+
+  const tryToUpgradeSelectSendFilters = async () => {
+    for (const model of documentModelStore.value.models) {
+      const isSender = model.typeDiscriminator.toLowerCase().includes('sender')
+      if (!isSender) continue //  we do not care about receivers
+
+      if ((model as ISenderModelCard).sendFilter?.type !== 'Select') continue // we do not care about filters other than Select type
+
+      const existingSelectFilter = (model as ISenderModelCard)
+        .sendFilter as SendFilterSelect
+      const newSelectFilter = availableSelectSendFilters.value[existingSelectFilter.id]
+      if (!newSelectFilter) {
+        continue
+      }
+      // here we do the upgrade by checking available select filter items and existing select filter items against ids
+      const updatedSelectedItems = existingSelectFilter.selectedItems.map(
+        (selected) => {
+          const upgraded = newSelectFilter.items.find((item) => item.id === selected.id)
+          return upgraded ?? selected
+        }
+      )
+
+      const newSelectedFilter = {
+        ...existingSelectFilter,
+        selectedItems: updatedSelectedItems
+      } as SendFilterSelect
+
+      existingSelectFilter.selectedItems = updatedSelectedItems
+      existingSelectFilter.summary = existingSelectFilter.isMultiSelectable
+        ? existingSelectFilter.selectedItems.map((v) => v.name).join(', ')
+        : existingSelectFilter.selectedItems[0].name
+
+      await patchModel(model.modelCardId, {
+        sendFilters: newSelectedFilter
+      })
+    }
   }
 
   const getSendSettings = async () => {

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -594,19 +594,15 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         }
       )
 
-      const newSelectedFilter = {
-        ...existingSelectFilter,
-        items: newSelectFilter.items,
-        selectedItems: updatedSelectedItems
-      } as SendFilterSelect
-
+      existingSelectFilter.items = newSelectFilter.items
       existingSelectFilter.selectedItems = updatedSelectedItems
       existingSelectFilter.summary = existingSelectFilter.isMultiSelectable
         ? existingSelectFilter.selectedItems.map((v) => v.name).join(', ')
         : existingSelectFilter.selectedItems[0].name
 
+      // update the state in host app
       await patchModel(model.modelCardId, {
-        sendFilters: newSelectedFilter
+        sendFilters: existingSelectFilter
       })
     }
   }

--- a/packages/dui3/store/hostApp.ts
+++ b/packages/dui3/store/hostApp.ts
@@ -596,6 +596,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
 
       const newSelectedFilter = {
         ...existingSelectFilter,
+        items: newSelectFilter.items,
         selectedItems: updatedSelectedItems
       } as SendFilterSelect
 


### PR DESCRIPTION
Whenever user change the layer names, it was not updating the selected items. Now I trigger `RefreshSendFilters` in `LayerTableEvent` to be able to update send filter selected items and its summary.

![Rhino_Hw08eujeG3](https://github.com/user-attachments/assets/2afff9ff-46e8-424c-84fd-f5c8252f7eec)
