### PR TITLE
feat(ci): improved caching around frontend2 builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -46,10 +46,22 @@ jobs:
         with:
           username: ${{ inputs.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+      - name: Build and push w/ version tag
         uses: useblacksmith/build-push-action@v1
+        if: ${{ inputs.PUSH_IMAGES }}
         with:
-          push: ${{ inputs.PUSH_IMAGES }}
+          push: true
+          tags: speckle/speckle-frontend-2:${{ inputs.IMAGE_VERSION_TAG }}
+          file: ./packages/frontend-2/Dockerfile
+          build-args: |
+            SPECKLE_SERVER_VERSION=${{ inputs.IMAGE_VERSION_TAG }}
+          cache-from: type=registry,ref=speckle/speckle-frontend-2:buildcache
+          cache-to: type=registry,ref=speckle/speckle-frontend-2:buildcache,mode=max
+      - name: Check frontend-2 build
+        uses: useblacksmith/build-push-action@v1
+        if: ${{ inputs.PUSH_IMAGES == false }}
+        with:
+          push: false
           tags: speckle/speckle-frontend-2:${{ inputs.IMAGE_VERSION_TAG }}
           file: ./packages/frontend-2/Dockerfile
 
@@ -164,5 +176,7 @@ jobs:
       - uses: useblacksmith/build-push-action@v1
         with:
           setup-only: true
+          cache-from: type=registry,ref=speckle/speckle-frontend-2:buildcache-sourcemaps
+          cache-to: type=registry,ref=speckle/speckle-frontend-2:buildcache-sourcemaps
       - name: Build and Publish sourcemaps
         run: ./.github/workflows/scripts/publish_fe2_sourcemaps.sh

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -52,8 +52,6 @@ jobs:
           push: ${{ inputs.PUSH_IMAGES }}
           tags: speckle/speckle-frontend-2:${{ inputs.IMAGE_VERSION_TAG }}
           file: ./packages/frontend-2/Dockerfile
-          build-args: |
-            SPECKLE_SERVER_VERSION=${{ inputs.IMAGE_VERSION_TAG }}
 
   docker-build-preview-service:
     runs-on: blacksmith


### PR DESCRIPTION
## Description & motivation

- Improved ci caching strategies for FE builds:
   - FE build on pull request consumes different caches than FE on deploy 
   - Sourcemaps stores a max cache
  
  
With this strategy: _(cache hit)_
https://github.com/specklesystems/speckle-server/actions/runs/15604028369

Without: _(both examples should be hits)_ 
(on main) https://github.com/specklesystems/speckle-server/actions/runs/15590454040/job/43908724547
(on pr) https://github.com/specklesystems/speckle-server/actions/runs/15590770112/job/43909051420
