### PR TITLE
fix(fe): Update cache after requesting discoverable workspace access

### DIFF
--- a/packages/frontend-2/lib/workspaces/composables/discoverableWorkspaces.ts
+++ b/packages/frontend-2/lib/workspaces/composables/discoverableWorkspaces.ts
@@ -151,6 +151,26 @@ export const useDiscoverableWorkspaces = () => {
                 return id !== workspaceId
               }
             )
+          },
+          workspaceJoinRequests(existingRefs = []) {
+            // Add the workspace to join requests with Pending status
+            const workspace = discoverableWorkspaces.value?.find(
+              (w) => w.id === workspaceId
+            )
+            if (workspace) {
+              return {
+                ...existingRefs,
+                items: [
+                  ...(existingRefs?.items || []),
+                  {
+                    id: workspaceId,
+                    status: 'Pending',
+                    workspace
+                  }
+                ]
+              }
+            }
+            return existingRefs
           }
         }
       })


### PR DESCRIPTION
https://linear.app/speckle/issue/WEB-3001/join-existing-workspaces-modal-workspace-disappears-after-requesting