### PR TITLE
fix(server): not emitting seat updated on role add

### DIFF
--- a/packages/server/modules/workspaces/services/management.ts
+++ b/packages/server/modules/workspaces/services/management.ts
@@ -482,7 +482,7 @@ export const addOrUpdateWorkspaceRoleFactory =
         workspaceId,
         type: seatType,
         assignedByUserId: updatedByUserId,
-        skipEvent: true // skip SeatUpdated, cause we only want RoleUpdated to come out of this
+        skipEvent
       })
     } else {
       await ensureValidWorkspaceRoleSeat({


### PR DESCRIPTION
we used to not emit SeatUpdated event emits from addOrUpdateRole functions, cause the seat update was a secondary side-effect, but apparently we only recalculate billing on seat changes so its important that we start doing so