### PR TITLE
fix(workspaces): use correct user id on `User.workspaces`

### DIFF
--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -1861,7 +1861,7 @@ export = FF_WORKSPACES_MODULE_ENABLED
 
           return await listExpiredSsoSessions({ userId: context.userId })
         },
-        workspaces: async (_parent, args, context) => {
+        workspaces: async (parent, args, context) => {
           if (!context.userId) {
             throw new WorkspacesNotAuthorizedError()
           }
@@ -1872,7 +1872,7 @@ export = FF_WORKSPACES_MODULE_ENABLED
           })
 
           const workspaces = await getWorkspaces({
-            userId: context.userId,
+            userId: parent.id,
             search: args.filter?.search ?? undefined,
             completed: args.filter?.completed ?? undefined
           })


### PR DESCRIPTION
use correct id when querying `User.workspaces` (currently surfaces requester in all cases)

Not usually user-visible because we almost always use `activeUser` these days, so it matches. But some custom gql queries behave silly.