### PR TITLE
Feat: Update legacy projects announcement

### DIFF
--- a/packages/frontend-2/components/projects/MoveToWorkspaceAlert.vue
+++ b/packages/frontend-2/components/projects/MoveToWorkspaceAlert.vue
@@ -1,42 +1,75 @@
 <template>
   <div>
-    <CommonCard class="!p-3 !bg-foundation mb-4">
+    <CommonCard class="pb-6 !bg-foundation mb-6">
       <div class="flex flex-col sm:flex-row sm:gap-2 text-foreground">
         <ExclamationCircleIcon class="h-8 w-8 m-1 text-warning shrink-0" />
         <div class="flex flex-col gap-4">
           <h3 class="text-heading mt-2">
             {{
               projectId
-                ? `Move this project to a workspace or it will be deleted in (count) days.`
-                : `Move projects to a workspace or they will be deleted in (count) days.`
+                ? `Move this project to a workspace`
+                : `Move your projects to a workspace`
             }}
           </h3>
 
-          <div class="text-body-xs max-w-3xl">
-            <p>
-              In our continuous effort to improve user experience, we are excited to
-              announce the rollout of several new features designed to simplify your
-              workflow and enhance navigation. Important facts:
+          <div class="text-body-xs">
+            <p class="mb-4">
+              How you work in Speckle is changing. We are
+              <span class="text-warning-darker align-top text-body">➊</span>
+              making workspaces the default way to work in Speckle, and
+              <span class="text-warning-darker align-top text-body">➋</span>
+              introducing new pricing including limits to the free plan.
             </p>
-            <ul class="list-disc list-inside pl-2">
-              <li>These updates will include customizable dashboards,</li>
-              <li>Improved search functionality,</li>
-              <li>And a more user-friendly interface</li>
-            </ul>
-          </div>
 
-          <div class="flex gap-2 mt-2 mb-3">
-            <FormButton @click="$emit('moveProject', projectId)">
-              {{ projectId ? 'Move project' : 'Show projects to move' }}
-            </FormButton>
+            <div v-show="showDetails" class="mb-3">
+              <h3 class="font-medium text-warning-darker">By June 1st 2025</h3>
+              <p>Move your projects to a workspace to:</p>
+              <ul class="list-disc list-inside pl-2 mb-4">
+                <li>
+                  <span class="font-medium">Create new projects and models</span>
+                  (will be disabled for personal projects; existing projects and models
+                  stay editable)
+                </li>
+                <li>
+                  <span class="font-medium">Invite new project collaborators</span>
+                  (new invites will be unavailable for personal projects)
+                </li>
+                <li>
+                  <span class="font-medium">Preserve version and comment history</span>
+                  (history is reduced to 7 days for personal projects)
+                </li>
+              </ul>
+              <h3 class="font-medium text-warning-darker">By Janury 1st 2026</h3>
+              <p>
+                All projects will be archived if not moved into a workspace. Don't
+                worry, we'll give you plenty of reminders before then.
+              </p>
+            </div>
+
             <FormButton
-              color="outline"
-              :to="LearnMoreMoveProjectsUrl"
-              external
-              target="_blank"
+              text
+              color="primary"
+              size="sm"
+              class="mb-5"
+              :icon-right="showDetails ? ChevronUpIcon : ChevronDownIcon"
+              @click="showDetails = !showDetails"
             >
-              Learn more
+              {{ showDetails ? 'Show less' : 'Show more' }}
             </FormButton>
+
+            <div class="flex gap-2">
+              <FormButton @click="$emit('moveProject', projectId)">
+                {{ projectId ? 'Move project' : 'Move projects' }}
+              </FormButton>
+              <FormButton
+                color="outline"
+                :to="LearnMoreMoveProjectsUrl"
+                external
+                target="_blank"
+              >
+                Explore new pricing
+              </FormButton>
+            </div>
           </div>
         </div>
       </div>
@@ -47,10 +80,14 @@
 <script setup lang="ts">
 import { ExclamationCircleIcon } from '@heroicons/vue/24/outline'
 import { LearnMoreMoveProjectsUrl } from '~/lib/common/helpers/route'
+import { ref } from 'vue'
+import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/vue/20/solid'
 
 defineEmits(['moveProject'])
 
 defineProps<{
   projectId?: string
 }>()
+
+const showDetails = ref(false)
 </script>

--- a/packages/frontend-2/components/projects/MoveToWorkspaceAlert.vue
+++ b/packages/frontend-2/components/projects/MoveToWorkspaceAlert.vue
@@ -80,7 +80,6 @@
 <script setup lang="ts">
 import { ExclamationCircleIcon } from '@heroicons/vue/24/outline'
 import { LearnMoreMoveProjectsUrl } from '~/lib/common/helpers/route'
-import { ref } from 'vue'
 import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/vue/20/solid'
 
 defineEmits(['moveProject'])

--- a/packages/frontend-2/lib/common/helpers/route.ts
+++ b/packages/frontend-2/lib/common/helpers/route.ts
@@ -213,4 +213,4 @@ export const doesRouteFitTarget = (fullPathA: string, fullPathB: string) => {
 // Link to Workspace roles and seats documentation
 // TODO: Add link when ready
 export const LearnMoreRolesSeatsUrl = 'https://speckle.guide/'
-export const LearnMoreMoveProjectsUrl = 'https://speckle.guide/'
+export const LearnMoreMoveProjectsUrl = 'https://speckle.systems/pricing'


### PR DESCRIPTION
Updated the personal projects announcement. A separate PR will track the expand/collapse so the state is preserved.

![CleanShot 2025-04-15 at 11 32 27@2x](https://github.com/user-attachments/assets/ca768caa-ebbc-45fc-998e-731d4048be79)

![CleanShot 2025-04-15 at 11 32 22@2x](https://github.com/user-attachments/assets/c8ba0c89-5086-420f-adca-239a964fc7d9)
