### PR TITLE
fix(automate): hide automation runs from deleted automations

### DIFF
--- a/packages/server/modules/automate/repositories/automations.ts
+++ b/packages/server/modules/automate/repositories/automations.ts
@@ -653,6 +653,7 @@ const getAutomationRunsTotalCountBaseQueryFactory =
         AutomationRevisions.col.automationId
       )
       .where(AutomationRevisions.col.automationId, args.automationId)
+      .where(Automations.col.isDeleted, false)
 
     if (args.revisionId?.length) {
       q.andWhere(AutomationRuns.col.automationRevisionId, args.revisionId)


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- We added the ability to "delete" automations by flagging them as deleted. Queries for automations will omit deleted automations.
- In most cases, this correctly hides deleted automations and all of their associated resources.
- In some cases, we find our way to the automation from a "child" resource. For example, in this associated issue: "automation run => automation"
- We successfully queried the run, tried to access the automation, and returned null where that violates the gql schema
- Extra: you can see that this particular error only started happening after delete was merged late April 22

## Changes:

- Also omits automation runs from queries if the parent automation is deleted
