### PR TITLE
fix(fe): fix signup error parsing to display server messages

### DIFF
--- a/packages/frontend-2/components/auth/RegisterWithEmailBlock.vue
+++ b/packages/frontend-2/components/auth/RegisterWithEmailBlock.vue
@@ -13,6 +13,7 @@
         :rules="emailRules"
         show-label
         :disabled="isEmailDisabled"
+        auto-focus
         :help="
           emailIsBlocked
             ? 'A work email makes it easier to discover and collaborate with your coworkers on Speckle.'
@@ -31,7 +32,6 @@
         color="foundation"
         show-label
         :disabled="loading"
-        auto-focus
         autocomplete="name"
       />
       <FormTextInput

--- a/packages/frontend-2/lib/common/generated/gql/graphql.ts
+++ b/packages/frontend-2/lib/common/generated/gql/graphql.ts
@@ -4589,6 +4589,7 @@ export type WorkspaceBillingMutationsUpgradePlanArgs = {
 /** Overridden by `WorkspaceCollaboratorGraphQLReturn` */
 export type WorkspaceCollaborator = {
   __typename?: 'WorkspaceCollaborator';
+  email?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Date that the user joined the workspace. */
   joinDate: Scalars['DateTime']['output'];
@@ -4733,6 +4734,7 @@ export type WorkspaceInviteUseInput = {
 export type WorkspaceJoinRequest = {
   __typename?: 'WorkspaceJoinRequest';
   createdAt: Scalars['DateTime']['output'];
+  email?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
   status: WorkspaceJoinRequestStatus;
   user: LimitedUser;
@@ -9110,6 +9112,7 @@ export type WorkspaceBillingMutationsFieldArgs = {
   upgradePlan: WorkspaceBillingMutationsUpgradePlanArgs,
 }
 export type WorkspaceCollaboratorFieldArgs = {
+  email: {},
   id: {},
   joinDate: {},
   projectRoles: {},
@@ -9147,6 +9150,7 @@ export type WorkspaceInviteMutationsFieldArgs = {
 }
 export type WorkspaceJoinRequestFieldArgs = {
   createdAt: {},
+  email: {},
   id: {},
   status: {},
   user: {},


### PR DESCRIPTION
Bug reported by @danielgak [in discord](https://discord.com/channels/726756379083145269/1186669913209847839/1377682069454458971).

Previously, signup errors with existing emails would show a generic "Authentication request unexpectedly did not redirect" message instead of the actual server error.

The error parsing logic only checked for `body.err` and `body.message`, but the server returns errors in this structure:

```json
{
  "error": {
    "message": "Email taken. Try logging in?",
    "code": "USER_INPUT_ERROR",
    "stack": "..."
  }
}
```

Added support for parsing `body.error.message`.