### PR TITLE
fix(server): throw stream not found error if stream not found

### DIFF
--- a/packages/server/modules/core/services/streams/management.ts
+++ b/packages/server/modules/core/services/streams/management.ts
@@ -8,6 +8,7 @@ import {
 import { StreamRecord } from '@/modules/core/helpers/types'
 import {
   StreamInvalidAccessError,
+  StreamNotFoundError,
   StreamUpdateError
 } from '@/modules/core/errors/stream'
 import { isProjectCreateInput } from '@/modules/core/helpers/stream'
@@ -37,7 +38,6 @@ import {
 } from '@/modules/core/domain/streams/operations'
 import { StoreBranch } from '@/modules/core/domain/branches/operations'
 import { DeleteAllResourceInvites } from '@/modules/serverinvites/domain/operations'
-import { LogicError } from '@/modules/shared/errors'
 import { EventBusEmit } from '@/modules/shared/services/eventBus'
 import { ProjectEvents } from '@/modules/core/domain/projects/events'
 
@@ -118,7 +118,9 @@ export const deleteStreamAndNotifyFactory =
   async (streamId: string, deleterId: string) => {
     const stream = await deps.getStream({ streamId })
     if (!stream)
-      throw new LogicError('Unexpectedly stream that should exist is not found...')
+      throw new StreamNotFoundError(
+        'Stream which we are attempting to delete cannot been found.'
+      )
 
     await deps.emitEvent({
       eventName: ProjectEvents.Deleted,


### PR DESCRIPTION
## Description & motivation

Repeated calls to delete a project/stream caused a LogicError to trigger. Instead, it should be a stream not found error.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
