### PR TITLE
refactor(fe): Workspace member actions updates

### DIFF
--- a/packages/frontend-2/lib/settings/composables/menu.ts
+++ b/packages/frontend-2/lib/settings/composables/menu.ts
@@ -206,6 +206,7 @@ export const useSettingsMembersActions = (params: {
   const showUpdateProjectPermissions = computed(() => canModifyUser.value)
 
   const actionItems = computed(() => {
+    const headerItems: LayoutMenuItem[] = []
     const mainItems: LayoutMenuItem[] = []
     const footerItems: LayoutMenuItem[] = []
 
@@ -230,13 +231,13 @@ export const useSettingsMembersActions = (params: {
       })
     }
     if (showUpgradeEditor.value) {
-      mainItems.push({
+      headerItems.push({
         title: 'Upgrade to editor...',
         id: WorkspaceUserActionTypes.UpgradeEditor
       })
     }
     if (showDowngradeEditor.value) {
-      mainItems.push({
+      headerItems.push({
         title: 'Downgrade to viewer...',
         id: WorkspaceUserActionTypes.DowngradeEditor,
         disabled: targetUserRole.value === Roles.Workspace.Admin,
@@ -278,6 +279,7 @@ export const useSettingsMembersActions = (params: {
     }
 
     const result: LayoutMenuItem[][] = []
+    if (headerItems.length) result.push(headerItems)
     if (mainItems.length) result.push(mainItems)
     if (footerItems.length) result.push(footerItems)
     return result

--- a/packages/frontend-2/lib/settings/composables/menu.ts
+++ b/packages/frontend-2/lib/settings/composables/menu.ts
@@ -184,7 +184,7 @@ export const useSettingsMembersActions = (params: {
   )
 
   const showMakeGuest = computed(
-    () => canModifyUser.value && targetUserRole.value !== Roles.Workspace.Guest
+    () => canModifyUser.value && targetUserRole.value === Roles.Workspace.Member
   )
 
   const showMakeMember = computed(
@@ -214,6 +214,14 @@ export const useSettingsMembersActions = (params: {
       mainItems.push({
         title: 'Make admin...',
         id: WorkspaceUserActionTypes.MakeAdmin
+      })
+    }
+    if (showRemoveAdmin.value) {
+      mainItems.push({
+        title: 'Revoke admin access...',
+        id: WorkspaceUserActionTypes.RemoveAdmin,
+        disabled: isOnlyAdmin.value,
+        disabledTooltip: 'There must be at least one admin in this workspace'
       })
     }
     if (showMakeGuest.value) {
@@ -253,14 +261,6 @@ export const useSettingsMembersActions = (params: {
       })
     }
 
-    if (showRemoveAdmin.value) {
-      footerItems.push({
-        title: 'Revoke admin access...',
-        id: WorkspaceUserActionTypes.RemoveAdmin,
-        disabled: isOnlyAdmin.value,
-        disabledTooltip: 'There must be at least one admin in this workspace'
-      })
-    }
     if (showRemoveFromWorkspace.value) {
       footerItems.push({
         title: 'Remove from workspace...',

--- a/packages/frontend-2/pages/settings/workspaces/[slug]/members.vue
+++ b/packages/frontend-2/pages/settings/workspaces/[slug]/members.vue
@@ -1,6 +1,6 @@
 <template>
   <section>
-    <div class="md:max-w-5xl md:mx-auto pb-6 md:pb-0">
+    <div class="md:max-w-5xl md:mx-auto pb-16">
       <SettingsSectionHeader
         hide-divider
         title="People"


### PR DESCRIPTION
Always show the seat change in a separate section alone in the top: 

In the admin menu: Hide the "Make guest…" action and move the "Revoke admin access…" up to the top of the second section.

