### PR TITLE
Move banners on billing page

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/billing/Page.vue
+++ b/packages/frontend-2/components/settings/workspaces/billing/Page.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="md:max-w-5xl md:mx-auto pb-6 md:pb-0 flex flex-col gap-y-2 md:gap-y-4">
+    <SettingsSectionHeader
+      title="Billing and plans"
+      text="Get billing information and upgrade your plan"
+    />
     <BillingAlert
       v-if="showBillingAlert"
-      class="mb-4"
+      class="mb-6"
       :workspace="workspace"
       hide-settings-links
     />
     <BillingUsageAlert
       v-if="reachedPlanLimit"
       :plan-name="workspace?.plan?.name"
-      class="mb-4"
-    />
-    <SettingsSectionHeader
-      title="Billing and plans"
-      text="Get billing information and upgrade your plan"
+      class="mb-6"
     />
     <div class="flex flex-col gap-y-6 md:gap-y-10">
       <section v-if="isNewPlan && !isFreePlan" class="flex flex-col gap-y-4 md:gap-y-6">


### PR DESCRIPTION
Move the banners on the Billing page below the section header

![CleanShot 2025-04-23 at 09 42 03@2x](https://github.com/user-attachments/assets/6a5c218b-fdf1-41f2-b1f8-bb9b5ed64753)
