### PR TITLE
fix(automate): return null if "function" is test automation

### DIFF
--- a/packages/server/modules/automate/graph/resolvers/automate.ts
+++ b/packages/server/modules/automate/graph/resolvers/automate.ts
@@ -392,6 +392,9 @@ export = (FF_AUTOMATE_MODULE_ENABLED
       },
       AutomateFunctionRun: {
         async function(parent, _args, ctx) {
+          if (!parent.functionId) {
+            return null
+          }
           const fn = await ctx.loaders.automationsApi.getFunction.load(
             parent.functionId
           )
@@ -540,6 +543,9 @@ export = (FF_AUTOMATE_MODULE_ENABLED
       },
       AutomateFunctionRelease: {
         async function(parent, _args, ctx) {
+          if (!parent.functionId) {
+            return null
+          }
           const fn = await ctx.loaders.automationsApi.getFunction.load(
             parent.functionId
           )


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Loud logs about an "invalid url" during some automate queries
- Trace blames the `new Url()` when mapping automate server return value to gql return value
- Invalid because it's `undefined`, `undefined` because the function doesn't exist
- How? Test automations recently added the ability to be created without a function. An empty string id makes this break (in a non user-visible way)
- This was also breaking the automation run results subscriptions for test automations

## Changes:

- Return early on null/empty `functionId` in relevant places


I still think we can do better with test automations in general, but this will quiet down the error for now.