### PR TITLE
chore(fe): Update vue-tippy & remove legacy code

### DIFF
--- a/packages/frontend-2/components/pricingTable/Plan.vue
+++ b/packages/frontend-2/components/pricingTable/Plan.vue
@@ -36,11 +36,7 @@
         <div v-if="hasCta">
           <slot name="cta" />
         </div>
-        <div
-          v-else
-          :key="`tooltip-${isYearlyIntervalSelected}-${plan}-${currentPlan?.name}`"
-          v-tippy="buttonTooltip"
-        >
+        <div v-else v-tippy="buttonTooltip">
           <FormButton
             :color="buttonColor"
             :disabled="!isSelectable"

--- a/packages/frontend-2/components/project/page/models/StructureItem.vue
+++ b/packages/frontend-2/components/project/page/models/StructureItem.vue
@@ -33,7 +33,6 @@
         <!-- Empty model action -->
         <div
           v-if="itemType === StructureItemType.EmptyModel"
-          :key="`add-submodel-${canCreateModel?.authorized}`"
           v-tippy="
             canCreateModel?.authorized
               ? undefined

--- a/packages/frontend-2/components/settings/workspaces/billing/addOns/Card.vue
+++ b/packages/frontend-2/components/settings/workspaces/billing/addOns/Card.vue
@@ -9,11 +9,7 @@
       <slot name="subtitle" />
     </div>
     <div class="flex items-center gap-x-2">
-      <div
-        v-if="button"
-        :key="`${buttonId}-${button.disabled}`"
-        v-tippy="button.disabledMessage"
-      >
+      <div v-if="button" v-tippy="button.disabledMessage">
         <FormButton
           v-bind="button.props || {}"
           :disabled="button.props?.disabled || button.disabled"
@@ -41,6 +37,4 @@ defineProps<{
   button: LayoutDialogButton
   disclaimer?: string
 }>()
-
-const buttonId = useId()
 </script>

--- a/packages/frontend-2/components/viewer/gendo/Panel.vue
+++ b/packages/frontend-2/components/viewer/gendo/Panel.vue
@@ -62,7 +62,7 @@
                   <ArrowTopRightOnSquareIcon class="h-3 w-3" />
                 </div>
               </FormButton>
-              <div :key="`gendo-tooltip-${buttonDisabled}`" v-tippy="tooltipMessage">
+              <div v-tippy="tooltipMessage">
                 <FormButton :disabled="buttonDisabled" size="sm" @click="enqueMagic()">
                   Generate
                 </FormButton>

--- a/packages/frontend-2/components/workspace/wizard/step/AddOns.vue
+++ b/packages/frontend-2/components/workspace/wizard/step/AddOns.vue
@@ -6,10 +6,7 @@
     <div class="flex flex-col gap-4 w-full max-w-lg items-center">
       <FormRadioGroup v-model="includeUnlimitedAddon" :options="options" is-stacked />
       <div class="flex flex-col gap-3 mt-4 w-full md:max-w-96">
-        <div
-          :key="`add-on-${includeUnlimitedAddon}`"
-          v-tippy="!includeUnlimitedAddon ? 'Please choose an option' : ''"
-        >
+        <div v-tippy="!includeUnlimitedAddon ? 'Please choose an option' : ''">
           <FormButton
             :disabled="!includeUnlimitedAddon"
             size="lg"

--- a/packages/frontend-2/package.json
+++ b/packages/frontend-2/package.json
@@ -82,7 +82,7 @@
     "ua-parser-js": "^1.0.38",
     "vee-validate": "4.7.0",
     "vue-advanced-cropper": "^2.8.8",
-    "vue-tippy": "^6.7.0",
+    "vue-tippy": "^6.7.1",
     "ws": "^8.17.1"
   },
   "devDependencies": {

--- a/packages/frontend-2/pages/book-a-demo.vue
+++ b/packages/frontend-2/pages/book-a-demo.vue
@@ -35,7 +35,6 @@
       <div class="flex flex-col gap-3 mt-4 w-full md:max-w-96">
         <div
           v-if="!showEmbed"
-          :key="`book-a-demo-cta-${bookDemoSelected}`"
           v-tippy="!bookDemoSelected ? 'Please select an option' : ''"
           class="w-full"
         >

--- a/packages/frontend-2/pages/settings/workspaces/[slug]/general.vue
+++ b/packages/frontend-2/pages/settings/workspaces/[slug]/general.vue
@@ -84,7 +84,6 @@
           <div class="flex h-full flex-col justify-center gap-y-2">
             <ClientOnly>
               <div
-                :key="`canEditEmbedOptions-${canEditEmbedOptions?.code}`"
                 v-tippy="
                   !canEditEmbedOptions?.authorized
                     ? canEditEmbedOptions?.message

--- a/packages/frontend-2/pages/verify-email.vue
+++ b/packages/frontend-2/pages/verify-email.vue
@@ -43,7 +43,6 @@
           Cancel
         </FormButton>
         <div
-          :key="cooldownRemaining"
           v-tippy="
             cooldownRemaining > 0
               ? `You can send another code in ${cooldownRemaining}s`

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -57,7 +57,7 @@
     "nanoid": "^3.0.0",
     "v3-infinite-loading": "^1.2.2",
     "vue-advanced-cropper": "^2.8.8",
-    "vue-tippy": "^6.0.0"
+    "vue-tippy": "^6.7.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15953,7 +15953,7 @@ __metadata:
     ua-parser-js: "npm:^1.0.38"
     vee-validate: "npm:4.7.0"
     vue-advanced-cropper: "npm:^2.8.8"
-    vue-tippy: "npm:^6.7.0"
+    vue-tippy: "npm:^6.7.1"
     vue-tsc: "npm:^2.2.2"
     wait-on: "npm:^6.0.1"
     ws: "npm:^8.17.1"
@@ -16478,7 +16478,7 @@ __metadata:
     vite-plugin-dts: "npm:^4.5.0"
     vue: "npm:^3.5.13"
     vue-advanced-cropper: "npm:^2.8.8"
-    vue-tippy: "npm:^6.0.0"
+    vue-tippy: "npm:^6.7.1"
     vue-tsc: "npm:^2.2.2"
     wait-on: "npm:^6.0.1"
   peerDependencies:
@@ -49920,25 +49920,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-tippy@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "vue-tippy@npm:6.0.0"
+"vue-tippy@npm:^6.7.1":
+  version: 6.7.1
+  resolution: "vue-tippy@npm:6.7.1"
   dependencies:
     tippy.js: "npm:^6.3.7"
   peerDependencies:
     vue: ^3.2.0
-  checksum: 10/6f6c79bcc85f5ed6f93745f5aa787336cac182a2b43b246c0b0856c6310bd1ee6028241921d4a781aac41ae8cb4a63348a199432e03d9def6a83b2eda3d7b90f
-  languageName: node
-  linkType: hard
-
-"vue-tippy@npm:^6.7.0":
-  version: 6.7.0
-  resolution: "vue-tippy@npm:6.7.0"
-  dependencies:
-    tippy.js: "npm:^6.3.7"
-  peerDependencies:
-    vue: ^3.2.0
-  checksum: 10/5794a740b1cde284150ae7ce873b2c60afa6f09607c96f38b800f12954e7dfa949f8c9b332f0db416f032b7fb32056b305179cb4ebbfa6613936c7150b98e293
+  checksum: 10/23c601a8aab5ced793a645710eeb63f829039c7693d8f564e1a97b936de5aefe5d4992b479f212b22b0142b6a61ce56febb13cf925a9e2d0565f761997ba9ce6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update to latest version of vue-tippy after Fabs fix. Remove all keys that were added to fix this bug. 