### PR TITLE
Fix(dui3): use personalonly flag

### DIFF
--- a/packages/dui3/components/wizard/ProjectSelector.vue
+++ b/packages/dui3/components/wizard/ProjectSelector.vue
@@ -305,14 +305,15 @@ const {
 } = useQuery(
   projectsListQuery,
   () => ({
-    limit: 20, // stupid hack, increased it since we do manual filter to be able to see more project, see below TODO note, once we have `personalOnly` filter, decrease back to 10
+    limit: 10, // stupid hack, increased it since we do manual filter to be able to see more project, see below TODO note, once we have `personalOnly` filter, decrease back to 10
     filter: {
       search: (searchText.value || '').trim() || null,
       workspaceId:
         selectedWorkspace.value?.id === 'personalProject'
           ? null
           : selectedWorkspace.value?.id,
-      includeImplicitAccess: true
+      includeImplicitAccess: true,
+      personalOnly: selectedWorkspace.value?.id === 'personalProject'
     }
   }),
   () => ({


### PR DESCRIPTION
Filtering was cumbersome, TODO note handled. Now we can see personal projects right away when we select it

![image](https://github.com/user-attachments/assets/f3ab1d7d-b321-45cf-a4ca-2e3059e4b6b3)
