### PR TITLE
fix(authz): expose canInvite gql queries

### DIFF
--- a/packages/frontend-2/lib/common/generated/gql/graphql.ts
+++ b/packages/frontend-2/lib/common/generated/gql/graphql.ts
@@ -2586,6 +2586,7 @@ export type ProjectPermissionChecks = {
   canCreateComment: PermissionCheckResult;
   canCreateModel: PermissionCheckResult;
   canDelete: PermissionCheckResult;
+  canInvite: PermissionCheckResult;
   canLeave: PermissionCheckResult;
   canLoad: PermissionCheckResult;
   canMoveToWorkspace: PermissionCheckResult;
@@ -4850,6 +4851,7 @@ export type WorkspacePaymentMethod = typeof WorkspacePaymentMethod[keyof typeof 
 export type WorkspacePermissionChecks = {
   __typename?: 'WorkspacePermissionChecks';
   canCreateProject: PermissionCheckResult;
+  canInvite: PermissionCheckResult;
   canMoveProjectToWorkspace: PermissionCheckResult;
 };
 
@@ -8414,6 +8416,7 @@ export type ProjectPermissionChecksFieldArgs = {
   canCreateComment: {},
   canCreateModel: {},
   canDelete: {},
+  canInvite: {},
   canLeave: {},
   canLoad: {},
   canMoveToWorkspace: ProjectPermissionChecksCanMoveToWorkspaceArgs,
@@ -9016,6 +9019,7 @@ export type WorkspacePaidPlanPricesFieldArgs = {
 }
 export type WorkspacePermissionChecksFieldArgs = {
   canCreateProject: {},
+  canInvite: {},
   canMoveProjectToWorkspace: WorkspacePermissionChecksCanMoveProjectToWorkspaceArgs,
 }
 export type WorkspacePlanFieldArgs = {

--- a/packages/server/assets/core/typedefs/permissions.graphql
+++ b/packages/server/assets/core/typedefs/permissions.graphql
@@ -15,6 +15,7 @@ type ProjectPermissionChecks {
   canRequestRender: PermissionCheckResult!
   canPublish: PermissionCheckResult!
   canLoad: PermissionCheckResult!
+  canInvite: PermissionCheckResult!
 }
 
 type RootPermissionChecks {

--- a/packages/server/assets/workspacesCore/typedefs/permissions.graphql
+++ b/packages/server/assets/workspacesCore/typedefs/permissions.graphql
@@ -4,5 +4,6 @@ extend type Workspace {
 
 type WorkspacePermissionChecks {
   canCreateProject: PermissionCheckResult!
+  canInvite: PermissionCheckResult!
   canMoveProjectToWorkspace(projectId: String): PermissionCheckResult!
 }

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -2609,6 +2609,7 @@ export type ProjectPermissionChecks = {
   canCreateComment: PermissionCheckResult;
   canCreateModel: PermissionCheckResult;
   canDelete: PermissionCheckResult;
+  canInvite: PermissionCheckResult;
   canLeave: PermissionCheckResult;
   canLoad: PermissionCheckResult;
   canMoveToWorkspace: PermissionCheckResult;
@@ -4873,6 +4874,7 @@ export type WorkspacePaymentMethod = typeof WorkspacePaymentMethod[keyof typeof 
 export type WorkspacePermissionChecks = {
   __typename?: 'WorkspacePermissionChecks';
   canCreateProject: PermissionCheckResult;
+  canInvite: PermissionCheckResult;
   canMoveProjectToWorkspace: PermissionCheckResult;
 };
 
@@ -6802,6 +6804,7 @@ export type ProjectPermissionChecksResolvers<ContextType = GraphQLContext, Paren
   canCreateComment?: Resolver<ResolversTypes['PermissionCheckResult'], ParentType, ContextType>;
   canCreateModel?: Resolver<ResolversTypes['PermissionCheckResult'], ParentType, ContextType>;
   canDelete?: Resolver<ResolversTypes['PermissionCheckResult'], ParentType, ContextType>;
+  canInvite?: Resolver<ResolversTypes['PermissionCheckResult'], ParentType, ContextType>;
   canLeave?: Resolver<ResolversTypes['PermissionCheckResult'], ParentType, ContextType>;
   canLoad?: Resolver<ResolversTypes['PermissionCheckResult'], ParentType, ContextType>;
   canMoveToWorkspace?: Resolver<ResolversTypes['PermissionCheckResult'], ParentType, ContextType, Partial<ProjectPermissionChecksCanMoveToWorkspaceArgs>>;
@@ -7550,6 +7553,7 @@ export type WorkspacePaidPlanPricesResolvers<ContextType = GraphQLContext, Paren
 
 export type WorkspacePermissionChecksResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['WorkspacePermissionChecks'] = ResolversParentTypes['WorkspacePermissionChecks']> = {
   canCreateProject?: Resolver<ResolversTypes['PermissionCheckResult'], ParentType, ContextType>;
+  canInvite?: Resolver<ResolversTypes['PermissionCheckResult'], ParentType, ContextType>;
   canMoveProjectToWorkspace?: Resolver<ResolversTypes['PermissionCheckResult'], ParentType, ContextType, Partial<WorkspacePermissionChecksCanMoveProjectToWorkspaceArgs>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/packages/server/modules/core/graph/resolvers/permissions.ts
+++ b/packages/server/modules/core/graph/resolvers/permissions.ts
@@ -106,6 +106,13 @@ export default {
         userId: ctx.userId
       })
       return Authz.toGraphqlResult(canLoad)
+    },
+    canInvite: async (parent, _args, ctx) => {
+      const canInvite = await ctx.authPolicies.project.canInvite({
+        projectId: parent.projectId,
+        userId: ctx.userId
+      })
+      return Authz.toGraphqlResult(canInvite)
     }
   },
   ModelPermissionChecks: {

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -2589,6 +2589,7 @@ export type ProjectPermissionChecks = {
   canCreateComment: PermissionCheckResult;
   canCreateModel: PermissionCheckResult;
   canDelete: PermissionCheckResult;
+  canInvite: PermissionCheckResult;
   canLeave: PermissionCheckResult;
   canLoad: PermissionCheckResult;
   canMoveToWorkspace: PermissionCheckResult;
@@ -4853,6 +4854,7 @@ export type WorkspacePaymentMethod = typeof WorkspacePaymentMethod[keyof typeof 
 export type WorkspacePermissionChecks = {
   __typename?: 'WorkspacePermissionChecks';
   canCreateProject: PermissionCheckResult;
+  canInvite: PermissionCheckResult;
   canMoveProjectToWorkspace: PermissionCheckResult;
 };
 

--- a/packages/server/modules/workspaces/graph/resolvers/permissions.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/permissions.ts
@@ -15,6 +15,13 @@ export default {
       })
       return Authz.toGraphqlResult(canCreateProject)
     },
+    canInvite: async (parent, _args, ctx) => {
+      const canInvite = await ctx.authPolicies.workspace.canInvite({
+        workspaceId: parent.workspaceId,
+        userId: ctx.userId
+      })
+      return Authz.toGraphqlResult(canInvite)
+    },
     canMoveProjectToWorkspace: async (parent, args, ctx) => {
       const canMoveProjectToWorkspace =
         await ctx.authPolicies.project.canMoveToWorkspace({

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -2590,6 +2590,7 @@ export type ProjectPermissionChecks = {
   canCreateComment: PermissionCheckResult;
   canCreateModel: PermissionCheckResult;
   canDelete: PermissionCheckResult;
+  canInvite: PermissionCheckResult;
   canLeave: PermissionCheckResult;
   canLoad: PermissionCheckResult;
   canMoveToWorkspace: PermissionCheckResult;
@@ -4854,6 +4855,7 @@ export type WorkspacePaymentMethod = typeof WorkspacePaymentMethod[keyof typeof 
 export type WorkspacePermissionChecks = {
   __typename?: 'WorkspacePermissionChecks';
   canCreateProject: PermissionCheckResult;
+  canInvite: PermissionCheckResult;
   canMoveProjectToWorkspace: PermissionCheckResult;
 };
 


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- We're using these policies in the resolvers but did not expose them as gql permissions queries

## Changes:

- Does so
