### PR TITLE
Small updates to projects settings table

### DIFF
--- a/packages/frontend-2/components/settings/shared/projects/index.vue
+++ b/packages/frontend-2/components/settings/shared/projects/index.vue
@@ -21,12 +21,11 @@
       class="mt-6"
       :columns="[
         { id: 'name', header: 'Name', classes: 'col-span-3 truncate' },
-        { id: 'type', header: 'Type', classes: 'col-span-1' },
         { id: 'created', header: 'Created', classes: 'col-span-2' },
         { id: 'modified', header: 'Modified', classes: 'col-span-2' },
         { id: 'models', header: 'Models', classes: 'col-span-1' },
         { id: 'versions', header: 'Versions', classes: 'col-span-1' },
-        { id: 'contributors', header: 'Contributors', classes: 'col-span-2 pr-8' },
+        { id: 'contributors', header: 'Project members', classes: 'col-span-2 pr-8' },
         { id: 'actions', header: '', classes: 'absolute right-2 top-0.5' }
       ]"
       :items="projects"
@@ -35,12 +34,6 @@
         <NuxtLink :to="projectRoute(item.id)">
           {{ isProject(item) ? item.name : '' }}
         </NuxtLink>
-      </template>
-
-      <template #type="{ item }">
-        <div class="capitalize">
-          {{ isProject(item) ? item.visibility.toLowerCase() : '' }}
-        </div>
       </template>
 
       <template #created="{ item }">


### PR DESCRIPTION
- Rename Contributors -> Project members
- Remove the visibliity type. For now it just adds confusion.

![CleanShot 2025-04-23 at 09 56 06@2x](https://github.com/user-attachments/assets/cf126219-c9d5-49c1-b21d-8eee2a051edc)
