### PR TITLE
chore(/auth/token): make thrown error more specific about message

### DIFF
--- a/packages/server/modules/auth/rest/index.ts
+++ b/packages/server/modules/auth/rest/index.ts
@@ -113,6 +113,15 @@ export default function (app: Express) {
   app.options('/auth/token', corsMiddlewareFactory())
   app.post('/auth/token', corsMiddlewareFactory(), async (req, res) => {
     try {
+      if (!req.body.appId)
+        throw new BadRequestError(
+          `Invalid request, insufficient information provided. App Id is required.`
+        )
+      if (!req.body.appSecret)
+        throw new BadRequestError(
+          `Invalid request, insufficient information provided. App Secret is required.`
+        )
+
       const createRefreshToken = createRefreshTokenFactory({ db })
       const getApp = getAppFactory({ db })
       const createAppToken = createAppTokenFactory({
@@ -146,10 +155,8 @@ export default function (app: Express) {
       if ('refreshToken' in req.body) {
         if (!req.body.refreshToken)
           throw new BadRequestError(
-            'Invalid request - a valid refresh token is required.'
+            'Invalid request, insufficient information provided. A valid refresh token is required.'
           )
-        if (!req.body.appId || !req.body.appSecret)
-          throw new BadRequestError('Invalid request - App Id and Secret are required.')
 
         const authResponse = await withOperationLogging(
           async () =>
@@ -168,21 +175,13 @@ export default function (app: Express) {
       }
 
       // Access-code - token exchange
-      if (!req.body.appId)
-        throw new BadRequestError(
-          `Invalid request, insufficient information provided in the request. App Id is required.`
-        )
-      if (!req.body.appSecret)
-        throw new BadRequestError(
-          `Invalid request, insufficient information provided in the request. App Secret is required.`
-        )
       if (!req.body.accessCode)
         throw new BadRequestError(
-          `Invalid request, insufficient information provided in the request. Access Code is required.`
+          `Invalid request, insufficient information provided. Access Code is required.`
         )
       if (!req.body.challenge)
         throw new BadRequestError(
-          `Invalid request, insufficient information provided in the request. Challenge is required.`
+          `Invalid request, insufficient information provided. Challenge is required.`
         )
 
       const authResponse = await withOperationLogging(


### PR DESCRIPTION
## Description & motivation

We wish to understand which variable is missing when there are user data failures for the `/auth/token` endpoint

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
