### PR TITLE
fix(automate): filter out deleted automation runs

### DIFF
--- a/packages/server/modules/automate/graph/resolvers/automate.ts
+++ b/packages/server/modules/automate/graph/resolvers/automate.ts
@@ -268,12 +268,10 @@ export = (FF_AUTOMATE_MODULE_ENABLED
         async automationsStatus(parent, _args, ctx) {
           const projectDb = await getProjectDbClient({ projectId: parent.streamId })
 
-          const getLatestVersionAutomationRuns = getLatestVersionAutomationRunsFactory({
-            db: projectDb
-          })
-
           const getStatus = getAutomationsStatusFactory({
-            getLatestVersionAutomationRuns
+            getLatestVersionAutomationRuns: getLatestVersionAutomationRunsFactory({
+              db: projectDb
+            })
           })
 
           const modelId = parent.id

--- a/packages/server/modules/automate/repositories/automations.ts
+++ b/packages/server/modules/automate/repositories/automations.ts
@@ -854,6 +854,7 @@ export const getLatestVersionAutomationRunsFactory =
       .andWhere(AutomationRunTriggers.col.triggeringId, versionId)
       .andWhere(Automations.col.projectId, projectId)
       .andWhere(BranchCommits.col.branchId, modelId)
+      .andWhere(Automations.col.isDeleted, false)
       .distinctOn(AutomationRevisions.col.automationId)
       .orderBy([
         { column: AutomationRevisions.col.automationId },


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- Queries that search for automations are properly filtering out deleted automations
- Some queries (see attached issue) begin querying for run results directly from associated resources
- These services/repo functions were not filtering out runs for deleted automations
- Led to silly behavior:
  - Deleted automations would still show their status in the donut on model cards
  - Error from associated issue, if the deleted automation had any runs

## Changes:

- Filters out automation runs from deleted automations
