### PR TITLE
Chore: unlist archicad temporarily 

### DIFF
--- a/packages/frontend-2/lib/dashboard/helpers/connectors.ts
+++ b/packages/frontend-2/lib/dashboard/helpers/connectors.ts
@@ -108,15 +108,15 @@ export const connectorItems: ConnectorItem[] = [
     image: '/images/connectors/navisworks.png',
     categories: [ConnectorCategory.NextGen, ConnectorCategory.BIM]
   },
-  {
-    title: 'Archicad',
-    slug: 'archicad',
-    description:
-      'Publish Archicad models to boost design coordination and business intelligence workflows.',
-    url: 'https://www.speckle.systems/connectors/archicad',
-    image: '/images/connectors/archicad.png',
-    categories: [ConnectorCategory.NextGen, ConnectorCategory.BIM]
-  },
+  // {
+  //   title: 'Archicad',
+  //   slug: 'archicad',
+  //   description:
+  //     'Publish Archicad models to boost design coordination and business intelligence workflows.',
+  //   url: 'https://www.speckle.systems/connectors/archicad',
+  //   image: '/images/connectors/archicad.png',
+  //   categories: [ConnectorCategory.NextGen, ConnectorCategory.BIM]
+  // },
   {
     title: 'Tekla',
     slug: 'teklastructures',


### PR DESCRIPTION
A vulnarability on archicad installer became a bad first impression. We are unlisting archicad as temporarily