### PR TITLE
fix(regions): fix for flaky move region test

### DIFF
--- a/packages/server/modules/multiregion/tests/e2e/projects.graph.spec.ts
+++ b/packages/server/modules/multiregion/tests/e2e/projects.graph.spec.ts
@@ -50,7 +50,7 @@ import {
   createTestStream,
   getUserStreamRole
 } from '@/test/speckle-helpers/streamHelper'
-import { retry, Roles } from '@speckle/shared'
+import { retry, Roles, wait } from '@speckle/shared'
 import { expect } from 'chai'
 import cryptoRandomString from 'crypto-random-string'
 import { Knex } from 'knex'
@@ -297,7 +297,8 @@ isMultiRegionTestMode()
           regionKey: regionKey2
         })
         expect(resA).to.not.haveGraphQLErrors()
-        await ensureProjectRegion(emptyProject.id, regionKey2)
+        // TODO: Change region move order of events to avoid wait
+        await wait(10_000)
         const role = await getUserStreamRole(adminUser.id, emptyProject.id)
         if (!role || role !== Roles.Stream.Owner) {
           expect.fail('Did not preserve roles on project after region move.')


### PR DESCRIPTION
Temporary and quick fix for flaky test. Follow-up shortly with wait-free test.

Move to region does the following:

1. Copy project record to regional db
2. Copy project assets from one db to another (i.e. objects, branches, webhooks)
3. Assert copy was success
4. Update project region key in regional db
5. Delete project in main db
6. Await replication of 1 & 5
7. Re-instate records lost in 5 (project roles)

The flaky test in question:

- Polls for the project region key to be updated in the main db
- Asserts state of step 7

Often enough, the region key is updated before the roles are set, and so the test "fails".

Updating the region key later, or any other similar changes, requires moving several pieces around (but will be done). This `wait` is ugly but will allow us to safely wait for replication before asserting test state.