### PR TITLE
fix(fe): fix discoverable workspaces empty list on first load by simplifying state management pattern

### DIFF
--- a/packages/frontend-2/components/workspace/JoinPage.vue
+++ b/packages/frontend-2/components/workspace/JoinPage.vue
@@ -30,8 +30,8 @@
         :workspace="workspace"
         :request-status="workspace.requestStatus"
         location="workspace_join_page"
-        @auto-joined="workspace.requestStatus = WorkspaceJoinRequestStatus.Approved"
-        @request="workspace.requestStatus = WorkspaceJoinRequestStatus.Pending"
+        @auto-joined="moveToTop(workspace.id, WorkspaceJoinRequestStatus.Approved)"
+        @request="moveToTop(workspace.id, WorkspaceJoinRequestStatus.Pending)"
       />
       <FormButton
         v-if="!showAllWorkspaces && discoverableWorkspacesAndJoinRequestsCount > 3"
@@ -94,17 +94,29 @@ const {
   hasDiscoverableJoinRequests
 } = useDiscoverableWorkspaces()
 
+const showAllWorkspaces = ref(false)
+
+const actionedWorkspaces = ref<
+  (DiscoverableWorkspace_LimitedWorkspaceFragment & { requestStatus: string | null })[]
+>([])
+
+const remainingWorkspaces = computed(() => {
+  const topIds = new Set(actionedWorkspaces.value.map((w) => w.id))
+  return (discoverableWorkspacesAndJoinRequests.value || []).filter(
+    (workspace) => !topIds.has(workspace.id)
+  )
+})
+
+const localWorkspaces = computed(() => [
+  ...actionedWorkspaces.value,
+  ...remainingWorkspaces.value
+])
+
 const hasApprovedWorkspace = computed(() =>
   localWorkspaces.value.some(
     (workspace) => workspace.requestStatus === WorkspaceJoinRequestStatus.Approved
   )
 )
-
-const showAllWorkspaces = ref(false)
-
-const localWorkspaces = ref<
-  (DiscoverableWorkspace_LimitedWorkspaceFragment & { requestStatus: string | null })[]
->([])
 
 const workspacesToShow = computed(() => {
   return showAllWorkspaces.value
@@ -112,21 +124,20 @@ const workspacesToShow = computed(() => {
     : localWorkspaces.value.slice(0, 3)
 })
 
+const moveToTop = (workspaceId: string, newStatus: WorkspaceJoinRequestStatus) => {
+  const workspace = remainingWorkspaces.value.find((w) => w.id === workspaceId)
+  if (workspace) {
+    actionedWorkspaces.value.unshift({
+      ...workspace,
+      requestStatus: newStatus
+    })
+  }
+}
+
 const description = computed(() => {
   if (discoverableWorkspacesAndJoinRequestsCount.value === 1) {
     return 'We found a workspace that matches your email domain'
   }
   return 'We found workspaces that match your email domain'
 })
-
-watch(
-  discoverableWorkspacesAndJoinRequests,
-  (newWorkspaces) => {
-    // Only update if localWorkspaces is empty (initial load) or if we don't have any local modifications
-    if (localWorkspaces.value.length === 0) {
-      localWorkspaces.value = [...newWorkspaces]
-    }
-  },
-  { immediate: true }
-)
 </script>

--- a/packages/frontend-2/components/workspace/discoverableWorkspaces/Card.vue
+++ b/packages/frontend-2/components/workspace/discoverableWorkspaces/Card.vue
@@ -2,7 +2,7 @@
   <WorkspaceCard
     :logo="workspace.logo ?? ''"
     :name="workspace.name"
-    :class="requestStatus === WorkspaceJoinRequestStatus.Pending ? '' : 'bg-foundation'"
+    :class="isActioned ? '' : 'bg-foundation'"
     :banner-text="
       workspace.discoverabilityAutoJoinEnabled &&
       requestStatus !== WorkspaceJoinRequestStatus.Approved
@@ -115,6 +115,13 @@ const members = computed(() => {
     // Multiple users: show all members including those who are also admins
     return allMembers.value
   }
+})
+
+const isActioned = computed(() => {
+  return (
+    props.requestStatus === WorkspaceJoinRequestStatus.Approved ||
+    props.requestStatus === WorkspaceJoinRequestStatus.Pending
+  )
 })
 
 const onRequest = () => {

--- a/packages/frontend-2/components/workspace/discoverableWorkspaces/Modal.vue
+++ b/packages/frontend-2/components/workspace/discoverableWorkspaces/Modal.vue
@@ -16,8 +16,8 @@
         :request-status="workspace.requestStatus"
         show-dismiss-button
         location="workspace_switcher"
-        @auto-joined="workspace.requestStatus = WorkspaceJoinRequestStatus.Approved"
-        @request="workspace.requestStatus = WorkspaceJoinRequestStatus.Pending"
+        @auto-joined="moveToTop(workspace.id, WorkspaceJoinRequestStatus.Approved)"
+        @request="moveToTop(workspace.id, WorkspaceJoinRequestStatus.Pending)"
         @dismissed="onWorkspaceDismissed"
         @go-to-workspace="open = false"
       />
@@ -46,7 +46,23 @@ const {
 
 const open = defineModel<boolean>('open', { required: true })
 const showAllWorkspaces = ref(false)
-const localWorkspaces = ref(discoverableWorkspacesAndJoinRequests.value)
+
+// Workspaces that have been interacted with (moved to top)
+const actionedWorkspaces = ref<typeof discoverableWorkspacesAndJoinRequests.value>([])
+
+// Remaining workspaces (excludes ones moved to top or dismissed)
+const remainingWorkspaces = computed(() => {
+  const topIds = new Set(actionedWorkspaces.value.map((w) => w.id))
+  return (discoverableWorkspacesAndJoinRequests.value || []).filter(
+    (workspace) => !topIds.has(workspace.id)
+  )
+})
+
+// Combined list: top workspaces first, then remaining
+const localWorkspaces = computed(() => [
+  ...actionedWorkspaces.value,
+  ...remainingWorkspaces.value
+])
 
 const workspacesToShow = computed(() => {
   return showAllWorkspaces.value
@@ -65,14 +81,26 @@ const dialogButtons = computed((): LayoutDialogButton[] => {
   ]
 })
 
+const moveToTop = (workspaceId: string, newStatus: WorkspaceJoinRequestStatus) => {
+  const workspace = remainingWorkspaces.value.find((w) => w.id === workspaceId)
+  if (workspace) {
+    actionedWorkspaces.value.unshift({
+      ...workspace,
+      requestStatus: newStatus
+    })
+  }
+}
+
 const onWorkspaceDismissed = (workspaceId: string) => {
-  localWorkspaces.value = localWorkspaces.value.filter((w) => w.id !== workspaceId)
+  actionedWorkspaces.value = actionedWorkspaces.value.filter(
+    (w) => w.id !== workspaceId
+  )
 }
 
 watch(open, () => {
   showAllWorkspaces.value = false
   if (!open.value) {
-    localWorkspaces.value = discoverableWorkspacesAndJoinRequests.value
+    actionedWorkspaces.value = []
   }
 })
 </script>


### PR DESCRIPTION
Replaces watchers and local ref copying with a simpler pattern using `actionedWorkspaces` for interacted items and computed properties that merge source data with local overrides.

This eliminates the timing issue with GraphQL data loading.

This will be updated in the near future when the backend changes for discoverable workspaces. 