### PR TITLE
fix(invites): projectinvitablecollaborators should only return members

### DIFF
--- a/packages/server/modules/workspaces/repositories/users.ts
+++ b/packages/server/modules/workspaces/repositories/users.ts
@@ -104,5 +104,5 @@ export const countInvitableCollaboratorsByProjectIdFactory =
       search
     })
     const [res] = await query.count()
-    return parseInt(res.count.toString())
+    return parseInt(res?.count?.toString() ?? '0')
   }

--- a/packages/server/modules/workspaces/repositories/users.ts
+++ b/packages/server/modules/workspaces/repositories/users.ts
@@ -41,8 +41,8 @@ const buildInvitableCollaboratorsByProjectIdQueryFactory =
         Users.col.id,
         tables
           .streamAcl(db)
-          .select(StreamAcl.col.resourceId)
-          .whereNot(StreamAcl.col.resourceId, projectId)
+          .select(StreamAcl.col.userId)
+          .where(StreamAcl.col.resourceId, projectId)
       )
     if (search) {
       query

--- a/packages/server/modules/workspaces/tests/integration/repositories/users.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/repositories/users.spec.ts
@@ -6,275 +6,140 @@ import {
 import { getInvitableCollaboratorsByProjectIdFactory } from '@/modules/workspaces/repositories/users'
 import {
   assignToWorkspace,
+  BasicTestWorkspace,
   createTestWorkspace
 } from '@/modules/workspaces/tests/helpers/creation'
-import { createTestUser } from '@/test/authHelper'
-import { createTestStream } from '@/test/speckle-helpers/streamHelper'
-import { Roles } from '@speckle/shared'
+import { BasicTestUser, createTestUser, createTestUsers } from '@/test/authHelper'
+import { BasicTestStream, createTestStream } from '@/test/speckle-helpers/streamHelper'
 import { expect } from 'chai'
 import { pick } from 'lodash'
 
 describe('Workspace repositories', () => {
   describe('users repository', () => {
-    describe('getInvitableCollaboratorsByProjectIdFactory returns a function that ', () => {
+    describe('getInvitableCollaboratorsByProjectIdFactory returns a function, that', () => {
       const getInvitableCollaboratorsByProjectId =
         getInvitableCollaboratorsByProjectIdFactory({ db })
 
+      const adminUser: BasicTestUser = {
+        id: '',
+        name: createRandomString(),
+        email: createRandomEmail()
+      }
+      const workspaceMemberA: BasicTestUser = {
+        id: '',
+        name: createRandomString() + 'foo',
+        email: 'baz' + createRandomEmail()
+      }
+      const workspaceMemberB: BasicTestUser = {
+        id: '',
+        name: createRandomString() + 'baz',
+        email: 'bar' + createRandomEmail()
+      }
+      const nonWorkspaceMember: BasicTestUser = {
+        id: '',
+        name: createRandomString(),
+        email: createRandomEmail()
+      }
+
+      const testWorkspace: BasicTestWorkspace = {
+        id: createRandomString(),
+        name: createRandomString(),
+        slug: createRandomString(),
+        ownerId: ''
+      }
+
+      // The project we will run the test suite search against
+      const testProject: BasicTestStream = {
+        id: '',
+        ownerId: '',
+        name: createRandomString(),
+        isPublic: true,
+        workspaceId: ''
+      }
+      // An extra project for test comprehensiveness
+      const testOtherProject: BasicTestStream = {
+        id: '',
+        ownerId: '',
+        name: createRandomString(),
+        isPublic: true,
+        workspaceId: ''
+      }
+
+      before(async () => {
+        await createTestUser(adminUser)
+        await createTestUsers([workspaceMemberA, workspaceMemberB, nonWorkspaceMember])
+
+        await createTestWorkspace(testWorkspace, adminUser, {
+          addPlan: {
+            name: 'unlimited',
+            status: 'valid'
+          }
+        })
+        await assignToWorkspace(testWorkspace, workspaceMemberA)
+        await assignToWorkspace(testWorkspace, workspaceMemberB)
+
+        testProject.workspaceId = testWorkspace.id
+        testOtherProject.workspaceId = testWorkspace.id
+
+        await createTestStream(testProject, adminUser)
+        await createTestStream(testOtherProject, workspaceMemberA)
+      })
+
       it('should return all workspace collaborators not members of the project', async () => {
-        const admin = await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-        const workspace = {
-          id: createRandomString(),
-          name: createRandomString(),
-          slug: createRandomString(),
-          ownerId: admin.id
-        }
-        await createTestWorkspace(workspace, admin)
-
-        const member = await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-        await assignToWorkspace(workspace, member, Roles.Workspace.Member)
-
-        // Non workspace member
-        await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-
-        const projectMember = await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-
-        const project = {
-          id: createRandomString(),
-          workspaceId: workspace.id
-        }
-        await createTestStream(project, projectMember)
-
-        // User in another project should still be invitable
-        const otherProject = {
-          id: createRandomString(),
-          workspaceId: workspace.id
-        }
-        await createTestStream(otherProject, admin)
-
         const invitable = await getInvitableCollaboratorsByProjectId({
           filter: {
-            workspaceId: workspace.id,
-            projectId: project.id
+            workspaceId: testWorkspace.id,
+            projectId: testProject.id
           },
           limit: 10
         })
         expect(invitable).to.have.length(2)
         expect(invitable.map((i) => pick(i, ['id', 'name']))).to.deep.equalInAnyOrder([
-          { id: admin.id, name: admin.name },
-          { id: member.id, name: member.name }
+          { id: workspaceMemberA.id, name: workspaceMemberA.name },
+          { id: workspaceMemberB.id, name: workspaceMemberB.name }
         ])
       })
       it('should should filter by user name', async () => {
-        const admin = await createTestUser({
-          name: createRandomString() + 'fixed' + createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-        const workspace = {
-          id: createRandomString(),
-          name: createRandomString(),
-          slug: createRandomString(),
-          ownerId: admin.id
-        }
-        await createTestWorkspace(workspace, admin)
-
-        const member = await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-        await assignToWorkspace(workspace, member, Roles.Workspace.Member)
-
-        // Non workspace member
-        await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-
-        const projectMember = await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-
-        const project = {
-          id: createRandomString(),
-          workspaceId: workspace.id
-        }
-        await createTestStream(project, projectMember)
-
-        // User in another project should still be invitable
-        const otherProject = {
-          id: createRandomString(),
-          workspaceId: workspace.id
-        }
-        await createTestStream(otherProject, admin)
-
         const invitable = await getInvitableCollaboratorsByProjectId({
           filter: {
-            workspaceId: workspace.id,
-            projectId: project.id,
-            search: 'fixed'
+            workspaceId: testWorkspace.id,
+            projectId: testProject.id,
+            search: 'foo'
           },
           limit: 10
         })
         expect(invitable).to.have.length(1)
         expect(invitable.map((i) => pick(i, ['id', 'name']))).to.deep.equalInAnyOrder([
-          { id: admin.id, name: admin.name }
+          { id: workspaceMemberA.id, name: workspaceMemberA.name }
         ])
       })
       it('should should filter by user email', async () => {
-        const admin = await createTestUser({
-          name: createRandomString(),
-          email: createRandomString() + 'fixed' + createRandomString(),
-          role: Roles.Server.User,
-          verified: true
-        })
-        const workspace = {
-          id: createRandomString(),
-          name: createRandomString(),
-          slug: createRandomString(),
-          ownerId: admin.id
-        }
-        await createTestWorkspace(workspace, admin)
-
-        const member = await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-        await assignToWorkspace(workspace, member, Roles.Workspace.Member)
-
-        // Non workspace member
-        await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-
-        const projectMember = await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-
-        const project = {
-          id: createRandomString(),
-          workspaceId: workspace.id
-        }
-        await createTestStream(project, projectMember)
-
-        // User in another project should still be invitable
-        const otherProject = {
-          id: createRandomString(),
-          workspaceId: workspace.id
-        }
-        await createTestStream(otherProject, admin)
-
         const invitable = await getInvitableCollaboratorsByProjectId({
           filter: {
-            workspaceId: workspace.id,
-            projectId: project.id,
-            search: 'fixed'
+            workspaceId: testWorkspace.id,
+            projectId: testProject.id,
+            search: 'bar'
           },
           limit: 10
         })
         expect(invitable).to.have.length(1)
         expect(invitable.map((i) => pick(i, ['id', 'name']))).to.deep.equalInAnyOrder([
-          { id: admin.id, name: admin.name }
+          { id: workspaceMemberB.id, name: workspaceMemberB.name }
         ])
       })
       it('should should filter by user name and email', async () => {
-        const admin = await createTestUser({
-          name: createRandomString(),
-          email: createRandomString() + 'fixed' + createRandomString(),
-          role: Roles.Server.User,
-          verified: true
-        })
-        const workspace = {
-          id: createRandomString(),
-          name: createRandomString(),
-          slug: createRandomString(),
-          ownerId: admin.id
-        }
-        await createTestWorkspace(workspace, admin)
-
-        const member = await createTestUser({
-          name: createRandomString() + 'fixed' + createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-        await assignToWorkspace(workspace, member, Roles.Workspace.Member)
-
-        // Non workspace member
-        await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-
-        const projectMember = await createTestUser({
-          name: createRandomString(),
-          email: createRandomEmail(),
-          role: Roles.Server.User,
-          verified: true
-        })
-
-        const project = {
-          id: createRandomString(),
-          workspaceId: workspace.id
-        }
-        await createTestStream(project, projectMember)
-
-        // User in another project should still be invitable
-        const otherProject = {
-          id: createRandomString(),
-          workspaceId: workspace.id
-        }
-        await createTestStream(otherProject, admin)
-
         const invitable = await getInvitableCollaboratorsByProjectId({
           filter: {
-            workspaceId: workspace.id,
-            projectId: project.id,
-            search: 'fixed'
+            workspaceId: testWorkspace.id,
+            projectId: testProject.id,
+            search: 'baz'
           },
           limit: 10
         })
         expect(invitable).to.have.length(2)
         expect(invitable.map((i) => pick(i, ['id', 'name']))).to.deep.equalInAnyOrder([
-          { id: admin.id, name: admin.name },
-          { id: member.id, name: member.name }
+          { id: workspaceMemberA.id, name: workspaceMemberA.name },
+          { id: workspaceMemberB.id, name: workspaceMemberB.name }
         ])
       })
     })


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Invitable collaborators logic was returning too many members

## Changes:

- Adjust query to return expected list of:
  - Workspace users
  - Without project roles
- Update tests to reflect updated behavior
