### PR TITLE
feat(server): dev-only endpoint for monitoring bull queues

### DIFF
--- a/packages/server/modules/core/index.ts
+++ b/packages/server/modules/core/index.ts
@@ -44,6 +44,7 @@ import {
 } from '@/modules/stats/repositories'
 import { getServerTotalModelCountFactory } from '@/modules/core/services/branch/retrieval'
 import { getServerTotalVersionCountFactory } from '@/modules/core/services/commit/retrieval'
+import { bullMonitoringRouterFactory } from '@/modules/core/rest/monitoring'
 
 let stopTestSubs: (() => void) | undefined = undefined
 
@@ -123,7 +124,7 @@ const coreModule: SpeckleModule<{
       })()
     }
   },
-  async finalize() {
+  async finalize({ app }) {
     // Update server profile in mp
     await updateServerMixpanelProfileFactory({
       getServerInfo: getCachedServerInfoFactory({ db }),
@@ -135,6 +136,9 @@ const coreModule: SpeckleModule<{
       getServerTotalVersionCount: getServerTotalVersionCountFactory(),
       logger: coreLogger
     })()
+
+    // Run BullMQ monitor once the app is fully ready
+    app.use(bullMonitoringRouterFactory())
   },
   async shutdown() {
     await shutdownResultListener()

--- a/packages/server/modules/core/rest/monitoring.ts
+++ b/packages/server/modules/core/rest/monitoring.ts
@@ -1,0 +1,40 @@
+import {
+  getServerOrigin,
+  isDevEnv,
+  isTestEnv
+} from '@/modules/shared/helpers/envHelper'
+import { Router } from 'express'
+import { ExpressAdapter } from '@bull-board/express'
+import { createBullBoard } from '@bull-board/api'
+import { BullAdapter } from '@bull-board/api/bullAdapter'
+import { getActiveQueues } from '@speckle/shared/queue'
+import { moduleLogger } from '@/observability/logging'
+
+/**
+ * Has to be invoked after all speckle modules are initialized, cause only then we have
+ * the full set of Bull queues registered.
+ */
+export const bullMonitoringRouterFactory = (): Router => {
+  const router = Router()
+  if (!isDevEnv() && !isTestEnv()) return router
+
+  const relativeUrl = '/monitoring/bull'
+  const url = new URL(relativeUrl, getServerOrigin())
+  const queues = getActiveQueues()
+  moduleLogger.info(
+    `Initializing Bull monitoring UI with ${
+      Object.keys(queues).length
+    } queues at ${url.toString()}`
+  )
+
+  const serverAdapter = new ExpressAdapter()
+  serverAdapter.setBasePath(relativeUrl)
+  createBullBoard({
+    serverAdapter,
+    queues: Object.values(queues).map((q) => new BullAdapter(q))
+  })
+
+  router.use(relativeUrl, serverAdapter.getRouter())
+
+  return router
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -50,6 +50,7 @@
     "@aws-sdk/client-s3": "^3.276.0",
     "@aws-sdk/lib-storage": "^3.100.0",
     "@aws-sdk/s3-request-presigner": "3.352.0",
+    "@bull-board/express": "^4.2.2",
     "@godaddy/terminus": "^4.9.0",
     "@graphql-tools/mock": "^9.0.4",
     "@graphql-tools/schema": "^10.0.6",
@@ -139,7 +140,6 @@
   },
   "devDependencies": {
     "@apollo/rover": "^0.23.0",
-    "@bull-board/express": "^4.2.2",
     "@faker-js/faker": "^8.4.1",
     "@graphql-codegen/cli": "^5.0.5",
     "@graphql-codegen/typed-document-node": "^5.1.1",


### PR DESCRIPTION
unlike the bull monitor CLI call, this one's always running (in dev & test envs) and automatically picks up on all active bull queues