### PR TITLE
feat(fe): shuffle onboarding question options

### DIFF
--- a/packages/frontend-2/components/onboarding/questions/PlanSelect.vue
+++ b/packages/frontend-2/components/onboarding/questions/PlanSelect.vue
@@ -11,7 +11,7 @@
     show-label
     allow-unset
     clearable
-    :items="plans"
+    :items="shuffledPlans"
   >
     <template #option="{ item }">
       <div class="label label--light">
@@ -33,6 +33,7 @@ import { useFormSelectChildInternals } from '@speckle/ui-components'
 import { PlanTitleMap } from '~/lib/auth/helpers/onboarding'
 import { OnboardingPlan } from '@speckle/shared'
 import { isRequired } from '~~/lib/common/helpers/validation'
+import { shuffle } from 'lodash-es'
 
 const props = defineProps<{
   modelValue?: OnboardingPlan[]
@@ -48,4 +49,6 @@ const { selectedValue, isArrayValue } = useFormSelectChildInternals<OnboardingPl
   props: toRefs(props),
   emit
 })
+
+const shuffledPlans = computed(() => shuffle([...plans]))
 </script>

--- a/packages/frontend-2/components/onboarding/questions/RoleSelect.vue
+++ b/packages/frontend-2/components/onboarding/questions/RoleSelect.vue
@@ -11,7 +11,7 @@
     show-label
     allow-unset
     clearable
-    :items="roles"
+    :items="shuffledRoles"
   >
     <template #option="{ item }">
       <div class="label label--light">
@@ -29,6 +29,7 @@ import { useFormSelectChildInternals } from '@speckle/ui-components'
 import { RoleTitleMap } from '~/lib/auth/helpers/onboarding'
 import { OnboardingRole } from '@speckle/shared'
 import { isRequired } from '~~/lib/common/helpers/validation'
+import { shuffle } from 'lodash'
 
 const props = defineProps<{
   modelValue?: OnboardingRole
@@ -43,5 +44,13 @@ const roles = Object.values(OnboardingRole)
 const { selectedValue, isArrayValue } = useFormSelectChildInternals<OnboardingRole>({
   props: toRefs(props),
   emit
+})
+
+const shuffledRoles = computed(() => {
+  // Filter out "Other" and shuffle the remaining roles
+  const rolesWithoutOther = roles.filter((role) => role !== OnboardingRole.Other)
+  const shuffled = shuffle([...rolesWithoutOther])
+  // Add "Other" at the end
+  return [...shuffled, OnboardingRole.Other]
 })
 </script>

--- a/packages/frontend-2/components/onboarding/questions/SourceSelect.vue
+++ b/packages/frontend-2/components/onboarding/questions/SourceSelect.vue
@@ -11,7 +11,7 @@
     show-label
     allow-unset
     clearable
-    :items="sources"
+    :items="shuffledSources"
   >
     <template #option="{ item }">
       <div class="label label--light">
@@ -29,6 +29,7 @@ import { useFormSelectChildInternals } from '@speckle/ui-components'
 import { SourceTitleMap } from '~/lib/auth/helpers/onboarding'
 import { OnboardingSource } from '@speckle/shared'
 import { isRequired } from '~~/lib/common/helpers/validation'
+import { shuffle } from 'lodash-es'
 
 const props = defineProps<{
   modelValue?: OnboardingSource
@@ -46,5 +47,15 @@ const sources = Object.values(OnboardingSource)
 const { selectedValue, isArrayValue } = useFormSelectChildInternals<OnboardingSource>({
   props: toRefs(props),
   emit
+})
+
+const shuffledSources = computed(() => {
+  // Filter out "Other" and shuffle the remaining sources
+  const sourcesWithoutOther = sources.filter(
+    (source) => source !== OnboardingSource.Other
+  )
+  const shuffled = shuffle([...sourcesWithoutOther])
+  // Add "Other" at the end
+  return [...shuffled, OnboardingSource.Other]
 })
 </script>

--- a/packages/frontend-2/lib/auth/helpers/onboarding.ts
+++ b/packages/frontend-2/lib/auth/helpers/onboarding.ts
@@ -20,8 +20,7 @@ export const PlanTitleMap: Record<OnboardingPlan, string> = {
     'Online collaboration (sharing and discussing 3D models online)',
   [OnboardingPlan.DataWarehouse]: 'Data warehouse and common data environment (CDE)',
   [OnboardingPlan.Development]: 'Develop custom functionalities and apps',
-  [OnboardingPlan.Automation]: 'Automation (pre-made or custom automations)',
-  [OnboardingPlan.Other]: 'Other'
+  [OnboardingPlan.Automation]: 'Automation (pre-made or custom automations)'
 }
 
 export const SourceTitleMap: Record<OnboardingSource, string> = {

--- a/packages/shared/src/onboarding/helpers/index.ts
+++ b/packages/shared/src/onboarding/helpers/index.ts
@@ -16,8 +16,7 @@ export enum OnboardingPlan {
   Collaboration = 'collaboration',
   DataWarehouse = 'data-warehouse',
   Development = 'development',
-  Automation = 'automation',
-  Other = 'other'
+  Automation = 'automation'
 }
 
 export enum OnboardingSource {

--- a/packages/ui-components/src/components/form/select/Base.vue
+++ b/packages/ui-components/src/components/form/select/Base.vue
@@ -134,7 +134,7 @@
                     />
                   </div>
                 </label>
-                <div class="overflow-auto simple-scrollbar max-h-60">
+                <div class="overflow-auto simple-scrollbar max-h-60 xl:max-h-80">
                   <div v-if="isAsyncSearchMode && isAsyncLoading" class="px-1">
                     <CommonLoadingBar :loading="true" />
                   </div>


### PR DESCRIPTION
Requested by growth team. 

We now shuffle the answers to the onboarding questions to hopefully make it more accurate. 

Also removed the other option from the Role Select as requested. 

Also removed the overflow on large screens for Role Select. 