### PR TITLE
feat(automate): create test automations without functions

### DIFF
--- a/packages/frontend-2/components/automate/automation/CreateDialog.vue
+++ b/packages/frontend-2/components/automate/automation/CreateDialog.vue
@@ -54,24 +54,15 @@
         v-model:has-errors="hasParameterErrors"
         :fn="selectedFunction"
       />
-      <template v-else-if="enumStep === AutomationCreateSteps.AutomationDetails">
-        <AutomateAutomationCreateDialogAutomationDetailsStep
-          v-model:project="selectedProject"
-          v-model:model="selectedModel"
-          v-model:automation-name="automationName"
-          :preselected-project="preselectedProject"
-          :is-test-automation="isTestAutomation"
-          :workspace-id="workspaceId"
-        />
-        <AutomateAutomationCreateDialogSelectFunctionStep
-          v-if="isTestAutomation"
-          v-model:selected-function="selectedFunction"
-          :preselected-function="validatedPreselectedFunction"
-          :page-size="2"
-          :is-test-automation="true"
-          :workspace-id="workspaceId"
-        />
-      </template>
+      <AutomateAutomationCreateDialogAutomationDetailsStep
+        v-else-if="enumStep === AutomationCreateSteps.AutomationDetails"
+        v-model:project="selectedProject"
+        v-model:model="selectedModel"
+        v-model:automation-name="automationName"
+        :preselected-project="preselectedProject"
+        :is-test-automation="isTestAutomation"
+        :workspace-id="workspaceId"
+      />
     </div>
   </LayoutDialog>
 </template>
@@ -191,8 +182,7 @@ const shouldShowStepsWidget = computed(() => {
 })
 
 const enableSubmitTestAutomation = computed(() => {
-  const isValidInput =
-    !!automationName.value && !!selectedModel.value && !!selectedFunction.value
+  const isValidInput = !!automationName.value && !!selectedModel.value
   const isLoading = creationLoading.value
 
   return isValidInput && !isLoading
@@ -353,7 +343,7 @@ const onDetailsSubmit = handleDetailsSubmit(async () => {
   const parameters = functionParameters.value
   const name = automationName.value
 
-  if (!fn || !project || !model || !name?.length) {
+  if (!project || !model || !name?.length) {
     logger.error('Missing required data', {
       fn,
       project,
@@ -376,7 +366,6 @@ const onDetailsSubmit = handleDetailsSubmit(async () => {
         projectId: project.id,
         input: {
           name,
-          functionId: fn.id,
           modelId: model.id
         }
       })
@@ -391,9 +380,8 @@ const onDetailsSubmit = handleDetailsSubmit(async () => {
       return
     }
 
-    // Test automations can be created with functions without versions
-    // TODO: Stop requiring functions for test automations
-    if (!fnRelease) {
+    // Test automations can be created without functions
+    if (!fn || !fnRelease) {
       logger.error('Missing required data', {
         fn,
         project,

--- a/packages/frontend-2/components/automate/automation/CreateDialog.vue
+++ b/packages/frontend-2/components/automate/automation/CreateDialog.vue
@@ -353,7 +353,7 @@ const onDetailsSubmit = handleDetailsSubmit(async () => {
   const parameters = functionParameters.value
   const name = automationName.value
 
-  if (!fn || !project || !model || !name?.length || !fnRelease) {
+  if (!fn || !project || !model || !name?.length) {
     logger.error('Missing required data', {
       fn,
       project,
@@ -388,6 +388,20 @@ const onDetailsSubmit = handleDetailsSubmit(async () => {
 
       automationId.value = testAutomationId
       await goToNewAutomation()
+      return
+    }
+
+    // Test automations can be created with functions without versions
+    // TODO: Stop requiring functions for test automations
+    if (!fnRelease) {
+      logger.error('Missing required data', {
+        fn,
+        project,
+        model,
+        parameters,
+        name,
+        fnRelease
+      })
       return
     }
 

--- a/packages/frontend-2/components/project/page/automation/TestAutomationInfo.vue
+++ b/packages/frontend-2/components/project/page/automation/TestAutomationInfo.vue
@@ -1,17 +1,101 @@
 <template>
   <div>
     <h2 class="h6 font-medium mb-6">Configuration</h2>
-    <CommonCard class="bg-foundation" title="Environment">
-      <p>{{ projectId }}</p>
-      <p>{{ automationId }}</p>
+    <CommonCard class="bg-foundation">
+      <FormSelectBase
+        v-model="selectedLanguage"
+        class="mb-2"
+        name="language"
+        label="Language"
+        :items="items"
+      >
+        <template #option="{ item }">
+          <p>{{ item }}</p>
+        </template>
+        <template #something-selected="{ value }">
+          <p>{{ value }}</p>
+        </template>
+      </FormSelectBase>
+      <div class="relative mb-4 w-full bg-foundation-2 rounded-md">
+        <div class="w-full p-2 overflow-x-auto">
+          <pre
+            class="font-mono text-foreground text-body-xs -translate-y-px leading-normal"
+            >{{ environment }}</pre
+          >
+        </div>
+        <button
+          class="absolute flex items-center justify-center bottom-2 right-2 w-8 h-8 rounded-md border border-outline-3 bg-foundation"
+          @click="handleCopy"
+        >
+          <ClipboardDocumentIcon class="h-5 w-5 text-foreground" />
+        </button>
+      </div>
+      <CommonTextLink
+        size="sm"
+        external
+        target="_blank"
+        to="https://speckle.guide/automate/function-testing.html"
+      >
+        Using test automations
+      </CommonTextLink>
+      <CommonTextLink
+        size="sm"
+        external
+        target="_blank"
+        to="https://speckle.guide/dev/tokens.html"
+      >
+        Create a personal access token
+      </CommonTextLink>
     </CommonCard>
-    <FormButton>Using test automations</FormButton>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ClipboardDocumentIcon } from '@heroicons/vue/24/outline'
+
 const props = defineProps<{
   projectId: string
   automationId: string
 }>()
+
+const origin = useApiOrigin()
+const { copy } = useClipboard()
+
+const selectedLanguage = defineModel<string>('selectedLanguage', {
+  default: 'python'
+})
+
+const items = ref(['python', 'dotnet'])
+
+const environment = computed(() => {
+  switch (selectedLanguage.value) {
+    case 'python': {
+      return [
+        'SPECKLE_TOKEN="YOUR-TOKEN-HERE"',
+        `SPECKLE_SERVER_URL="${origin}"`,
+        `SPECKLE_PROJECT_ID="${props.projectId}"`,
+        `SPECKLE_AUTOMATION_ID="${props.automationId}"`
+      ].join('\n')
+    }
+    case 'dotnet': {
+      return [
+        '{',
+        '  "SpeckleToken": "YOUR-TOKEN-HERE"',
+        `  "SpeckleServerUrl": "${origin}"`,
+        `  "SpeckleProjectId": "${props.projectId}"`,
+        `  "SpeckleAutomationId": "${props.automationId}"`,
+        '}'
+      ].join('\n')
+    }
+    default: {
+      return ''
+    }
+  }
+})
+
+const handleCopy = () => {
+  copy(environment.value, {
+    successMessage: 'Configuration copied to clipboard.'
+  })
+}
 </script>

--- a/packages/frontend-2/components/project/page/automation/TestAutomationInfo.vue
+++ b/packages/frontend-2/components/project/page/automation/TestAutomationInfo.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <h2 class="h6 font-medium mb-6">Configuration</h2>
+    <CommonCard class="bg-foundation" title="Environment">
+      <p>{{ projectId }}</p>
+      <p>{{ automationId }}</p>
+    </CommonCard>
+    <FormButton>Using test automations</FormButton>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  projectId: string
+  automationId: string
+}>()
+</script>

--- a/packages/frontend-2/lib/common/generated/gql/graphql.ts
+++ b/packages/frontend-2/lib/common/generated/gql/graphql.ts
@@ -2608,7 +2608,6 @@ export type ProjectRole = {
 };
 
 export type ProjectTestAutomationCreateInput = {
-  functionId: Scalars['String']['input'];
   modelId: Scalars['String']['input'];
   name: Scalars['String']['input'];
 };

--- a/packages/frontend-2/pages/projects/[id]/index/automations/[aid].vue
+++ b/packages/frontend-2/pages/projects/[id]/index/automations/[aid].vue
@@ -8,7 +8,7 @@
 
     <div class="grid grid-cols-1 xl:grid-cols-4 gap-6 w-full">
       <div
-        class="col-span-1 grid gap-6 mb-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-1"
+        class="col-span-1 grid gap-6 mb-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-1 auto-rows-min"
       >
         <ProjectPageAutomationTestAutomationInfo
           v-if="isTestAutomation"

--- a/packages/frontend-2/pages/projects/[id]/index/automations/[aid].vue
+++ b/packages/frontend-2/pages/projects/[id]/index/automations/[aid].vue
@@ -10,7 +10,13 @@
       <div
         class="col-span-1 grid gap-6 mb-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-1"
       >
+        <ProjectPageAutomationTestAutomationInfo
+          v-if="isTestAutomation"
+          :automation-id="automation.id"
+          :project-id="projectId"
+        />
         <ProjectPageAutomationFunctions
+          v-else
           :automation="automation"
           :workspace-id="workspaceId"
           :project-id="projectId"
@@ -77,4 +83,7 @@ const workspaceId = computed(() => project.value?.workspaceId ?? undefined)
 const isEditable = computed(() => {
   return result?.value?.project?.automation?.permissions?.canUpdate.authorized ?? false
 })
+const isTestAutomation = computed(
+  () => result.value?.project.automation.isTestAutomation
+)
 </script>

--- a/packages/server/assets/automate/typedefs/automate.graphql
+++ b/packages/server/assets/automate/typedefs/automate.graphql
@@ -209,7 +209,6 @@ input ProjectAutomationCreateInput {
 input ProjectTestAutomationCreateInput {
   name: String!
   modelId: String!
-  functionId: String!
 }
 
 input AutomateFunctionsFilter {

--- a/packages/server/modules/automate/graph/resolvers/automate.ts
+++ b/packages/server/modules/automate/graph/resolvers/automate.ts
@@ -842,6 +842,12 @@ export = (FF_AUTOMATE_MODULE_ENABLED
         async createTestAutomation(parent, { input }, ctx) {
           const projectId = parent.projectId
 
+          const authResult = await ctx.authPolicies.project.automation.canCreate({
+            userId: ctx.userId,
+            projectId
+          })
+          throwIfAuthNotOk(authResult)
+
           const logger = ctx.log.child({
             projectId,
             streamId: projectId //legacy
@@ -860,10 +866,10 @@ export = (FF_AUTOMATE_MODULE_ENABLED
           return await withOperationLogging(
             async () =>
               await create({
-                input,
+                automationName: input.name,
+                modelId: input.modelId,
                 projectId,
-                userId: ctx.userId!,
-                userResourceAccessRules: ctx.resourceAccessRules
+                userId: ctx.userId!
               }),
             {
               logger,

--- a/packages/server/modules/automate/graph/resolvers/automate.ts
+++ b/packages/server/modules/automate/graph/resolvers/automate.ts
@@ -851,7 +851,6 @@ export = (FF_AUTOMATE_MODULE_ENABLED
 
           const create = createTestAutomationFactory({
             getEncryptionKeyPair,
-            getFunction: getFunctionFactory({ logger: ctx.log }),
             storeAutomation: storeAutomationFactory({ db: projectDb }),
             storeAutomationRevision: storeAutomationRevisionFactory({ db: projectDb }),
             validateStreamAccess,

--- a/packages/server/modules/automate/repositories/automations.ts
+++ b/packages/server/modules/automate/repositories/automations.ts
@@ -380,40 +380,39 @@ export const storeAutomationRevisionFactory =
         id
       })
       .returning('*')
-    const [functions, triggers] = await Promise.all([
-      tables
-        .automationRevisionFunctions(deps.db)
-        .insert(
-          revision.functions.map(
-            (f): AutomationRevisionFunctionRecord => ({
-              ...f,
-              automationRevisionId: id
-            })
-          )
+    const functions =
+      revision.functions.length > 0
+        ? await tables
+            .automationRevisionFunctions(deps.db)
+            .insert(
+              revision.functions.map(
+                (f): AutomationRevisionFunctionRecord => ({
+                  ...f,
+                  automationRevisionId: id
+                })
+              )
+            )
+            .returning('*')
+        : []
+    const triggers = await tables
+      .automationTriggers(deps.db)
+      .insert(
+        revision.triggers.map(
+          (t): AutomationTriggerDefinitionRecord => ({
+            ...t,
+            automationRevisionId: id
+          })
         )
-        .returning('*'),
-      tables
-        .automationTriggers(deps.db)
-        .insert(
-          revision.triggers.map(
-            (t): AutomationTriggerDefinitionRecord => ({
-              ...t,
-              automationRevisionId: id
-            })
-          )
-        )
-        .returning('*'),
-      // Unset 'active in revision' for all other revisions
-      ...(revision.active
-        ? [
-            tables
-              .automationRevisions(deps.db)
-              .where(AutomationRevisions.col.automationId, newRev.automationId)
-              .andWhereNot(AutomationRevisions.col.id, newRev.id)
-              .update(AutomationRevisions.withoutTablePrefix.col.active, false)
-          ]
-        : [])
-    ])
+      )
+      .returning('*')
+    // Unset 'active in revision' for all other revisions
+    if (revision.active) {
+      await tables
+        .automationRevisions(deps.db)
+        .where(AutomationRevisions.col.automationId, newRev.automationId)
+        .andWhereNot(AutomationRevisions.col.id, newRev.id)
+        .update(AutomationRevisions.withoutTablePrefix.col.active, false)
+    }
 
     return {
       ...newRev,

--- a/packages/server/modules/automate/services/automationManagement.ts
+++ b/packages/server/modules/automate/services/automationManagement.ts
@@ -15,8 +15,7 @@ import { AuthCodePayloadAction } from '@/modules/automate/services/authCode'
 import {
   ProjectAutomationCreateInput,
   ProjectAutomationRevisionCreateInput,
-  ProjectAutomationUpdateInput,
-  ProjectTestAutomationCreateInput
+  ProjectAutomationUpdateInput
 } from '@/modules/core/graph/generated/graphql'
 import { ContextResourceAccessRules } from '@/modules/core/helpers/token'
 import {
@@ -142,40 +141,27 @@ export type CreateTestAutomationDeps = {
 export const createTestAutomationFactory =
   (deps: CreateTestAutomationDeps) =>
   async (params: {
-    input: ProjectTestAutomationCreateInput
+    automationName: string
     projectId: string
+    modelId: string
     userId: string
-    userResourceAccessRules?: ContextResourceAccessRules
   }) => {
-    const {
-      input: { name, modelId },
-      projectId,
-      userId,
-      userResourceAccessRules
-    } = params
+    const { automationName, projectId, modelId, userId } = params
     const {
       getEncryptionKeyPair,
       storeAutomation,
       storeAutomationRevision,
-      validateStreamAccess,
       eventEmit
     } = deps
 
-    validateAutomationName(name)
-
-    await validateStreamAccess(
-      userId,
-      projectId,
-      Roles.Stream.Owner,
-      userResourceAccessRules
-    )
+    validateAutomationName(automationName)
 
     // Create and store the automation record
     const automationId = cryptoRandomString({ length: 10 })
 
     const automationRecord = await storeAutomation({
       id: automationId,
-      name,
+      name: automationName,
       userId,
       createdAt: new Date(),
       updatedAt: new Date(),

--- a/packages/server/modules/automate/services/trigger.ts
+++ b/packages/server/modules/automate/services/trigger.ts
@@ -633,10 +633,27 @@ export const createTestAutomationRunFactory =
       }
     })
 
+    // Create test automation function run with "empty" data
     const automationRunRecord = await createAutomationRunDataFactory(deps)({
       manifests: triggerManifests,
       automationWithRevision: automationRevisionRecord
     })
+    automationRunRecord.functionRuns = [
+      {
+        functionId: '',
+        id: cryptoRandomString({ length: 15 }),
+        status: 'pending' as const,
+        elapsed: 0,
+        results: null,
+        contextView: null,
+        statusMessage: null,
+        resultVersions: [],
+        functionReleaseId: '',
+        functionInputs: null,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ]
     await upsertAutomationRun(automationRunRecord)
 
     await emitEvent({

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -2631,7 +2631,6 @@ export type ProjectRole = {
 };
 
 export type ProjectTestAutomationCreateInput = {
-  functionId: Scalars['String']['input'];
   modelId: Scalars['String']['input'];
   name: Scalars['String']['input'];
 };

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -2611,7 +2611,6 @@ export type ProjectRole = {
 };
 
 export type ProjectTestAutomationCreateInput = {
-  functionId: Scalars['String']['input'];
   modelId: Scalars['String']['input'];
   name: Scalars['String']['input'];
 };

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -2612,7 +2612,6 @@ export type ProjectRole = {
 };
 
 export type ProjectTestAutomationCreateInput = {
-  functionId: Scalars['String']['input'];
   modelId: Scalars['String']['input'];
   name: Scalars['String']['input'];
 };


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- The current implementation of test automations is very much a "shortest path to do this at the time" kind of implementation
- The "requirement" to select a function, even though it has no effect, has confused users and Specklers alike
- We recently tried to let users at least select functions without versions here (i.e. test a function they just created) but this didn't work because the version requirement was hard-coded
- In working to fix that, I saw that it wasn't too much more work to drop the function requirement entirely here

## Changes:

- Omit functions when creating test automations (creates an automation with an empty functions array)
  - This is already safe and handled by the UI (defensively written in case functions got deleted) and triggers (although test automations cannot be triggered)
- Populate test automation runs with "empty" function runs
  - FE still leans heavily on specific function runs in showing results
- Adds a useful copy-paste-able `.env` where the functions panel would go:

![Screen Shot 2025-05-02 at 16 23 23](https://github.com/user-attachments/assets/73728a64-6f00-4551-9876-e94e7d079e6f)

I'm still partial to a pretty thorough re-imagining of this, but this is a good enough kick in the pants for now.

Testable on testing3