### PR TITLE
Fix: Improve copy in intro call step

### DIFF
--- a/packages/frontend-2/pages/book-a-demo.vue
+++ b/packages/frontend-2/pages/book-a-demo.vue
@@ -20,11 +20,13 @@
     </template>
     <div class="flex flex-col items-center justify-center p-4 relative">
       <h1 class="text-heading-xl text-foreground mb-3">
-        <template v-if="!showEmbed">Book an intro call</template>
+        <template v-if="!showEmbed">Do you want a personal onboarding call?</template>
         <template v-else>Find a time</template>
       </h1>
       <template v-if="!showEmbed">
-        <p class="text-body-sm text-foreground-2">We'd love to help you get started</p>
+        <p class="text-body-sm text-foreground-2">
+          Get started like our most successful users
+        </p>
         <div class="flex flex-col gap-3 w-full md:max-w-96 mt-8">
           <FormRadioGroup v-model="bookDemoSelected" :options="options" is-stacked />
         </div>
@@ -77,8 +79,8 @@ const showEmbed = ref(false)
 const options = computed(() => [
   {
     value: 'yes',
-    title: `Yes, let's talk`,
-    subtitle: 'Find a time in the next step'
+    title: `Yes, help me get started`,
+    subtitle: 'Schedule your 15 minute call in the next step'
   },
   {
     value: 'no',

--- a/packages/frontend-2/pages/book-a-demo.vue
+++ b/packages/frontend-2/pages/book-a-demo.vue
@@ -84,8 +84,7 @@ const options = computed(() => [
   },
   {
     value: 'no',
-    title: 'No, maybe later',
-    subtitle: 'You can also book a time later'
+    title: 'No, I will pass for now'
   }
 ])
 


### PR DESCRIPTION
Changing the copy a bit in the intro call step to hopefully get even more bookings:

![CleanShot 2025-05-27 at 22 12 55@2x](https://github.com/user-attachments/assets/37c14d99-3cac-46e8-9bb8-66ba4567df75)

