### PR TITLE
feat: add lastSyncAt to workspaces

### DIFF
--- a/packages/server/modules/workspaces/services/tracking.ts
+++ b/packages/server/modules/workspaces/services/tracking.ts
@@ -137,6 +137,7 @@ export const buildWorkspaceTrackingPropertiesFactory =
       createdAt: workspace.createdAt,
       projectCount: workspacesProjectCount[workspace.id] || 0,
       modelCount,
+      lastSyncAt: new Date(),
       ...getBaseTrackingProperties()
     }
   }


### PR DESCRIPTION
## Description & motivation

To have a synced workspaces number on mixpanel we need to know when was the last time it was synced as there are many that did not get the update at deletion moment, and those ones will never get updated anymore.