### PR TITLE
fix(fe): Discoverable workspace card not dismissing

### DIFF
--- a/packages/frontend-2/components/workspace/discoverableWorkspaces/Card.vue
+++ b/packages/frontend-2/components/workspace/discoverableWorkspaces/Card.vue
@@ -91,6 +91,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'auto-joined'): void
   (e: 'request'): void
+  (e: 'dismissed', workspaceId: string): void
 }>()
 
 const { requestToJoinWorkspace, dismissDiscoverableWorkspace } =
@@ -127,6 +128,7 @@ const onRequest = () => {
 
 const onDismiss = async () => {
   await dismissDiscoverableWorkspace(props.workspace.id)
+  emit('dismissed', props.workspace.id)
   mixpanel.track('Workspace Discovery Banner Dismissed', {
     workspaceId: props.workspace.id,
     location: 'discovery_card',

--- a/packages/frontend-2/components/workspace/discoverableWorkspaces/Modal.vue
+++ b/packages/frontend-2/components/workspace/discoverableWorkspaces/Modal.vue
@@ -18,6 +18,7 @@
         location="workspace_switcher"
         @auto-joined="workspace.requestStatus = WorkspaceJoinRequestStatus.Approved"
         @request="workspace.requestStatus = WorkspaceJoinRequestStatus.Pending"
+        @dismissed="onWorkspaceDismissed"
         @go-to-workspace="open = false"
       />
       <FormButton
@@ -63,6 +64,10 @@ const dialogButtons = computed((): LayoutDialogButton[] => {
     }
   ]
 })
+
+const onWorkspaceDismissed = (workspaceId: string) => {
+  localWorkspaces.value = localWorkspaces.value.filter((w) => w.id !== workspaceId)
+}
 
 watch(open, () => {
   showAllWorkspaces.value = false


### PR DESCRIPTION
Add dismissed event to the card, and remove the worskpace from the local ref of workspaces. 