### PR TITLE
chore(server): fixed/improved commandFactory

### DIFF
--- a/packages/server/modules/shared/helpers/dbHelper.ts
+++ b/packages/server/modules/shared/helpers/dbHelper.ts
@@ -107,7 +107,7 @@ export const numberOfFreeConnections = (knex: Knex) => {
 }
 
 export const withTransaction = async <T>(
-  operation: (args: { db: Knex }) => MaybeAsync<T>,
+  operation: (args: { db: Knex; trx: Knex }) => MaybeAsync<T>,
   params: {
     db: Knex
   }
@@ -116,7 +116,8 @@ export const withTransaction = async <T>(
   const trx = await db.transaction()
 
   try {
-    const result = await operation({ db: trx })
+    // db and trx are just aliases, you can use whichever is more convenient
+    const result = await operation({ db: trx, trx })
     await trx.commit()
     return result
   } catch (e) {

--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -576,8 +576,6 @@ export = FF_WORKSPACES_MODULE_ENABLED
               return workspace
             },
             {
-              db,
-              eventBus,
               logger,
               name: 'createWorkspace',
               description: 'Create workspace',


### PR DESCRIPTION
commandFactory replacement that does what it already did, but also:
* makes sure `db` is the actual transaction. this misleading aspect of the original caused many usages to not use the trx correctly
* also merges withOperationLogging into the logic