### PR TITLE
fix(fe): Add canCreateModel check to ProjectDashboardCard empty state

### DIFF
--- a/packages/frontend-2/components/projects/ProjectDashboardCard.vue
+++ b/packages/frontend-2/components/projects/ProjectDashboardCard.vue
@@ -110,7 +110,10 @@
           v-if="hasNoModels"
           empty-state-variant="modelsSection"
           :project-id="project.id"
-          :disabled="project?.workspace?.readOnly"
+          :disabled="
+            project?.workspace?.readOnly ||
+            !project.permissions.canCreateModel.authorized
+          "
           class="h-28 col-span-4"
         />
       </div>


### PR DESCRIPTION
I don't have a local workspace I can recreate this on, but will confirm on app with Nikos. 