### PR TITLE
Chore: re-list archicad temporarily

### DIFF
--- a/packages/frontend-2/lib/dashboard/helpers/connectors.ts
+++ b/packages/frontend-2/lib/dashboard/helpers/connectors.ts
@@ -108,15 +108,15 @@ export const connectorItems: ConnectorItem[] = [
     image: '/images/connectors/navisworks.png',
     categories: [ConnectorCategory.NextGen, ConnectorCategory.BIM]
   },
-  // {
-  //   title: 'Archicad',
-  //   slug: 'archicad',
-  //   description:
-  //     'Publish Archicad models to boost design coordination and business intelligence workflows.',
-  //   url: 'https://www.speckle.systems/connectors/archicad',
-  //   image: '/images/connectors/archicad.png',
-  //   categories: [ConnectorCategory.NextGen, ConnectorCategory.BIM]
-  // },
+  {
+    title: 'Archicad',
+    slug: 'archicad',
+    description:
+      'Publish Archicad models to boost design coordination and business intelligence workflows.',
+    url: 'https://www.speckle.systems/connectors/archicad',
+    image: '/images/connectors/archicad.png',
+    categories: [ConnectorCategory.NextGen, ConnectorCategory.BIM]
+  },
   {
     title: 'Tekla',
     slug: 'teklastructures',


### PR DESCRIPTION
Undoes the temporary change by @oguzhankoral in #4675

We now have a released a new version of Archicad that no longer triggers a false positive trigger by windows defender.
We've replaced the offending py2exe `exe` with a .NET8 equivalent `exe` https://github.com/specklesystems/connector-installers/pull/102

Old exe report: https://www.virustotal.com/gui/file/0a1f447b6986c808d3b1586121201220fd70586be5c2f92ccca11517f28f43de

New exe report: https://www.virustotal.com/gui/file/fb72c608e630a31d9443d35e06c5606757a2638b462c86e658ada3bc162469e6?nocache=1

Confident now that the new release is good after some testing by @JR-Morgan and @kekesidavid 

---

Tomorrow I'll look into removing the old releases from the feed