### PR TITLE
Fix: Tweak textarea font size and tweak some copy

### DIFF
--- a/packages/frontend-2/components/workspace/sidebar/FreePlanAlert.vue
+++ b/packages/frontend-2/components/workspace/sidebar/FreePlanAlert.vue
@@ -4,7 +4,7 @@
       class="p-2 pl-3 bg-info-lighter rounded-md flex items-center justify-between gap-x-2"
     >
       <p class="text-primary-focus text-body-3xs font-semibold dark:text-foreground">
-        You're on a free plan.
+        You're on the Free plan
       </p>
       <FormButton
         size="sm"

--- a/packages/ui-components/src/components/form/TextArea.vue
+++ b/packages/ui-components/src/components/form/TextArea.vue
@@ -154,7 +154,7 @@ const iconClasses = computed(() => {
 const sizeClasses = computed((): string => {
   switch (props.size) {
     case 'sm':
-      return 'text-body sm:text-2xs !leading-tight'
+      return 'text-body sm:text-body-2xs'
     case 'lg':
       return 'text-body sm:text-sm'
     case 'xl':


### PR DESCRIPTION
Two fixes to the workspace sidebar:
1. Fix the font size in the sm textarea
2. Tweak the copy in the Free banner

Text looked like this in the sm textarea...
![CleanShot 2025-04-26 at 07 25 32@2x](https://github.com/user-attachments/assets/35656081-6589-48b5-ad19-2a1ba591331d)
