### PR TITLE
Fix: Move Automate beta badge to the automations page

### DIFF
--- a/packages/frontend-2/components/project/page/automations/Header.vue
+++ b/packages/frontend-2/components/project/page/automations/Header.vue
@@ -2,7 +2,16 @@
   <div
     class="flex flex-col gap-y-2 md:gap-y-0 md:flex-row md:justify-between md:items-center mt-3"
   >
-    <h1 class="block text-heading-lg md:text-heading-xl">Automations</h1>
+    <h1 class="block text-heading-lg md:text-heading-xl flex items-center gap-3">
+      Automations
+      <CommonBadge
+        v-tippy="
+          'Speckle Automate is in public beta. Help us improve by giving us lots of feedback!'
+        "
+      >
+        BETA
+      </CommonBadge>
+    </h1>
     <div v-if="showHeader" class="flex flex-col gap-2 md:flex-row md:items-center">
       <FormTextInput
         name="search"

--- a/packages/frontend-2/pages/projects/[id]/index.vue
+++ b/packages/frontend-2/pages/projects/[id]/index.vue
@@ -244,8 +244,7 @@ const pageTabItems = computed((): LayoutPageTabItem[] => {
   if (isAutomateEnabled.value && project.value?.workspace) {
     items.push({
       title: 'Automations',
-      id: 'automations',
-      tag: 'BETA'
+      id: 'automations'
     })
   }
 


### PR DESCRIPTION
Moves the Automate beta badge into the Automations page and adds a hover tooltip. I thought the constant Beta badge in the project navigation took too much space and focus.

![CleanShot 2025-05-05 at 16 32 53@2x](https://github.com/user-attachments/assets/28bd9374-4d1e-4df8-b517-675a892f9122)
