### PR TITLE
Feat(dui3): store user selected workspace

### DIFF
--- a/packages/dui3/lib/bindings/definitions/IConfigBinding.ts
+++ b/packages/dui3/lib/bindings/definitions/IConfigBinding.ts
@@ -18,6 +18,9 @@ export interface IConfigBinding extends IBinding<IConfigBindingEvents> {
   updateConfig: (config: ConnectorConfig) => void
   setUserSelectedAccountId: (accountId: string) => void
   getUserSelectedAccountId: () => Promise<AccountsConfig>
+  getAccountsConfig: () => Promise<AccountsConfig> // should have been named like this from day 0. we should get rid of `getUserSelectedAccountId` function after some amount of time to not confuse ourselves.
+  setUserSelectedWorkspaceId: (workspaceId: string) => void
+  getWorkspacesConfig: () => Promise<WorkspacesConfig>
 }
 
 export interface IConfigBindingEvents extends IBindingSharedEvents {}
@@ -28,6 +31,10 @@ export type ConnectorConfig = {
 
 export type AccountsConfig = {
   userSelectedAccountId: string
+}
+
+export type WorkspacesConfig = {
+  userSelectedWorkspaceId: string
 }
 
 // Useless, but will do for now :)

--- a/packages/dui3/store/config.ts
+++ b/packages/dui3/store/config.ts
@@ -22,7 +22,11 @@ export const useConfigStore = defineStore('configStore', () => {
 
   const setUserSelectedWorkspace = (workspaceId: string) => {
     userSelectedWorkspaceId.value = workspaceId
-    $configBinding.setUserSelectedWorkspaceId(workspaceId)
+    try {
+      $configBinding.setUserSelectedWorkspaceId(workspaceId)
+    } catch (error) {
+      console.warn(error) // for the users who do not have latest version with workspace config handling
+    }
   }
 
   const isInitialized = ref(false)

--- a/packages/dui3/store/config.ts
+++ b/packages/dui3/store/config.ts
@@ -6,6 +6,8 @@ export const useConfigStore = defineStore('configStore', () => {
 
   const hasConfigBindings = ref(!!$configBinding)
 
+  const userSelectedWorkspaceId = ref<string>()
+
   const config = ref<ConnectorConfig>({ darkTheme: true })
 
   const isDarkTheme = computed(() => {
@@ -18,11 +20,20 @@ export const useConfigStore = defineStore('configStore', () => {
     $configBinding.updateConfig(config.value)
   }
 
+  const setUserSelectedWorkspace = (workspaceId: string) => {
+    userSelectedWorkspaceId.value = workspaceId
+    $configBinding.setUserSelectedWorkspaceId(workspaceId)
+  }
+
   const isInitialized = ref(false)
 
   const init = async () => {
     if (!$configBinding) return
     config.value = await $configBinding.getConfig()
+    const workspacesConfig = await $configBinding.getWorkspacesConfig()
+    if (workspacesConfig && workspacesConfig.userSelectedWorkspaceId) {
+      userSelectedWorkspaceId.value = workspacesConfig.userSelectedWorkspaceId
+    }
   }
   init()
 
@@ -37,6 +48,8 @@ export const useConfigStore = defineStore('configStore', () => {
     hasConfigBindings,
     isDarkTheme,
     isDevMode,
-    toggleTheme
+    userSelectedWorkspaceId,
+    toggleTheme,
+    setUserSelectedWorkspace
   }
 })


### PR DESCRIPTION
Same as user selected account id. we have internal state and also store in DUI3Config.db as below for next session.

Related sharp PR https://github.com/specklesystems/speckle-sharp-connectors/pull/771

![selected_workspace_in_db](https://github.com/user-attachments/assets/31fcb53a-8950-4230-bdda-596d3792743d)
