### PR TITLE
ci(helm): use https to clone git if ssh is not available

### DIFF
--- a/.circleci/update_helm_documentation.sh
+++ b/.circleci/update_helm_documentation.sh
@@ -21,7 +21,8 @@ HELM_GIT_TARGET_BRANCH="gh-pages"
 if [ ! -d "${README_GENERATOR_DIR}" ]; then
   echo "🔭 Could not find 'readme-generator-for-helm' in a sibling directory"
   echo "👩‍👩‍👧‍👧 Proceeding with cloning readme-generator-for-helm to a sibling directory, 'readme-generator-for-helm'"
-  if ssh -T git@github.com 2>/dev/null | grep -q 'successfully authenticated'; then
+  SSH_OUTPUT="$(ssh -T git@github.com 2>&1 || true)"
+  if echo "${SSH_OUTPUT}" | grep -q 'successfully authenticated'; then
     echo "🔑 SSH authentication successful, cloning using SSH"
     git clone git@github.com:bitnami-labs/readme-generator-for-helm.git "${README_GENERATOR_DIR}"
   else


### PR DESCRIPTION
## Description & motivation

The current pre-commit image no longer has git with ssh configured and defaults to https.

The bash script we use in CI for validating helm documentation should be robust to different git clone mechanisms.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
