### PR TITLE
fix(multiregion): guarantee zero counts on project region move

### DIFF
--- a/packages/server/modules/multiregion/tests/e2e/projects.graph.spec.ts
+++ b/packages/server/modules/multiregion/tests/e2e/projects.graph.spec.ts
@@ -98,6 +98,13 @@ isMultiRegionTestMode()
         isPublic: true
       }
 
+      const emptyProject: BasicTestStream = {
+        id: '',
+        ownerId: '',
+        name: 'Empty Regional Project',
+        isPublic: true
+      }
+
       const testModel: BasicTestBranch = {
         id: '',
         name: cryptoRandomString({ length: 8 }),
@@ -141,8 +148,10 @@ isMultiRegionTestMode()
           }
         })
 
+        emptyProject.workspaceId = testWorkspace.id
         testProject.workspaceId = testWorkspace.id
 
+        await createTestStream(emptyProject, adminUser)
         await createTestStream(testProject, adminUser)
         await createTestBranch({
           stream: testProject,
@@ -228,6 +237,15 @@ isMultiRegionTestMode()
         testBlobId = testBlob.blobId
 
         await assertProjectRegion(testProject.id, regionKey1)
+      })
+
+      it('moves projects with no resources of a given type', async () => {
+        const resA = await apollo.execute(UpdateProjectRegionDocument, {
+          projectId: emptyProject.id,
+          regionKey: regionKey2
+        })
+        expect(resA).to.not.haveGraphQLErrors()
+        await ensureProjectRegion(emptyProject.id, regionKey2)
       })
 
       it('moves project record to target regional db', async () => {

--- a/packages/server/modules/workspaces/repositories/projectRegions.ts
+++ b/packages/server/modules/workspaces/repositories/projectRegions.ts
@@ -110,6 +110,16 @@ const tables = {
   blobStorage: (db: Knex) => db.table<BlobStorageItem>(BlobStorage.name)
 }
 
+const getCountObject = (projectIds: string[]) => {
+  const countObject: Record<string, number> = {}
+
+  for (const projectId of projectIds) {
+    countObject[projectId] = 0
+  }
+
+  return countObject
+}
+
 /**
  * Copies rows from the following tables:
  * - workspaces
@@ -205,7 +215,7 @@ export const copyProjectsFactory =
 export const copyProjectModelsFactory =
   (deps: { sourceDb: Knex; targetDb: Knex }): CopyProjectModels =>
   async ({ projectIds }) => {
-    const copiedModelCountByProjectId: Record<string, number> = {}
+    const copiedModelCountByProjectId = getCountObject(projectIds)
 
     // Fetch `branches` rows for projects in batch
     const selectModels = tables
@@ -218,7 +228,6 @@ export const copyProjectModelsFactory =
       await tables.models(deps.targetDb).insert(models).onConflict().ignore()
 
       for (const model of models) {
-        copiedModelCountByProjectId[model.streamId] ??= 0
         copiedModelCountByProjectId[model.streamId]++
       }
     }
@@ -235,7 +244,7 @@ export const copyProjectModelsFactory =
 export const copyProjectVersionsFactory =
   (deps: { sourceDb: Knex; targetDb: Knex }): CopyProjectVersions =>
   async ({ projectIds }) => {
-    const copiedVersionCountByProjectId: Record<string, number> = {}
+    const copiedVersionCountByProjectId = getCountObject(projectIds)
 
     const selectVersions = tables
       .streamCommits(deps.sourceDb)
@@ -269,7 +278,6 @@ export const copyProjectVersionsFactory =
       await tables.versions(deps.targetDb).insert(commits).onConflict().ignore()
 
       for (const version of versions) {
-        copiedVersionCountByProjectId[version.streamId] ??= 0
         copiedVersionCountByProjectId[version.streamId]++
       }
 
@@ -315,7 +323,7 @@ export const copyProjectVersionsFactory =
 export const copyProjectObjectsFactory =
   (deps: { sourceDb: Knex; targetDb: Knex }): CopyProjectObjects =>
   async ({ projectIds }) => {
-    const copiedObjectCountByProjectId: Record<string, number> = {}
+    const copiedObjectCountByProjectId = getCountObject(projectIds)
 
     // Copy `objects` table rows in batches
     const selectObjects = tables
@@ -329,7 +337,6 @@ export const copyProjectObjectsFactory =
       await tables.objects(deps.targetDb).insert(objects).onConflict().ignore()
 
       for (const object of objects) {
-        copiedObjectCountByProjectId[object.streamId] ??= 0
         copiedObjectCountByProjectId[object.streamId]++
       }
     }
@@ -362,7 +369,7 @@ export const copyProjectObjectsFactory =
 export const copyProjectAutomationsFactory =
   (deps: { sourceDb: Knex; targetDb: Knex }): CopyProjectAutomations =>
   async ({ projectIds }) => {
-    const copiedAutomationCountByProjectId: Record<string, number> = {}
+    const copiedAutomationCountByProjectId = getCountObject(projectIds)
 
     // Copy `automations` table rows in batches
     const selectAutomations = tables
@@ -382,7 +389,6 @@ export const copyProjectAutomationsFactory =
         .ignore()
 
       for (const automation of automations) {
-        copiedAutomationCountByProjectId[automation.projectId] ??= 0
         copiedAutomationCountByProjectId[automation.projectId]++
       }
 
@@ -501,7 +507,7 @@ export const copyProjectAutomationsFactory =
 export const copyProjectCommentsFactory =
   (deps: { sourceDb: Knex; targetDb: Knex }): CopyProjectComments =>
   async ({ projectIds }) => {
-    const copiedCommentCountByProjectId: Record<string, number> = {}
+    const copiedCommentCountByProjectId = getCountObject(projectIds)
 
     // Copy `comments` table rows in batches
     const selectComments = tables
@@ -516,7 +522,6 @@ export const copyProjectCommentsFactory =
       await tables.comments(deps.targetDb).insert(comments).onConflict().ignore()
 
       for (const comment of comments) {
-        copiedCommentCountByProjectId[comment.streamId] ??= 0
         copiedCommentCountByProjectId[comment.streamId]++
       }
 
@@ -556,7 +561,7 @@ export const copyProjectCommentsFactory =
 export const copyProjectWebhooksFactory =
   (deps: { sourceDb: Knex; targetDb: Knex }): CopyProjectWebhooks =>
   async ({ projectIds }) => {
-    const copiedWebhookCountByProjectId: Record<string, number> = {}
+    const copiedWebhookCountByProjectId = getCountObject(projectIds)
 
     // Copy `webhooks_config` table rows in batches
     const selectWebhooks = tables
@@ -571,7 +576,6 @@ export const copyProjectWebhooksFactory =
       await tables.webhooks(deps.targetDb).insert(webhooks).onConflict().ignore()
 
       for (const webhook of webhooks) {
-        copiedWebhookCountByProjectId[webhook.streamId] ??= 0
         copiedWebhookCountByProjectId[webhook.streamId]++
       }
 
@@ -608,7 +612,7 @@ export const copyProjectBlobs =
     targetObjectStorage: ObjectStorage
   }): CopyProjectBlobs =>
   async ({ projectIds }) => {
-    const copiedBlobsCountByProjectId: Record<string, number> = {}
+    const copiedBlobsCountByProjectId = getCountObject(projectIds)
 
     // Copy `blob_storage` table rows in batches
     const selectBlobs = tables
@@ -621,7 +625,6 @@ export const copyProjectBlobs =
       await tables.blobStorage(deps.targetDb).insert(blobs).onConflict().ignore()
 
       for (const blob of blobs) {
-        copiedBlobsCountByProjectId[blob.streamId] ??= 0
         copiedBlobsCountByProjectId[blob.streamId]++
 
         // Copy file blob from one regional storage to the other

--- a/packages/server/modules/workspaces/services/projectRegions.ts
+++ b/packages/server/modules/workspaces/services/projectRegions.ts
@@ -94,12 +94,12 @@ export const updateProjectRegionFactory =
 
     // Validate that state after move captures latest state of project
     const targetProjectResources = {
-      models: copiedModelCount[projectId],
-      versions: copiedVersionCount[projectId],
-      objects: copiedObjectCount[projectId],
-      automations: copiedAutomationCount[projectId],
-      comments: copiedCommentCount[projectId],
-      webhooks: copiedWebhookCount[projectId]
+      models: copiedModelCount[projectId] ?? 0,
+      versions: copiedVersionCount[projectId] ?? 0,
+      objects: copiedObjectCount[projectId] ?? 0,
+      automations: copiedAutomationCount[projectId] ?? 0,
+      comments: copiedCommentCount[projectId] ?? 0,
+      webhooks: copiedWebhookCount[projectId] ?? 0
     }
 
     const [isValidCopy, sourceProjectResources] = await deps.validateProjectRegionCopy({


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- sometimes the project region move counts would fail to emit a `0` if the project had no resources of a certain type
- we recently guaranteed a `0` on counting moved project resources
- `0 !== undefined` and so some moves were still being flagged as "failed"

## Changes:

- Guarantees a zero when no resources of a type exist and when none were moved
- `0 === 0`
- Add test case for this
