### PR TITLE
fix(authz): only exempt empty main model

### DIFF
--- a/packages/server/modules/gatekeeper/tests/integration/workspace.graph.spec.ts
+++ b/packages/server/modules/gatekeeper/tests/integration/workspace.graph.spec.ts
@@ -33,10 +33,7 @@ import {
   BasicTestBranch,
   createTestBranches
 } from '@/test/speckle-helpers/branchHelper'
-import {
-  createTestCommits,
-  createTestObject
-} from '@/test/speckle-helpers/commitHelper'
+import { createTestCommit, createTestObject } from '@/test/speckle-helpers/commitHelper'
 import { BasicTestStream, createTestStream } from '@/test/speckle-helpers/streamHelper'
 import { Roles } from '@speckle/shared'
 import { expect } from 'chai'
@@ -291,50 +288,34 @@ describe('Workspaces Billing', () => {
         }
         await createTestStream(project, user)
 
-        const models: BasicTestBranch[] = [
-          {
-            id: '',
-            streamId: project.id,
-            authorId: user.id,
-            name: createRandomString()
-          },
-          {
-            id: '',
-            streamId: project.id,
-            authorId: user.id,
-            name: createRandomString()
-          },
-          {
-            id: '',
-            streamId: project.id,
-            authorId: user.id,
-            name: createRandomString()
-          }
-        ]
+        const modelWithVersions: BasicTestBranch = {
+          id: '',
+          streamId: project.id,
+          authorId: user.id,
+          name: createRandomString()
+        }
+        const modelWithoutVersions: BasicTestBranch = {
+          id: '',
+          streamId: project.id,
+          authorId: user.id,
+          name: createRandomString()
+        }
         await createTestBranches(
-          models.map((branch) => ({
+          [modelWithVersions, modelWithoutVersions].map((branch) => ({
             owner: user,
             stream: project,
             branch
           }))
         )
+
         const objectId = await createTestObject({ projectId: project.id })
-        await createTestCommits([
-          {
-            id: '',
-            authorId: user.id,
-            objectId,
-            streamId: project.id,
-            branchName: models[0].name
-          },
-          {
-            id: '',
-            authorId: user.id,
-            objectId,
-            streamId: project.id,
-            branchName: models[1].name
-          }
-        ])
+        await createTestCommit({
+          id: '',
+          authorId: user.id,
+          objectId,
+          streamId: project.id,
+          branchName: modelWithVersions.name
+        })
 
         const session = await login(user)
 

--- a/packages/server/modules/workspaces/services/workspaceLimits.ts
+++ b/packages/server/modules/workspaces/services/workspaceLimits.ts
@@ -16,12 +16,7 @@ export const getWorkspaceModelCountFactory =
     for await (const projects of deps.queryAllWorkspaceProjects({ workspaceId })) {
       for (const project of projects) {
         modelCount =
-          modelCount +
-          (await deps.getPaginatedProjectModelsTotalCount(project.id, {
-            filter: {
-              onlyWithVersions: true
-            }
-          }))
+          modelCount + (await deps.getPaginatedProjectModelsTotalCount(project.id, {}))
       }
     }
 


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- As written, _all_ empty models are ignored for model count, but we only want to exempt `main` for v2

## Changes:

- Does that
