### PR TITLE
feat: disable hardened logic for install speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ aliases:
   - &yarn
     run:
       name: Install Dependencies
-      command: PUPPETEER_SKIP_DOWNLOAD=true PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn
+      command: YARN_ENABLE_HARDENED_MODE=0 PUPPETEER_SKIP_DOWNLOAD=true PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn
 
 workflows:
   test-build:
@@ -774,7 +774,7 @@ jobs:
       - checkout
       - run:
           name: Install Dependencies
-          command: PUPPETEER_SKIP_DOWNLOAD=true yarn
+          command: YARN_ENABLE_HARDENED_MODE=0 PUPPETEER_SKIP_DOWNLOAD=true yarn
       - run:
           name: Build public packages
           command: yarn build:public


### PR DESCRIPTION
## Description & motivation

Seems that [this mode](https://yarnpkg.com/features/security#hardened-mode) enables automatically on public repos. Tested the difference in another pr and it went from ~1m 40sec installs to ~50sec (both on cache hits).

## Changes:
- Disable yarn hardened install in all repos coming from Speckle.