### PR TITLE
fix(fe): setActiveWorkspaceMutation - check workspace FF and early return if false

### DIFF
--- a/packages/frontend-2/lib/navigation/composables/navigation.ts
+++ b/packages/frontend-2/lib/navigation/composables/navigation.ts
@@ -14,6 +14,7 @@ export const useNavigation = () => {
   const state = useNavigationState()
   const { mutate } = useMutation(setActiveWorkspaceMutation)
   const { $intercom } = useNuxtApp()
+  const isWorkspacesEnabled = useIsWorkspacesEnabled()
 
   const activeWorkspaceSlug = computed({
     get: () => state.value.activeWorkspaceSlug,
@@ -28,6 +29,8 @@ export const useNavigation = () => {
   const mutateActiveWorkspaceSlug = async (newVal: string | null) => {
     state.value.activeWorkspaceSlug = newVal
     state.value.isProjectsActive = false
+    if (!isWorkspacesEnabled.value) return
+
     await mutate({ slug: newVal, isProjectsActive: false })
     $intercom.updateCompany()
   }
@@ -35,6 +38,8 @@ export const useNavigation = () => {
   const mutateIsProjectsActive = async (isActive: boolean) => {
     state.value.isProjectsActive = isActive
     state.value.activeWorkspaceSlug = null
+    if (!isWorkspacesEnabled.value) return
+
     await mutate({ isProjectsActive: state.value.isProjectsActive, slug: null })
   }
 


### PR DESCRIPTION
https://seq.speckle.systems/#/events?range=1d&filter=@EventType%20%3D%200x237EF726%20and%20err.message%20%3D%20'Cannot%20return%20null%20for%20non-nullable%20field%20ActiveUserMutations.setActiveWorkspace.'

Possible fix for [this ticket](https://linear.app/speckle/issue/WEB-3393/cannot-return-null-for-non-nullable-field).

I think this is caused because workspaces are not enabled, and we're trying to set the active workspace somewhere. I added an early return to the composable to fix this. 