### PR TITLE
feat(workspaces): sort discoverable workspaces by member count

### DIFF
--- a/packages/server/assets/workspacesCore/typedefs/workspaces.graphql
+++ b/packages/server/assets/workspacesCore/typedefs/workspaces.graphql
@@ -393,6 +393,10 @@ type LimitedWorkspace {
   Workspace members visible to people with verified email domain
   """
   team(cursor: String, limit: Int! = 25): LimitedWorkspaceCollaboratorCollection
+  """
+  Workspace admins ordered by join date
+  """
+  adminTeam: [LimitedWorkspaceCollaborator!]!
 }
 
 type LimitedWorkspaceCollaboratorCollection {

--- a/packages/server/codegen.yml
+++ b/packages/server/codegen.yml
@@ -72,6 +72,7 @@ generates:
         WorkspaceBillingMutations: '@/modules/gatekeeper/helpers/graphTypes#WorkspaceBillingMutationsGraphQLReturn'
         PendingWorkspaceCollaborator: '@/modules/workspacesCore/helpers/graphTypes#PendingWorkspaceCollaboratorGraphQLReturn'
         WorkspaceCollaborator: '@/modules/workspacesCore/helpers/graphTypes#WorkspaceCollaboratorGraphQLReturn'
+        LimitedWorkspace: '@/modules/workspacesCore/helpers/graphTypes#LimitedWorkspaceGraphQLReturn'
         LimitedWorkspaceCollaborator: '@/modules/workspacesCore/helpers/graphTypes#LimitedWorkspaceCollaboratorGraphQLReturn'
         WorkspaceSubscriptionSeats: '@/modules/gatekeeper/helpers/graphTypes#WorkspaceSubscriptionSeatsGraphQLReturn'
         WorkspaceJoinRequest: '@/modules/workspacesCore/helpers/graphTypes#WorkspaceJoinRequestGraphQLReturn'

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -5,7 +5,7 @@ import { CommentReplyAuthorCollectionGraphQLReturn, CommentGraphQLReturn, Commen
 import { PendingStreamCollaboratorGraphQLReturn } from '@/modules/serverinvites/helpers/graphTypes';
 import { FileUploadGraphQLReturn } from '@/modules/fileuploads/helpers/types';
 import { AutomateFunctionGraphQLReturn, AutomateFunctionReleaseGraphQLReturn, AutomationGraphQLReturn, AutomationPermissionChecksGraphQLReturn, AutomationRevisionGraphQLReturn, AutomationRevisionFunctionGraphQLReturn, AutomateRunGraphQLReturn, AutomationRunTriggerGraphQLReturn, AutomationRevisionTriggerDefinitionGraphQLReturn, AutomateFunctionRunGraphQLReturn, TriggeredAutomationsStatusGraphQLReturn, ProjectAutomationMutationsGraphQLReturn, ProjectTriggeredAutomationsStatusUpdatedMessageGraphQLReturn, ProjectAutomationsUpdatedMessageGraphQLReturn, UserAutomateInfoGraphQLReturn } from '@/modules/automate/helpers/graphTypes';
-import { WorkspaceGraphQLReturn, WorkspaceSsoGraphQLReturn, WorkspaceMutationsGraphQLReturn, WorkspaceJoinRequestMutationsGraphQLReturn, WorkspaceInviteMutationsGraphQLReturn, WorkspaceProjectMutationsGraphQLReturn, PendingWorkspaceCollaboratorGraphQLReturn, WorkspaceCollaboratorGraphQLReturn, LimitedWorkspaceCollaboratorGraphQLReturn, WorkspaceJoinRequestGraphQLReturn, LimitedWorkspaceJoinRequestGraphQLReturn, ProjectMoveToWorkspaceDryRunGraphQLReturn, ProjectRoleGraphQLReturn, WorkspacePermissionChecksGraphQLReturn } from '@/modules/workspacesCore/helpers/graphTypes';
+import { WorkspaceGraphQLReturn, WorkspaceSsoGraphQLReturn, WorkspaceMutationsGraphQLReturn, WorkspaceJoinRequestMutationsGraphQLReturn, WorkspaceInviteMutationsGraphQLReturn, WorkspaceProjectMutationsGraphQLReturn, PendingWorkspaceCollaboratorGraphQLReturn, WorkspaceCollaboratorGraphQLReturn, LimitedWorkspaceGraphQLReturn, LimitedWorkspaceCollaboratorGraphQLReturn, WorkspaceJoinRequestGraphQLReturn, LimitedWorkspaceJoinRequestGraphQLReturn, ProjectMoveToWorkspaceDryRunGraphQLReturn, ProjectRoleGraphQLReturn, WorkspacePermissionChecksGraphQLReturn } from '@/modules/workspacesCore/helpers/graphTypes';
 import { WorkspacePlanGraphQLReturn, WorkspacePlanUsageGraphQLReturn, PriceGraphQLReturn } from '@/modules/gatekeeperCore/helpers/graphTypes';
 import { WorkspaceBillingMutationsGraphQLReturn, WorkspaceSubscriptionSeatsGraphQLReturn, WorkspaceSubscriptionGraphQLReturn } from '@/modules/gatekeeper/helpers/graphTypes';
 import { WebhookGraphQLReturn } from '@/modules/webhooks/helpers/graphTypes';
@@ -1220,6 +1220,8 @@ export type LimitedUserWorkspaceRoleArgs = {
 /** Workspace metadata visible to non-workspace members. */
 export type LimitedWorkspace = {
   __typename?: 'LimitedWorkspace';
+  /** Workspace admins ordered by join date */
+  adminTeam: Array<LimitedWorkspaceCollaborator>;
   /** Workspace description */
   description?: Maybe<Scalars['String']['output']>;
   /** Workspace id */
@@ -5344,7 +5346,7 @@ export type ResolversTypes = {
   JoinWorkspaceInput: JoinWorkspaceInput;
   LegacyCommentViewerData: ResolverTypeWrapper<LegacyCommentViewerData>;
   LimitedUser: ResolverTypeWrapper<LimitedUserGraphQLReturn>;
-  LimitedWorkspace: ResolverTypeWrapper<Omit<LimitedWorkspace, 'team'> & { team?: Maybe<ResolversTypes['LimitedWorkspaceCollaboratorCollection']> }>;
+  LimitedWorkspace: ResolverTypeWrapper<LimitedWorkspaceGraphQLReturn>;
   LimitedWorkspaceCollaborator: ResolverTypeWrapper<LimitedWorkspaceCollaboratorGraphQLReturn>;
   LimitedWorkspaceCollaboratorCollection: ResolverTypeWrapper<Omit<LimitedWorkspaceCollaboratorCollection, 'items'> & { items: Array<ResolversTypes['LimitedWorkspaceCollaborator']> }>;
   LimitedWorkspaceJoinRequest: ResolverTypeWrapper<LimitedWorkspaceJoinRequestGraphQLReturn>;
@@ -5680,7 +5682,7 @@ export type ResolversParentTypes = {
   JoinWorkspaceInput: JoinWorkspaceInput;
   LegacyCommentViewerData: LegacyCommentViewerData;
   LimitedUser: LimitedUserGraphQLReturn;
-  LimitedWorkspace: Omit<LimitedWorkspace, 'team'> & { team?: Maybe<ResolversParentTypes['LimitedWorkspaceCollaboratorCollection']> };
+  LimitedWorkspace: LimitedWorkspaceGraphQLReturn;
   LimitedWorkspaceCollaborator: LimitedWorkspaceCollaboratorGraphQLReturn;
   LimitedWorkspaceCollaboratorCollection: Omit<LimitedWorkspaceCollaboratorCollection, 'items'> & { items: Array<ResolversParentTypes['LimitedWorkspaceCollaborator']> };
   LimitedWorkspaceJoinRequest: LimitedWorkspaceJoinRequestGraphQLReturn;
@@ -6420,6 +6422,7 @@ export type LimitedUserResolvers<ContextType = GraphQLContext, ParentType extend
 };
 
 export type LimitedWorkspaceResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['LimitedWorkspace'] = ResolversParentTypes['LimitedWorkspace']> = {
+  adminTeam?: Resolver<Array<ResolversTypes['LimitedWorkspaceCollaborator']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   logo?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
+++ b/packages/server/modules/cross-server-sync/graph/generated/graphql.ts
@@ -1200,6 +1200,8 @@ export type LimitedUserWorkspaceRoleArgs = {
 /** Workspace metadata visible to non-workspace members. */
 export type LimitedWorkspace = {
   __typename?: 'LimitedWorkspace';
+  /** Workspace admins ordered by join date */
+  adminTeam: Array<LimitedWorkspaceCollaborator>;
   /** Workspace description */
   description?: Maybe<Scalars['String']['output']>;
   /** Workspace id */

--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -1986,6 +1986,16 @@ export = FF_WORKSPACES_MODULE_ENABLED
             cursor: args.cursor ?? undefined
           })
           return team
+        },
+        adminTeam: async (parent) => {
+          const team = await getWorkspaceCollaboratorsFactory({ db })({
+            workspaceId: parent.id,
+            limit: 100,
+            filter: {
+              roles: [Roles.Workspace.Admin]
+            }
+          })
+          return team
         }
       },
       ActiveUserMutations: {

--- a/packages/server/modules/workspaces/tests/integration/repositories.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/repositories.spec.ts
@@ -30,7 +30,8 @@ import {
   BasicTestWorkspace,
   assignToWorkspace,
   buildBasicTestWorkspace,
-  createTestWorkspace
+  createTestWorkspace,
+  createTestWorkspaces
 } from '@/modules/workspaces/tests/helpers/creation'
 import {
   createUserEmailFactory,
@@ -930,6 +931,78 @@ describe('Workspace repositories', () => {
 
       expect(otherUserWorkspaces.length).to.equal(1)
       expect(otherUserWorkspaces[0].id).to.equal(workspaceWithExistingRequest.id)
+    })
+
+    it('should return workspaces in order of team size', async () => {
+      const userA: BasicTestUser = {
+        id: '',
+        name: 'John Speckle',
+        email: createRandomEmail(),
+        verified: true
+      }
+      const userB: BasicTestUser = {
+        id: '',
+        name: 'John Speckle 2',
+        email: createRandomEmail(),
+        verified: true
+      }
+      const userC: BasicTestUser = {
+        id: '',
+        name: 'John Speckle 2 2',
+        email: createRandomEmail(),
+        verified: true
+      }
+      const userD: BasicTestUser = {
+        id: '',
+        name: 'No Workspace User',
+        email: createRandomEmail(),
+        verified: true
+      }
+
+      const workspaceA: BasicTestWorkspace = {
+        id: '',
+        ownerId: '',
+        name: 'Small Workspace',
+        slug: cryptoRandomString({ length: 9 }),
+        discoverabilityEnabled: true
+      }
+      const workspaceB: BasicTestWorkspace = {
+        id: '',
+        ownerId: '',
+        name: 'Medium Workspace',
+        slug: cryptoRandomString({ length: 9 }),
+        discoverabilityEnabled: true
+      }
+      const workspaceC: BasicTestWorkspace = {
+        id: '',
+        ownerId: '',
+        name: 'Large Workspace',
+        slug: cryptoRandomString({ length: 9 }),
+        discoverabilityEnabled: true
+      }
+
+      await createTestUsers([userA, userB, userC])
+      await createTestWorkspaces([
+        [workspaceA, userA, { domain: 'example.org' }],
+        [workspaceB, userB, { domain: 'example.org' }],
+        [workspaceC, userC, { domain: 'example.org' }]
+      ])
+
+      await Promise.all([
+        assignToWorkspace(workspaceB, userA),
+        assignToWorkspace(workspaceC, userA),
+        assignToWorkspace(workspaceC, userB)
+      ])
+
+      const workspaces = await getUserDiscoverableWorkspaces({
+        domains: ['example.org'],
+        userId: userD.id
+      })
+
+      expect(workspaces.length).to.equal(3)
+      expect(workspaces[0].id).to.equal(workspaceC.id)
+      expect(workspaces[1].id).to.equal(workspaceB.id)
+      expect(workspaces[2].id).to.equal(workspaceA.id)
     })
   })
 

--- a/packages/server/modules/workspacesCore/helpers/graphTypes.ts
+++ b/packages/server/modules/workspacesCore/helpers/graphTypes.ts
@@ -36,6 +36,11 @@ export type PendingWorkspaceCollaboratorGraphQLReturn = {
 }
 
 export type WorkspaceCollaboratorGraphQLReturn = WorkspaceTeamMember
+
+export type LimitedWorkspaceGraphQLReturn = Pick<
+  Workspace,
+  'id' | 'name' | 'slug' | 'description' | 'logo'
+>
 export type LimitedWorkspaceCollaboratorGraphQLReturn = WorkspaceTeamMember
 
 export type WorkspacePermissionChecksGraphQLReturn = {

--- a/packages/server/test/authHelper.ts
+++ b/packages/server/test/authHelper.ts
@@ -133,6 +133,16 @@ export async function createTestUser(userObj?: Partial<BasicTestUser>) {
   })
   setVal('id', id)
 
+  // if (userObj?.verified && userObj.email) {
+  //   await createUserEmailFactory({ db })({
+  //     userEmail: {
+  //       userId: id,
+  //       email: userObj.email,
+  //       verified: true
+  //     }
+  //   })
+  // }
+
   return baseUser
 }
 

--- a/packages/server/test/authHelper.ts
+++ b/packages/server/test/authHelper.ts
@@ -133,16 +133,6 @@ export async function createTestUser(userObj?: Partial<BasicTestUser>) {
   })
   setVal('id', id)
 
-  // if (userObj?.verified && userObj.email) {
-  //   await createUserEmailFactory({ db })({
-  //     userEmail: {
-  //       userId: id,
-  //       email: userObj.email,
-  //       verified: true
-  //     }
-  //   })
-  // }
-
   return baseUser
 }
 

--- a/packages/server/test/graphql/generated/graphql.ts
+++ b/packages/server/test/graphql/generated/graphql.ts
@@ -1201,6 +1201,8 @@ export type LimitedUserWorkspaceRoleArgs = {
 /** Workspace metadata visible to non-workspace members. */
 export type LimitedWorkspace = {
   __typename?: 'LimitedWorkspace';
+  /** Workspace admins ordered by join date */
+  adminTeam: Array<LimitedWorkspaceCollaborator>;
   /** Workspace description */
   description?: Maybe<Scalars['String']['output']>;
   /** Workspace id */


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- The current discoverable workspaces list (seen when joining as a new user, and in the workspace switcher) can be overwhelming when there's several options.
- We want to (1) surface the most relevant ones and (2) give users confidence they're requesting to join the right ones

## Changes:

- Sort discoverable workspaces by total member count by default
- Emit workspace admins from `LimitedWorkspace` so FE can show who workspace admins are as well (cc @Mikehrn )
