### PR TITLE
fix(fe): Move version dialog overflow issue

### DIFF
--- a/packages/frontend-2/components/common/model/Select.vue
+++ b/packages/frontend-2/components/common/model/Select.vue
@@ -10,7 +10,7 @@
     :allow-unset="allowUnset"
     :label-id="labelId"
     :button-id="buttonId"
-    :menu-max-height-classes="`max-h-[30vh]`"
+    menu-max-height-classes="max-h-[30vh]"
     :help="help"
     by="id"
   >

--- a/packages/frontend-2/components/common/model/Select.vue
+++ b/packages/frontend-2/components/common/model/Select.vue
@@ -10,6 +10,7 @@
     :allow-unset="allowUnset"
     :label-id="labelId"
     :button-id="buttonId"
+    :menu-max-height-classes="`max-h-[30vh]`"
     :help="help"
     by="id"
   >

--- a/packages/frontend-2/lib/projects/composables/versionManagement.ts
+++ b/packages/frontend-2/lib/projects/composables/versionManagement.ts
@@ -25,7 +25,7 @@ import {
   ProjectPendingVersionsUpdatedMessageType,
   ProjectVersionsUpdatedMessageType
 } from '~~/lib/common/generated/gql/graphql'
-import { modelRoute } from '~~/lib/common/helpers/route'
+import { modelRoute, modelVersionsRoute } from '~~/lib/common/helpers/route'
 import {
   onProjectPendingVersionsUpdatedSubscription,
   onProjectVersionsUpdateSubscription
@@ -557,7 +557,11 @@ export function useMoveVersions() {
       const deleteCount = input.versionIds.length
       triggerNotification({
         type: ToastNotificationType.Info,
-        title: `${deleteCount} version${deleteCount > 1 ? 's' : ''} moved`
+        title: `${deleteCount} version${deleteCount > 1 ? 's' : ''} moved`,
+        cta: {
+          title: 'View versions',
+          url: modelVersionsRoute(input.projectId, data.versionMutations.moveToModel.id)
+        }
       })
     } else {
       const errMsg = getFirstErrorMessage(errors)

--- a/packages/ui-components/src/components/form/select/Base.vue
+++ b/packages/ui-components/src/components/form/select/Base.vue
@@ -134,7 +134,10 @@
                     />
                   </div>
                 </label>
-                <div class="overflow-auto simple-scrollbar max-h-60 xl:max-h-80">
+                <div
+                  class="overflow-auto simple-scrollbar"
+                  :class="props.menuMaxHeightClasses || 'max-h-[50vh] xl:max-h-80'"
+                >
                   <div v-if="isAsyncSearchMode && isAsyncLoading" class="px-1">
                     <CommonLoadingBar :loading="true" />
                   </div>
@@ -490,6 +493,13 @@ const props = defineProps({
   menuOpenDirection: {
     type: String as PropType<'left' | 'right'>,
     default: 'left'
+  },
+  /**
+   * Custom max height classes for the dropdown menu. If not provided, defaults to 'max-h-[50vh] xl:max-h-80'
+   */
+  menuMaxHeightClasses: {
+    type: String,
+    default: undefined
   }
 })
 


### PR DESCRIPTION
Reported by @JR-Morgan in discord:

https://github.com/user-attachments/assets/8c21cc81-774d-481f-9781-36397dda1755

and:
```also, not a bug, but when you do move a version, It would be amazing if the notification had an option to navigate to the :modelid/versions page that the version was just moved to```
