### PR TITLE
fix(multiregion): repair counting for project region moves

### DIFF
--- a/packages/server/modules/multiregion/services/queue.ts
+++ b/packages/server/modules/multiregion/services/queue.ts
@@ -23,11 +23,6 @@ import { getProjectFactory } from '@/modules/core/repositories/projects'
 import { getAvailableRegionsFactory } from '@/modules/workspaces/services/regions'
 import { getRegionsFactory } from '@/modules/multiregion/repositories'
 import { canWorkspaceUseRegionsFactory } from '@/modules/gatekeeper/services/featureAuthorization'
-import { getProjectAutomationsTotalCountFactory } from '@/modules/automate/repositories/automations'
-import { getStreamCommentCountFactory } from '@/modules/comments/repositories/comments'
-import { getStreamBranchCountFactory } from '@/modules/core/repositories/branches'
-import { getStreamCommitCountFactory } from '@/modules/core/repositories/commits'
-import { getStreamObjectCountFactory } from '@/modules/core/repositories/objects'
 import { getWorkspacePlanFactory } from '@/modules/gatekeeper/repositories/billing'
 import {
   upsertProjectRegionKeyFactory,
@@ -36,7 +31,6 @@ import {
 import { updateProjectRegionKeyFactory } from '@/modules/multiregion/services/projectRegion'
 import { getGenericRedis } from '@/modules/shared/redis/redis'
 import { getEventBus } from '@/modules/shared/services/eventBus'
-import { getStreamWebhooksFactory } from '@/modules/webhooks/repositories/webhooks'
 import {
   copyWorkspaceFactory,
   copyProjectsFactory,
@@ -46,7 +40,13 @@ import {
   copyProjectAutomationsFactory,
   copyProjectCommentsFactory,
   copyProjectWebhooksFactory,
-  copyProjectBlobs
+  copyProjectBlobs,
+  countProjectModelsFactory,
+  countProjectVersionsFactory,
+  countProjectObjectsFactory,
+  countProjectAutomationsFactory,
+  countProjectCommentsFactory,
+  countProjectWebhooksFactory
 } from '@/modules/workspaces/repositories/projectRegions'
 import { withTransaction } from '@/modules/shared/helpers/dbHelper'
 
@@ -208,22 +208,14 @@ export const startQueue = async () => {
                 targetObjectStorage
               }),
               validateProjectRegionCopy: validateProjectRegionCopyFactory({
-                countProjectModels: getStreamBranchCountFactory({
+                countProjectModels: countProjectModelsFactory({ db: sourceDb }),
+                countProjectVersions: countProjectVersionsFactory({ db: sourceDb }),
+                countProjectObjects: countProjectObjectsFactory({ db: sourceDb }),
+                countProjectAutomations: countProjectAutomationsFactory({
                   db: sourceDb
                 }),
-                countProjectVersions: getStreamCommitCountFactory({
-                  db: sourceDb
-                }),
-                countProjectObjects: getStreamObjectCountFactory({
-                  db: sourceDb
-                }),
-                countProjectAutomations: getProjectAutomationsTotalCountFactory({
-                  db: sourceDb
-                }),
-                countProjectComments: getStreamCommentCountFactory({
-                  db: sourceDb
-                }),
-                getProjectWebhooks: getStreamWebhooksFactory({ db: sourceDb })
+                countProjectComments: countProjectCommentsFactory({ db: sourceDb }),
+                countProjectWebhooks: countProjectWebhooksFactory({ db: sourceDb })
               }),
               updateProjectRegionKey: updateProjectRegionKeyFactory({
                 upsertProjectRegionKey: upsertProjectRegionKeyFactory({ db }),

--- a/packages/server/modules/workspaces/domain/operations.ts
+++ b/packages/server/modules/workspaces/domain/operations.ts
@@ -492,6 +492,13 @@ export type CopyProjectAutomations = (params: {
   projectIds: string[]
 }) => Promise<Record<string, number>>
 
+export type CountProjectModels = (params: { projectId: string }) => Promise<number>
+export type CountProjectVersions = (params: { projectId: string }) => Promise<number>
+export type CountProjectObjects = (params: { projectId: string }) => Promise<number>
+export type CountProjectAutomations = (params: { projectId: string }) => Promise<number>
+export type CountProjectComments = (params: { projectId: string }) => Promise<number>
+export type CountProjectWebhooks = (params: { projectId: string }) => Promise<number>
+
 export type AssignWorkspaceSeat = (
   params: Pick<WorkspaceSeat, 'userId' | 'workspaceId'> & {
     type: WorkspaceSeatType

--- a/packages/server/modules/workspaces/repositories/projectRegions.ts
+++ b/packages/server/modules/workspaces/repositories/projectRegions.ts
@@ -41,7 +41,13 @@ import {
   CopyProjects,
   CopyProjectVersions,
   CopyProjectWebhooks,
-  CopyWorkspace
+  CopyWorkspace,
+  CountProjectAutomations,
+  CountProjectComments,
+  CountProjectModels,
+  CountProjectObjects,
+  CountProjectVersions,
+  CountProjectWebhooks
 } from '@/modules/workspaces/domain/operations'
 import { WorkspaceNotFoundError } from '@/modules/workspaces/errors/workspace'
 import { Knex } from 'knex'
@@ -649,4 +655,49 @@ export const copyProjectBlobs =
     }
 
     return copiedBlobsCountByProjectId
+  }
+
+export const countProjectModelsFactory =
+  (deps: { db: Knex }): CountProjectModels =>
+  async ({ projectId }) => {
+    const [res] = await tables.models(deps.db).where({ streamId: projectId }).count()
+    return parseInt(res?.count?.toString() ?? '0')
+  }
+
+export const countProjectVersionsFactory =
+  (deps: { db: Knex }): CountProjectVersions =>
+  async ({ projectId }) => {
+    const [res] = await tables
+      .streamCommits(deps.db)
+      .where({ streamId: projectId })
+      .count()
+    return parseInt(res?.count?.toString() ?? '0')
+  }
+
+export const countProjectObjectsFactory =
+  (deps: { db: Knex }): CountProjectObjects =>
+  async ({ projectId }) => {
+    const [res] = await tables.objects(deps.db).where({ streamId: projectId }).count()
+    return parseInt(res?.count?.toString() ?? '0')
+  }
+
+export const countProjectAutomationsFactory =
+  (deps: { db: Knex }): CountProjectAutomations =>
+  async ({ projectId }) => {
+    const [res] = await tables.automations(deps.db).where({ projectId }).count()
+    return parseInt(res?.count?.toString() ?? '0')
+  }
+
+export const countProjectCommentsFactory =
+  (deps: { db: Knex }): CountProjectComments =>
+  async ({ projectId }) => {
+    const [res] = await tables.comments(deps.db).where({ streamId: projectId }).count()
+    return parseInt(res?.count?.toString() ?? '0')
+  }
+
+export const countProjectWebhooksFactory =
+  (deps: { db: Knex }): CountProjectWebhooks =>
+  async ({ projectId }) => {
+    const [res] = await tables.webhooks(deps.db).where({ streamId: projectId }).count()
+    return parseInt(res?.count?.toString() ?? '0')
   }

--- a/packages/server/modules/workspaces/services/projectRegions.ts
+++ b/packages/server/modules/workspaces/services/projectRegions.ts
@@ -1,11 +1,5 @@
-import { GetProjectAutomationCount } from '@/modules/automate/domain/operations'
-import { GetStreamCommentCount } from '@/modules/comments/domain/operations'
-import { GetStreamBranchCount } from '@/modules/core/domain/branches/operations'
-import { GetStreamCommitCount } from '@/modules/core/domain/commits/operations'
-import { GetStreamObjectCount } from '@/modules/core/domain/objects/operations'
 import { GetProject } from '@/modules/core/domain/projects/operations'
 import { UpdateProjectRegionKey } from '@/modules/multiregion/services/projectRegion'
-import { GetStreamWebhooks } from '@/modules/webhooks/domain/operations'
 import {
   CopyProjectAutomations,
   CopyProjectBlobs,
@@ -16,6 +10,12 @@ import {
   CopyProjectVersions,
   CopyProjectWebhooks,
   CopyWorkspace,
+  CountProjectAutomations,
+  CountProjectComments,
+  CountProjectModels,
+  CountProjectObjects,
+  CountProjectVersions,
+  CountProjectWebhooks,
   GetAvailableRegions,
   UpdateProjectRegion,
   ValidateProjectRegionCopy
@@ -127,24 +127,22 @@ export const updateProjectRegionFactory =
 
 export const validateProjectRegionCopyFactory =
   (deps: {
-    countProjectModels: GetStreamBranchCount
-    countProjectVersions: GetStreamCommitCount
-    countProjectObjects: GetStreamObjectCount
-    countProjectAutomations: GetProjectAutomationCount
-    countProjectComments: GetStreamCommentCount
-    getProjectWebhooks: GetStreamWebhooks
+    countProjectModels: CountProjectModels
+    countProjectVersions: CountProjectVersions
+    countProjectObjects: CountProjectObjects
+    countProjectAutomations: CountProjectAutomations
+    countProjectComments: CountProjectComments
+    countProjectWebhooks: CountProjectWebhooks
   }): ValidateProjectRegionCopy =>
   async ({ projectId, copiedRowCount }) => {
-    const sourceProjectModelCount = await deps.countProjectModels(projectId)
-    const sourceProjectVersionCount = await deps.countProjectVersions(projectId)
-    const sourceProjectObjectCount = await deps.countProjectObjects({
-      streamId: projectId
-    })
+    const sourceProjectModelCount = await deps.countProjectModels({ projectId })
+    const sourceProjectVersionCount = await deps.countProjectVersions({ projectId })
+    const sourceProjectObjectCount = await deps.countProjectObjects({ projectId })
     const sourceProjectAutomationCount = await deps.countProjectAutomations({
       projectId
     })
-    const sourceProjectCommentCount = await deps.countProjectComments(projectId)
-    const sourceProjectWebhooks = await deps.getProjectWebhooks({ streamId: projectId })
+    const sourceProjectCommentCount = await deps.countProjectComments({ projectId })
+    const sourceProjectWebhooksCount = await deps.countProjectWebhooks({ projectId })
 
     const tests = [
       copiedRowCount.models === sourceProjectModelCount,
@@ -152,7 +150,7 @@ export const validateProjectRegionCopyFactory =
       copiedRowCount.objects === sourceProjectObjectCount,
       copiedRowCount.automations === sourceProjectAutomationCount,
       copiedRowCount.comments === sourceProjectCommentCount,
-      copiedRowCount.webhooks === sourceProjectWebhooks.length
+      copiedRowCount.webhooks === sourceProjectWebhooksCount
     ]
 
     return [
@@ -163,7 +161,7 @@ export const validateProjectRegionCopyFactory =
         objects: sourceProjectObjectCount,
         automations: sourceProjectAutomationCount,
         comments: sourceProjectCommentCount,
-        webhooks: sourceProjectWebhooks.length
+        webhooks: sourceProjectWebhooksCount
       }
     ]
   }


### PR DESCRIPTION
## Description & motivation

- Some project region moves were completing correctly but being flagged as incomplete incorrectly (see issue for more detail)

## Changes:

- Counts db rows directly for project region moves instead of using repo/service functions (that may or may not have their own implicit filtering)
