### PR TITLE
fix: workspace create event relationship to user

### DIFF
--- a/packages/server/modules/workspaces/events/eventListener.ts
+++ b/packages/server/modules/workspaces/events/eventListener.ts
@@ -544,9 +544,13 @@ export const workspaceTrackingFactory =
     const getUserTrackingProperties = async ({ userId }: { userId: string }) => {
       const primaryEmail = await findPrimaryEmailForUser({ userId })
       if (!primaryEmail) return {}
+      const mixpanelUserId = resolveMixpanelUserId(primaryEmail.email)
+
       return {
         // eslint-disable-next-line camelcase
-        user_id: resolveMixpanelUserId(primaryEmail.email)
+        user_id: mixpanelUserId,
+        // eslint-disable-next-line camelcase
+        distinct_id: mixpanelUserId
       }
     }
 


### PR DESCRIPTION
## Description & motivation

- user_id does not get correlated to user, so when query by User on mixpanel, workspace create does not get recorded as his action
