### PR TITLE
fix (OL2): we don't want to break eviction checking for first item...continue the check

### DIFF
--- a/packages/objectloader2/src/deferment/defermentManager.ts
+++ b/packages/objectloader2/src/deferment/defermentManager.ts
@@ -127,7 +127,7 @@ export class DefermentManager {
         //we do not clean it up to allow the requests to resolve
         const requestCount = this.totalDefermentRequests.get(deferredBase.getId())
         if (requestCount && requestCount > 1) {
-          break
+          continue
         }
         this.currentSize -= deferredBase.getSize() || 0
         this.deferments.delete(deferredBase.getId())

--- a/packages/objectloader2/src/deferment/defermentManager.ts
+++ b/packages/objectloader2/src/deferment/defermentManager.ts
@@ -66,11 +66,11 @@ export class DefermentManager {
     //order matters here with found before undefer
     const deferredBase = this.deferments.get(item.baseId)
     if (deferredBase) {
-      deferredBase.found(base)
+      deferredBase.found(base, item.size || 0)
       deferredBase.setAccess(now)
     } else {
       const existing = new DeferredBase(this.options.ttlms, item.baseId, now)
-      existing.found(base)
+      existing.found(base, item.size || 0)
       this.deferments.set(item.baseId, existing)
     }
   }

--- a/packages/objectloader2/src/deferment/deferredBase.ts
+++ b/packages/objectloader2/src/deferment/deferredBase.ts
@@ -43,7 +43,7 @@ export class DeferredBase {
     this.expiresAt = now + this.ttl
   }
 
-  found(value: Base, size?: number): void {
+  found(value: Base, size: number): void {
     this.base = value
     this.size = size
     this.resolve(value)


### PR DESCRIPTION
This "fix" actually makes things worse but uses less memory.

Before, the clean up process stopped because of the first invalid object.  Now, this will continue the process as it should.  This, however, causes the eviction then read slowness issue.