### PR TITLE
fix(server/auth/google): handle error parameter in request query

### DIFF
--- a/packages/server/modules/auth/services/passportService.ts
+++ b/packages/server/modules/auth/services/passportService.ts
@@ -112,6 +112,36 @@ export const passportAuthenticationCallbackFactory =
         'Unknown authentication error. Please contact server admins'
       )
 
+      // google will throw a TokenError for various reasons, such as invalid_grant, and the Google strategy will not call the verify method
+      if (err.name === 'TokenError' && 'code' in err) {
+        switch (err.code) {
+          // invalid_grant is a common error from strategies such as Google and a number of reasons
+          // can cause it. Many user-related issues, so we will treat it as user-related.
+          // https://blog.timekit.io/google-oauth-invalid-grant-nightmare-and-how-to-fix-it-9f4efaf1da35
+          case 'invalid_grant':
+            req.log.warn(
+              { err: e, strategy },
+              'Authentication error for strategy "{strategy}" encountered an Invalid Grant error'
+            )
+            res.redirect(
+              buildRedirectUrl({
+                resolveAuthRedirectPath,
+                path: defaultErrorPath(
+                  'Failed to authenticate, please refer to your SSO provider.'
+                )
+              })
+            )
+            return
+          default:
+            req.log.info(
+              // log at info level, as the error logging will be handled below
+              { err, strategy },
+              'Authentication error for strategy "{strategy}" encountered an unexpected TokenError of code "{err.code}"'
+            )
+          // fall through to the unknown error handler
+        }
+      }
+
       // unknown and unexpected error
       req.log.error({ err, strategy }, 'Authentication error for strategy "{strategy}"')
       return next(err)

--- a/packages/server/modules/auth/strategies/google.ts
+++ b/packages/server/modules/auth/strategies/google.ts
@@ -73,6 +73,8 @@ const googleStrategyBuilderFactory =
         })
 
         try {
+          // seems very weird that the Google strategy is not parsing 'error' query params
+          // and generating a thrown error for us, but here we are.
           if ('error' in req.query) {
             switch (req.query.error) {
               case 'access_denied':
@@ -182,25 +184,6 @@ const googleStrategyBuilderFactory =
                 email: (e as UnverifiedEmailSSOLoginError).info().email
               })
             default:
-              // handle other common errors thrown by the underlying client libraries
-              if (
-                e.name === 'TokenError' &&
-                'code' in e &&
-                e.code === 'invalid_grant'
-              ) {
-                req.log.warn(
-                  { err: e },
-                  "Authentication error for strategy 'google' encountered an Invalid Grant error"
-                )
-                // This is a common error from Google and a number of reasons
-                // can cause it. Many user-related issues, so we will treat it as user-related.
-                // https://blog.timekit.io/google-oauth-invalid-grant-nightmare-and-how-to-fix-it-9f4efaf1da35
-                return done(null, false, {
-                  message: e.message,
-                  failureType: ExpectedAuthFailure.InvalidGrantError
-                })
-              }
-
               logger.error({ err: e }, 'Auth error for Google strategy')
               return done(e, false, { message: e.message })
           }


### PR DESCRIPTION
## Description & motivation

Callbacks from Google server authentication strategy included an `error` parameter in the request query with a value of `access_denied`.

These were being sent from the verify handler via the verifyCallback to passportService as the case of no user, no error, and a null failureType. This resulted in an error log.

In the case where the request to the verify handler contains an `error` parameter, we can immediately call the verifyCallback and return.

## Changes:

- return early if there is an `error` parameter in the callback from Google
- use a different default error message if the invite is invalid.

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
