### PR TITLE
fix(automate): do not return invalid type for revisions

### DIFF
--- a/packages/server/modules/automate/graph/resolvers/automate.ts
+++ b/packages/server/modules/automate/graph/resolvers/automate.ts
@@ -325,7 +325,9 @@ export = (FF_AUTOMATE_MODULE_ENABLED
           const automationRevision = await ctx.loaders
             .forRegion({ db: projectDb })
             .automations.getLatestAutomationRevision.load(parent.id)
-          return { ...automationRevision, projectId: parent.projectId }
+          return automationRevision
+            ? { ...automationRevision, projectId: parent.projectId }
+            : null
         },
         async runs(parent, args) {
           const projectDb = await getProjectDbClient({ projectId: parent.projectId })
@@ -413,6 +415,7 @@ export = (FF_AUTOMATE_MODULE_ENABLED
           } catch (e) {
             ctx.log.warn('Error formatting results schema', e)
           }
+          return null
         },
         status: (parent) => mapDbStatusToGqlStatus(parent.status)
       },


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- We were seeing an error on every automation create when accessing `currentRevision`
- It was because we were _always_ appending the project id (for multiregion) to the return value here, even though a `null` value was entirely valid

## Changes:

- Only append and return projectId if revision exists
