### PR TITLE
fix(server): ensure object IDs are like MD5 hashes; 32 character hexadecimal

### DIFF
--- a/packages/server/modules/core/services/objects/management.ts
+++ b/packages/server/modules/core/services/objects/management.ts
@@ -34,9 +34,9 @@ const prepInsertionObject = (
     obj.id =
       obj.id || crypto.createHash('md5').update(JSON.stringify(obj)).digest('hex') // generate a hash if none is present
 
-  if (!/^[a-f0-9]{32}$/.test(obj.id)) {
+  if (obj.id.length !== 32) {
     throw new ObjectHandlingError(
-      `Invalid object ID. Object ID: ${obj.id}. Object ID's must be hashes represented by a string of 32 hexadecimal characters.`
+      `Invalid object ID. Object ID: ${obj.id}. Object ID's must be hashes represented by a string of 32 characters.`
     )
   }
 


### PR DESCRIPTION
## Description & motivation

A number of users or third party application developers have caused some issues due to object IDs that are not 32-character length hashes.

This PR prevents objects being uploaded which are not conformant to the ID expectations.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
