### PR TITLE
fix(ci): deduplicated lint runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,9 +84,6 @@ jobs:
         run: YARN_ENABLE_HARDENED_MODE=0 PUPPETEER_SKIP_DOWNLOAD=true PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn --immutable
       - name: Build public packages
         run: yarn build:public
-      - name: Lint viewer-sandbox
-        run: yarn lint:ci
-        working-directory: 'packages/viewer-sandbox'
       - name: Build viewer-sandbox
         run: yarn build
         working-directory: 'packages/viewer-sandbox'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
   test-frontend-2:
     name: Frontend
     runs-on: blacksmith
+    if: false # disabled as there is nothing to run
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: useblacksmith/setup-node@v5
@@ -79,9 +80,6 @@ jobs:
         run: YARN_ENABLE_HARDENED_MODE=0 PUPPETEER_SKIP_DOWNLOAD=true PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn --immutable
       - name: Build public packages
         run: yarn build:public
-      - name: Lint everything
-        run: yarn lint:ci
-        working-directory: 'packages/frontend-2'
 
   test-viewer:
     name: Viewer
@@ -96,15 +94,9 @@ jobs:
         run: YARN_ENABLE_HARDENED_MODE=0 PUPPETEER_SKIP_DOWNLOAD=true PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn --immutable
       - name: Build public packages
         run: yarn build:public
-      - name: Lint viewer
-        run: yarn lint:ci
-        working-directory: 'packages/viewer'
       - name: Run tests
         run: yarn test
         working-directory: 'packages/viewer'
-      - name: Lint viewer-sandbox
-        run: yarn lint:ci
-        working-directory: 'packages/viewer-sandbox'
       - name: Build viewer-sandbox
         run: yarn build
         working-directory: 'packages/viewer-sandbox'
@@ -141,9 +133,6 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: YARN_ENABLE_HARDENED_MODE=0 PUPPETEER_SKIP_DOWNLOAD=true PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn --immutable
-      - name: Lint
-        run: yarn lint:ci
-        working-directory: 'packages/shared'
       - name: Run tests (all FFs)
         run: ENABLE_ALL_FFS=1 yarn test:ci
         working-directory: 'packages/shared'
@@ -179,7 +168,7 @@ jobs:
         run: YARN_ENABLE_HARDENED_MODE=0 PUPPETEER_SKIP_DOWNLOAD=true PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn --immutable
       - name: Build public packages
         run: yarn build:public
-      - name: Lint everything
+      - name: Test object sender
         run: yarn test:ci
         working-directory: 'packages/objectsender'
       - uses: codecov/codecov-action@v5
@@ -202,15 +191,6 @@ jobs:
         run: YARN_ENABLE_HARDENED_MODE=0 PUPPETEER_SKIP_DOWNLOAD=true yarn --immutable # we need PLAYWRIGHT
       - name: Build public packages
         run: yarn build:public
-      - name: Lint tailwind theme
-        run: yarn lint:ci
-        working-directory: 'packages/tailwind-theme'
-      - name: Lint ui components
-        run: yarn lint:ci
-        working-directory: 'packages/ui-components'
-      - name: Lint component nuxt package
-        run: yarn lint:ci
-        working-directory: 'packages/ui-components-nuxt'
       - name: Test via Storybook
         run: yarn storybook:test:ci
         working-directory: 'packages/ui-components'
@@ -218,6 +198,7 @@ jobs:
   test-preview-service:
     name: Preview service
     runs-on: blacksmith
+    if: false # disabled as there is nothing to run
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: useblacksmith/setup-node@v5
@@ -228,9 +209,6 @@ jobs:
         run: YARN_ENABLE_HARDENED_MODE=0 PUPPETEER_SKIP_DOWNLOAD=true PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn --immutable
       - name: Build public packages
         run: yarn build:public
-      - name: Lint everything
-        run: yarn lint:ci
-        working-directory: 'packages/preview-service'
 
   docker-build-postgres-container:
     runs-on: blacksmith
@@ -318,9 +296,6 @@ jobs:
       - name: Build public packages
         run: yarn build:public
       - run: cp .env.test-example .env.test
-        working-directory: 'packages/server'
-      - name: 'Lint'
-        run: yarn lint:ci
         working-directory: 'packages/server'
       - name: 'Run test'
         run: yarn test:report


### PR DESCRIPTION
projectwide linter runs already:
- packages/objectloader
- packages/tailwind-theme
- packages/preview-frontend
- packages/preview-service
- packages/objectloader2
- packages/monitor-deployment
- packages/viewer-sandbox
- packages/objectsender
- packages/fileimport-service
- packages/shared
- packages/viewer
- packages/frontend-2
- packages/server
- packages/ui-components
- packages/ui-components-nuxt
- packages/webhook-service

So disabled the lint runs on:
- frontend job (nothing else to run so disabled the job)
- publish preview-service
- test-viewer 
- test-shared
- test-preview-service (nothing else to run so disabled the job)
- test-ui-component
- test-server
