### PR TITLE
fix(fe): Remove thread id from url when resolved

### DIFF
--- a/packages/frontend-2/components/viewer/anchored-point/Thread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/Thread.vue
@@ -408,18 +408,18 @@ const canArchiveOrUnarchive = computed(
 )
 
 const toggleCommentResolvedStatus = async () => {
-  await archiveComment({
-    commentId: props.modelValue.id,
-    projectId: projectId.value,
-    archived: !props.modelValue.archived
-  })
-
   // Remove thread ID from URL when resolving
   if (!props.modelValue.archived) {
     const query = { ...router.currentRoute.value.query }
     delete query.thread
     await router.replace({ query })
   }
+
+  await archiveComment({
+    commentId: props.modelValue.id,
+    projectId: projectId.value,
+    archived: !props.modelValue.archived
+  })
 
   mp.track('Comment Action', {
     type: 'action',

--- a/packages/frontend-2/components/viewer/anchored-point/Thread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/Thread.vue
@@ -253,6 +253,7 @@ const { ellipsis, controls } = useAnimatingEllipsis()
 const { threadResourceStatus, hasClickedFullContext, goBack, handleContextClick } =
   useCommentContext()
 const { isOpenThread, open, closeAllThreads } = useThreadUtilities()
+const router = useRouter()
 
 const commentsContainer = ref(null as Nullable<HTMLElement>)
 const threadContainer = ref(null as Nullable<HTMLElement>)
@@ -412,6 +413,14 @@ const toggleCommentResolvedStatus = async () => {
     projectId: projectId.value,
     archived: !props.modelValue.archived
   })
+
+  // Remove thread ID from URL when resolving
+  if (!props.modelValue.archived) {
+    const query = { ...router.currentRoute.value.query }
+    delete query.thread
+    await router.replace({ query })
+  }
+
   mp.track('Comment Action', {
     type: 'action',
     name: 'archive',


### PR DESCRIPTION
To fix bug where limits dialog is shown on resolving thread. The thread id stays in the url, which triggers this bug as it sees the thread as unavailable. 