### PR TITLE
fix(server): mailchimp problems throw a sanitised error

### DIFF
--- a/packages/server/modules/auth/errors/index.ts
+++ b/packages/server/modules/auth/errors/index.ts
@@ -35,3 +35,10 @@ export class RefreshTokenError extends BaseError {
   static defaultMessage = 'An issue occurred while refreshing a token'
   static statusCode = 400
 }
+
+export class MailchimpResourceError extends BaseError {
+  static code = 'MAILCHIMP'
+  static defaultMessage =
+    'An issue occurred while trying to reconcile Mailchimp resources'
+  static statusCode = 500
+}

--- a/packages/server/modules/auth/services/mailchimp.ts
+++ b/packages/server/modules/auth/services/mailchimp.ts
@@ -5,6 +5,7 @@ import { getMailchimpConfig } from '@/modules/shared/helpers/envHelper'
 import { UserRecord } from '@/modules/core/helpers/types'
 import { MisconfiguredEnvironmentError } from '@/modules/shared/errors'
 import { OnboardingCompletionInput } from '@/modules/core/graph/generated/graphql'
+import { MailchimpResourceError } from '@/modules/auth/errors'
 
 let mailchimpInitialized = false
 
@@ -76,8 +77,11 @@ export async function updateMailchimpMemberTags(
   try {
     await mailchimp.lists.getListMember(listId, subscriberHash)
   } catch {
-    throw new Error(
-      `User ${user.email} not found in Mailchimp audience. They should have been added during registration.`
+    throw new MailchimpResourceError(
+      'User not found in Mailchimp audience. They should have been added during registration.',
+      {
+        info: { userEmailHash: subscriberHash }
+      }
     )
   }
 


### PR DESCRIPTION
## Description & motivation

The logs were polluted with potentially sensitive data. The logs had a high cardinality because the error message was not using a template.



## Changes:

- Uses a hash to redact user emails (hash can be looked up in MailChimp).
- Throws an error which conforms to message template formatting, and passes additional properties via `info` property.

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
