### PR TITLE
feat(gatekeeper): add updatedAt field to workspace plans

### DIFF
--- a/packages/server/modules/gatekeeper/services/checkout.ts
+++ b/packages/server/modules/gatekeeper/services/checkout.ts
@@ -56,6 +56,7 @@ export const completeCheckoutSessionFactory =
     // a plan determines the workspace feature set
     const workspacePlan = {
       createdAt: new Date(),
+      updatedAt: new Date(),
       workspaceId: checkoutSession.workspaceId,
       name: checkoutSession.workspacePlan,
       status: 'valid'

--- a/packages/server/modules/gatekeeper/services/subscriptions/upgradeWorkspaceSubscription.ts
+++ b/packages/server/modules/gatekeeper/services/subscriptions/upgradeWorkspaceSubscription.ts
@@ -186,7 +186,8 @@ export const upgradeWorkspaceSubscriptionFactory =
         status: workspacePlan.status,
         workspaceId,
         name: targetPlan,
-        createdAt: new Date()
+        createdAt: new Date(),
+        updatedAt: new Date()
       }
     })
     await updateWorkspaceSubscription({ workspaceSubscription })

--- a/packages/server/modules/gatekeeper/services/workspacePlans.ts
+++ b/packages/server/modules/gatekeeper/services/workspacePlans.ts
@@ -27,6 +27,7 @@ export const updateWorkspacePlanFactory =
     })
     if (!workspace) throw new WorkspaceNotFoundError()
     const createdAt = new Date()
+    const updatedAt = new Date()
     switch (name) {
       case 'team':
       case 'teamUnlimited':
@@ -38,7 +39,7 @@ export const updateWorkspacePlanFactory =
           case 'canceled':
           case 'paymentFailed':
             await upsertWorkspacePlan({
-              workspacePlan: { workspaceId, status, name, createdAt }
+              workspacePlan: { workspaceId, status, name, createdAt, updatedAt }
             })
             break
           default:
@@ -54,7 +55,7 @@ export const updateWorkspacePlanFactory =
         switch (status) {
           case 'valid':
             await upsertWorkspacePlan({
-              workspacePlan: { workspaceId, status, name, createdAt }
+              workspacePlan: { workspaceId, status, name, createdAt, updatedAt }
             })
             break
           case 'cancelationScheduled':

--- a/packages/server/modules/gatekeeper/tests/integration/billingRepositories.spec.ts
+++ b/packages/server/modules/gatekeeper/tests/integration/billingRepositories.spec.ts
@@ -61,7 +61,8 @@ describe('billing repositories @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           status: 'paymentFailed',
           workspaceId,
-          createdAt: new Date()
+          createdAt: new Date(),
+          updatedAt: new Date()
         } as const
         await upsertPaidWorkspacePlan({
           workspacePlan
@@ -77,6 +78,7 @@ describe('billing repositories @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           status: 'paymentFailed',
           createdAt: new Date(),
+          updatedAt: new Date(),
           workspaceId
         } as const
         await upsertPaidWorkspacePlan({
@@ -103,6 +105,7 @@ describe('billing repositories @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           status: 'paymentFailed',
           createdAt: createdAt1,
+          updatedAt: createdAt1,
           workspaceId: workspace1.id
         } as const
         await upsertPaidWorkspacePlan({
@@ -115,6 +118,7 @@ describe('billing repositories @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           status: 'paymentFailed',
           createdAt: createdAt2,
+          updatedAt: createdAt2,
           workspaceId: workspace2.id
         } as const
         await upsertPaidWorkspacePlan({
@@ -140,6 +144,7 @@ describe('billing repositories @gatekeeper', () => {
           name: PaidWorkspacePlans.Pro,
           status: 'paymentFailed',
           createdAt: createdAt1,
+          updatedAt: createdAt1,
           workspaceId: workspace1.id
         } as const
         await upsertPaidWorkspacePlan({
@@ -152,6 +157,7 @@ describe('billing repositories @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           status: 'paymentFailed',
           createdAt: createdAt2,
+          updatedAt: createdAt2,
           workspaceId: workspace2.id
         } as const
         await upsertPaidWorkspacePlan({
@@ -174,6 +180,7 @@ describe('billing repositories @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           status: 'paymentFailed',
           createdAt: createdAt1,
+          updatedAt: createdAt1,
           workspaceId: workspace1.id
         } as const
         await upsertPaidWorkspacePlan({
@@ -186,6 +193,7 @@ describe('billing repositories @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           status: 'valid',
           createdAt: createdAt2,
+          updatedAt: createdAt2,
           workspaceId: workspace2.id
         } as const
         await upsertPaidWorkspacePlan({
@@ -208,6 +216,7 @@ describe('billing repositories @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           status: 'valid',
           createdAt: createdAt1,
+          updatedAt: createdAt1,
           workspaceId: workspace1.id
         } as const
         await upsertPaidWorkspacePlan({
@@ -220,6 +229,7 @@ describe('billing repositories @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           status: 'valid',
           createdAt: createdAt2,
+          updatedAt: createdAt2,
           workspaceId: workspace2.id
         } as const
         await upsertPaidWorkspacePlan({
@@ -448,7 +458,8 @@ describe('billing repositories @gatekeeper', () => {
             workspaceId: workspace2Subscription.workspaceId,
             name: PaidWorkspacePlans.Team,
             status: 'valid',
-            createdAt: new Date()
+            createdAt: new Date(),
+            updatedAt: new Date()
           }
         })
         await upsertWorkspaceSubscription({

--- a/packages/server/modules/gatekeeper/tests/intergration/repositories/workspacePlan.spec.ts
+++ b/packages/server/modules/gatekeeper/tests/intergration/repositories/workspacePlan.spec.ts
@@ -34,6 +34,7 @@ describe('Module @gatekeeper', () => {
             workspaceId: workspace1.id,
             name: PaidWorkspacePlans.Team,
             createdAt: now,
+            updatedAt: now,
             status: PaidWorkspacePlanStatuses.Valid
           }
           await upsertWorkspacePlan({
@@ -49,6 +50,7 @@ describe('Module @gatekeeper', () => {
             workspaceId: workspace2.id,
             name: PaidWorkspacePlans.Team,
             createdAt: now,
+            updatedAt: now,
             status: PaidWorkspacePlanStatuses.Valid
           }
           await upsertWorkspacePlan({

--- a/packages/server/modules/gatekeeper/tests/unit/checkout.spec.ts
+++ b/packages/server/modules/gatekeeper/tests/unit/checkout.spec.ts
@@ -147,7 +147,7 @@ describe('checkout @gatekeeper', () => {
           })({ sessionId, subscriptionId })
 
           expect(storedCheckoutSession.paymentStatus).to.equal('paid')
-          expect(omit(storedWorkspacePlan, 'createdAt')).to.deep.equal({
+          expect(omit(storedWorkspacePlan, 'createdAt', 'updatedAt')).to.deep.equal({
             workspaceId,
             name: storedCheckoutSession.workspacePlan,
             status: 'valid'
@@ -228,6 +228,7 @@ describe('checkout @gatekeeper', () => {
             name: 'team',
             status: 'valid',
             createdAt: new Date(),
+            updatedAt: new Date(),
             workspaceId
           }),
           getWorkspaceCheckoutSession: () => {
@@ -264,6 +265,7 @@ describe('checkout @gatekeeper', () => {
             name: 'team',
             status: 'paymentFailed',
             createdAt: new Date(),
+            updatedAt: new Date(),
             workspaceId
           }),
           getWorkspaceCheckoutSession: () => {
@@ -300,7 +302,7 @@ describe('checkout @gatekeeper', () => {
             name: 'free',
             status: 'valid',
             createdAt: new Date(),
-
+            updatedAt: new Date(),
             workspaceId
           }),
           getWorkspaceCheckoutSession: async () => ({
@@ -362,6 +364,7 @@ describe('checkout @gatekeeper', () => {
           workspaceId,
           name: 'free',
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'valid'
         }),
         getWorkspaceCheckoutSession: async () => null,
@@ -417,7 +420,8 @@ describe('checkout @gatekeeper', () => {
           workspaceId,
           name: 'free',
           status: 'valid',
-          createdAt: new Date()
+          createdAt: new Date(),
+          updatedAt: new Date()
         }),
         getWorkspaceCheckoutSession: async () => existingCheckoutSession!,
         countSeatsByTypeInWorkspace: async () => 1,
@@ -462,6 +466,7 @@ describe('checkout @gatekeeper', () => {
             workspaceId,
             name: 'free',
             createdAt: new Date(),
+            updatedAt: new Date(),
             status: 'valid'
           }),
           getWorkspaceCheckoutSession: async () => existingCheckoutSession!,
@@ -517,6 +522,7 @@ describe('checkout @gatekeeper', () => {
           name: 'team',
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'canceled'
         }),
         getWorkspaceCheckoutSession: async () => existingCheckoutSession!,

--- a/packages/server/modules/gatekeeper/tests/unit/featureAuthorization.spec.ts
+++ b/packages/server/modules/gatekeeper/tests/unit/featureAuthorization.spec.ts
@@ -38,7 +38,8 @@ describe('featureAuthorization @gatekeeper', () => {
             name: plan,
             status,
             workspaceId,
-            createdAt: new Date()
+            createdAt: new Date(),
+            updatedAt: new Date()
           })
         })
         const result = await canWorkspaceAccessFeature({

--- a/packages/server/modules/gatekeeper/tests/unit/subscriptions.spec.ts
+++ b/packages/server/modules/gatekeeper/tests/unit/subscriptions.spec.ts
@@ -96,6 +96,7 @@ describe('subscriptions @gatekeeper', () => {
               name,
               workspaceId,
               createdAt: new Date(),
+              updatedAt: new Date(),
               status: 'valid'
             }),
             upsertWorkspaceSubscription: async () => {
@@ -129,6 +130,7 @@ describe('subscriptions @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'valid'
         }),
         upsertWorkspaceSubscription: async ({ workspaceSubscription }) => {
@@ -171,6 +173,7 @@ describe('subscriptions @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'paymentFailed'
         }),
         upsertWorkspaceSubscription: async ({ workspaceSubscription }) => {
@@ -208,6 +211,7 @@ describe('subscriptions @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'valid'
         }),
         upsertWorkspaceSubscription: async ({ workspaceSubscription }) => {
@@ -249,6 +253,7 @@ describe('subscriptions @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'valid'
         }),
         upsertWorkspaceSubscription: async ({ workspaceSubscription }) => {
@@ -286,6 +291,7 @@ describe('subscriptions @gatekeeper', () => {
             name: PaidWorkspacePlans.Team,
             workspaceId,
             createdAt: new Date(),
+            updatedAt: new Date(),
             status: 'valid'
           }),
           upsertWorkspaceSubscription: async () => {
@@ -333,6 +339,7 @@ describe('subscriptions @gatekeeper', () => {
             name: 'free',
             workspaceId,
             createdAt: new Date(),
+            updatedAt: new Date(),
             status: 'valid'
           }),
           getWorkspaceSubscription: async () => null,
@@ -366,6 +373,7 @@ describe('subscriptions @gatekeeper', () => {
             name: 'free',
             workspaceId,
             createdAt: new Date(),
+            updatedAt: new Date(),
             status: 'valid'
           }),
           getWorkspaceSubscription: async () => workspaceSubscription,
@@ -401,6 +409,7 @@ describe('subscriptions @gatekeeper', () => {
             name: 'team',
             workspaceId,
             createdAt: new Date(),
+            updatedAt: new Date(),
             status: 'canceled'
           }),
           getWorkspaceSubscription: async () => workspaceSubscription,
@@ -431,6 +440,7 @@ describe('subscriptions @gatekeeper', () => {
         name: 'team',
         workspaceId,
         createdAt: new Date(),
+        updatedAt: new Date(),
         status: 'valid'
       }
       const priceId = cryptoRandomString({ length: 10 })
@@ -503,6 +513,7 @@ describe('subscriptions @gatekeeper', () => {
         name: 'team',
         workspaceId,
         createdAt: new Date(),
+        updatedAt: new Date(),
         status: 'valid'
       }
       const roleCount = 10
@@ -570,6 +581,7 @@ describe('subscriptions @gatekeeper', () => {
         name: 'team',
         workspaceId,
         createdAt: new Date(),
+        updatedAt: new Date(),
         status: 'valid'
       }
       const count = 1
@@ -642,6 +654,7 @@ describe('subscriptions @gatekeeper', () => {
           name: 'unlimited',
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'valid'
         }),
         countSeatsByTypeInWorkspace: async () => {
@@ -671,6 +684,7 @@ describe('subscriptions @gatekeeper', () => {
           name: PaidWorkspacePlans.Team,
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'canceled'
         }),
         countSeatsByTypeInWorkspace: async () => {
@@ -707,6 +721,7 @@ describe('subscriptions @gatekeeper', () => {
           name: workspacePlanName,
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'valid'
         }),
         countSeatsByTypeInWorkspace: async ({ type }) => {
@@ -751,6 +766,7 @@ describe('subscriptions @gatekeeper', () => {
           name: workspacePlanName,
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'valid'
         }),
         countSeatsByTypeInWorkspace: async ({ type }) => {
@@ -805,6 +821,7 @@ describe('subscriptions @gatekeeper', () => {
           name: 'unlimited',
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'valid'
         }),
         countSeatsByTypeInWorkspace: async () => {
@@ -834,6 +851,7 @@ describe('subscriptions @gatekeeper', () => {
           name: 'pro',
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'canceled'
         }),
         countSeatsByTypeInWorkspace: async () => {
@@ -870,6 +888,7 @@ describe('subscriptions @gatekeeper', () => {
           name: workspacePlanName,
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'valid'
         }),
         countSeatsByTypeInWorkspace: async () => {
@@ -915,6 +934,7 @@ describe('subscriptions @gatekeeper', () => {
           name: workspacePlanName,
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           status: 'valid'
         }),
         countSeatsByTypeInWorkspace: async () => {
@@ -978,6 +998,7 @@ describe('subscriptions @gatekeeper', () => {
         const upgradeWorkspaceSubscription = upgradeWorkspaceSubscriptionFactory({
           getWorkspacePlan: async () => ({
             createdAt: new Date(),
+            updatedAt: new Date(),
             name: plan,
             status: 'valid',
             workspaceId
@@ -1024,6 +1045,7 @@ describe('subscriptions @gatekeeper', () => {
               getWorkspacePlan: async () => ({
                 workspaceId,
                 createdAt: new Date(),
+                updatedAt: new Date(),
                 name: plan,
                 status
               }),
@@ -1068,6 +1090,7 @@ describe('subscriptions @gatekeeper', () => {
         getWorkspacePlan: async () => ({
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           name: 'team',
           status: 'valid'
         }),
@@ -1111,6 +1134,7 @@ describe('subscriptions @gatekeeper', () => {
         getWorkspacePlan: async () => ({
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           name: 'pro',
           status: 'valid'
         }),
@@ -1156,6 +1180,7 @@ describe('subscriptions @gatekeeper', () => {
         getWorkspacePlan: async () => ({
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           name: 'team',
           status: 'valid'
         }),
@@ -1200,6 +1225,7 @@ describe('subscriptions @gatekeeper', () => {
         getWorkspacePlan: async () => ({
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           name: 'team',
           status: 'valid'
         }),
@@ -1252,6 +1278,7 @@ describe('subscriptions @gatekeeper', () => {
         getWorkspacePlan: async () => ({
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           name: 'team',
           status: 'valid'
         }),
@@ -1316,6 +1343,7 @@ describe('subscriptions @gatekeeper', () => {
         getWorkspacePlan: async () => ({
           workspaceId,
           createdAt: new Date(),
+          updatedAt: new Date(),
           name: 'team',
           status: 'valid'
         }),

--- a/packages/server/modules/gatekeeper/tests/unit/workspacePlans.spec.ts
+++ b/packages/server/modules/gatekeeper/tests/unit/workspacePlans.spec.ts
@@ -192,7 +192,9 @@ describe('workspacePlan services @gatekeeper', () => {
               status
             })
             const expectedPlan = { workspaceId, name: planName, status }
-            expect(omit(storedWorkspacePlan, 'createdAt')).to.deep.equal(expectedPlan)
+            expect(omit(storedWorkspacePlan, 'createdAt', 'updatedAt')).to.deep.equal(
+              expectedPlan
+            )
             expect(emittedEventName).to.equal('gatekeeper.workspace-plan-updated')
             expect(eventPayload).to.deep.equal({ workspacePlan: expectedPlan })
           }

--- a/packages/server/modules/gatekeeperCore/migrations/20250521102621_add_updatedAt_to_workspace_plans.ts
+++ b/packages/server/modules/gatekeeperCore/migrations/20250521102621_add_updatedAt_to_workspace_plans.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex'
+
+const TABLE_NAME = 'workspace_plans'
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table
+      .timestamp('updatedAt', { precision: 3, useTz: true })
+      .defaultTo(knex.fn.now())
+      .notNullable()
+  })
+
+  // we do not have traceability when the plan was changed; assuming it never did as a starting point
+  await knex(TABLE_NAME).update({ updatedAt: knex.ref('createdAt') })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn('updatedAt')
+  })
+}

--- a/packages/server/modules/workspaces/events/eventListener.ts
+++ b/packages/server/modules/workspaces/events/eventListener.ts
@@ -775,7 +775,8 @@ export const initializeEventListenersFactory =
             name: 'free',
             status: 'valid',
             workspaceId: payload.workspace.id,
-            createdAt: new Date()
+            createdAt: new Date(),
+            updatedAt: new Date()
           }
         })
       }),

--- a/packages/server/modules/workspaces/services/tracking.ts
+++ b/packages/server/modules/workspaces/services/tracking.ts
@@ -126,6 +126,7 @@ export const buildWorkspaceTrackingPropertiesFactory =
       planName: plan?.name || '',
       planStatus: plan?.status || '',
       planCreatedAt: plan?.createdAt || null,
+      planUpdatedAt: plan?.updatedAt || null,
       subscriptionCreatedAt,
       subscriptionBillingInterval,
       subscriptionCurrentBillingCycleEnd,

--- a/packages/shared/src/workspaces/helpers/plans.ts
+++ b/packages/shared/src/workspaces/helpers/plans.ts
@@ -131,6 +131,7 @@ export type WorkspacePlanStatuses =
 type BaseWorkspacePlan = {
   workspaceId: string
   createdAt: Date
+  updatedAt: Date
 }
 
 export type PaidWorkspacePlan = BaseWorkspacePlan & {


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

Right now we do not record how long the plan was active since, as a change or workspace_plan upserts and does not update the createdAt field since it was created, and subscriptions get updated monthly/yearly to update the `currentBillingCycleEnd`;

<!---

Describe your changes, and why you're making them.  What benefit will this have to others?

Is this linked to an open Github issue, a thread in Speckle community,
or another pull request? Link it here.

If it is related to a Github issue, and resolves it, please link to the issue number, e.g.:
Fixes #85, Fixes #22, Fixes username/repo#123
Connects #123

-->

## Changes:

- Added migration to table and default value
- Updated type and all tests 
- Add the field to mixpanel update


