### PR TITLE
fix(helm chart): prefix OCI helm chart tag with `chart.`

### DIFF
--- a/.circleci/publish_helm_chart_oci.sh
+++ b/.circleci/publish_helm_chart_oci.sh
@@ -10,16 +10,16 @@ source "${SCRIPT_DIR}/common.sh"
 RELEASE_VERSION="chart.${IMAGE_VERSION_TAG}"
 HELM_STABLE_BRANCH="${HELM_STABLE_BRANCH:-"main"}"
 
-echo "Releasing Helm Chart version ${RELEASE_VERSION}"
+echo "Releasing Helm Chart version ${RELEASE_VERSION} for application version ${IMAGE_VERSION_TAG}"
 
-yq e -i ".docker_image_tag = \"${RELEASE_VERSION}\"" "${GIT_REPO}/utils/helm/speckle-server/values.yaml"
+yq e -i ".docker_image_tag = \"${IMAGE_VERSION_TAG}\"" "${GIT_REPO}/utils/helm/speckle-server/values.yaml"
 
 echo "${DOCKER_REG_PASS}" | helm registry login "${DOCKER_HELM_REG_URL}" --username "${DOCKER_REG_USER}" --password-stdin
-helm package "${GIT_REPO}/utils/helm/speckle-server" --version "${RELEASE_VERSION}" --app-version "${RELEASE_VERSION}" --destination "/tmp"
+helm package "${GIT_REPO}/utils/helm/speckle-server" --version "${RELEASE_VERSION}" --app-version "${IMAGE_VERSION_TAG}" --destination "/tmp"
 helm push "/tmp/${CHART_NAME}-${RELEASE_VERSION}.tgz" "oci://${DOCKER_HELM_REG_URL}/speckle"
 
 if [[ "${IMAGE_VERSION_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+)?$ ]]; then
   echo "🏷 Tagging and pushing helm chart as 'speckle/${CHART_NAME}:chart.latest'"
-  helm package "${GIT_REPO}/utils/helm/speckle-server" --version "chart.latest" --app-version "${RELEASE_VERSION}" --destination "/tmp"
+  helm package "${GIT_REPO}/utils/helm/speckle-server" --version "chart.latest" --app-version "${IMAGE_VERSION_TAG}" --destination "/tmp"
   helm push "/tmp/${CHART_NAME}-chart-latest.tgz" "oci://${DOCKER_HELM_REG_URL}/speckle"
 fi


### PR DESCRIPTION
## Description & motivation

Kubernetes is not smart enough to differentiate between Docker images and Helm Charts tagged with the same tag.

So it will pull the Helm Chart and attempt to run it as the Docker image, causing problems.

## Changes:

Helm chart versions are prefixed with `chart.` to prevent clashes with Docker images.

Helm charts do not need to be tagged with `2`.

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
