### PR TITLE
fix: avoid workpaces to turn free when susbscription is present

### DIFF
--- a/packages/server/modules/cli/commands/workspaces/set-plan.ts
+++ b/packages/server/modules/cli/commands/workspaces/set-plan.ts
@@ -7,6 +7,7 @@ import {
 import { db } from '@/db/knex'
 import {
   getWorkspacePlanFactory,
+  getWorkspaceSubscriptionFactory,
   upsertWorkspacePlanFactory
 } from '@/modules/gatekeeper/repositories/billing'
 import { WorkspaceNotFoundError } from '@/modules/workspaces/errors/workspace'
@@ -58,6 +59,7 @@ const command: CommandModule<
       getWorkspace: getWorkspaceFactory({ db }),
       upsertWorkspacePlan: upsertWorkspacePlanFactory({ db }),
       getWorkspacePlan: getWorkspacePlanFactory({ db }),
+      getWorkspaceSubscription: getWorkspaceSubscriptionFactory({ db }),
       emitEvent: getEventBus().emit
     })
     await updateWorkspacePlan({

--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -178,6 +178,7 @@ import { getDefaultRegionFactory } from '@/modules/workspaces/repositories/regio
 import { convertFunctionToGraphQLReturn } from '@/modules/automate/services/functionManagement'
 import {
   getWorkspacePlanFactory,
+  getWorkspaceSubscriptionFactory,
   getWorkspaceWithPlanFactory,
   upsertWorkspacePlanFactory
 } from '@/modules/gatekeeper/repositories/billing'
@@ -590,6 +591,7 @@ export = FF_WORKSPACES_MODULE_ENABLED
             getWorkspace: getWorkspaceFactory({ db }),
             upsertWorkspacePlan: upsertWorkspacePlanFactory({ db }),
             getWorkspacePlan: getWorkspacePlanFactory({ db }),
+            getWorkspaceSubscription: getWorkspaceSubscriptionFactory({ db }),
             emitEvent: getEventBus().emit
           })
 


### PR DESCRIPTION
## Description & motivation

- workpaces with current ongoing subscriptions can't turned into non paid by admin mutation