### PR TITLE
Fix input zooming on mobile Safari

### DIFF
--- a/packages/ui-components/src/components/form/TextArea.vue
+++ b/packages/ui-components/src/components/form/TextArea.vue
@@ -154,14 +154,14 @@ const iconClasses = computed(() => {
 const sizeClasses = computed((): string => {
   switch (props.size) {
     case 'sm':
-      return 'text-2xs !leading-tight'
+      return 'text-body sm:text-2xs !leading-tight'
     case 'lg':
-      return 'text-sm'
+      return 'text-body sm:text-sm'
     case 'xl':
-      return 'text-base'
+      return 'text-body sm:text-base'
     case 'base':
     default:
-      return 'text-body-xs'
+      return 'text-body sm:text-body-xs'
   }
 })
 

--- a/packages/ui-components/src/components/form/TextInput.vue
+++ b/packages/ui-components/src/components/form/TextInput.vue
@@ -376,9 +376,9 @@ const sizeClasses = computed((): string => {
     case 'sm':
       return 'h-6 text-body sm:text-body-sm'
     case 'lg':
-      return 'h-10 text-body sm:text-body-sm'
+      return 'h-10 text-body sm:text-[13px]'
     case 'xl':
-      return 'h-14 text-body sm:text-body-sm'
+      return 'h-14 text-body sm:text-sm'
     case 'base':
     default:
       return 'h-8 text-body sm:text-body-sm'

--- a/packages/ui-components/src/components/form/TextInput.vue
+++ b/packages/ui-components/src/components/form/TextInput.vue
@@ -374,14 +374,14 @@ const iconClasses = computed((): string => {
 const sizeClasses = computed((): string => {
   switch (props.size) {
     case 'sm':
-      return 'h-6 text-body-sm'
+      return 'h-6 text-body sm:text-body-sm'
     case 'lg':
-      return 'h-10 text-[13px]'
+      return 'h-10 text-body sm:text-body-sm'
     case 'xl':
-      return 'h-14 text-sm'
+      return 'h-14 text-body sm:text-body-sm'
     case 'base':
     default:
-      return 'h-8 text-body-sm'
+      return 'h-8 text-body sm:text-body-sm'
   }
 })
 

--- a/packages/ui-components/src/composables/form/textInput.ts
+++ b/packages/ui-components/src/composables/form/textInput.ts
@@ -78,7 +78,7 @@ export function useTextInputCore<V extends string | string[] = string>(params: {
 
   const coreClasses = computed(() => {
     const classParts = [
-      'block w-full text-foreground transition-all text-body-sm',
+      'block w-full text-foreground transition-all',
       coreInputClasses.value
     ]
 


### PR DESCRIPTION
Input and text area components have been updated to have 16px font size on mobile so that mobile browsers (Safari...) don't zoom on focus.

The font sizes in these components are really due for a clean up but I decided to do that later. For now I just added a mobile breakpoint change.