### PR TITLE
Fix: Update auth watcher

### DIFF
--- a/packages/frontend-2/lib/auth/composables/auth.ts
+++ b/packages/frontend-2/lib/auth/composables/auth.ts
@@ -343,7 +343,7 @@ export const useAuthManager = (
    */
   const watchEmbedToken = () => {
     watch(
-      () => embedToken,
+      () => embedToken.value,
       async (newVal, oldVal) => {
         if (newVal && newVal !== oldVal) {
           await resetAuthState()


### PR DESCRIPTION
Because it's watching the computed obj the newVal !== oldVal because true and it's causing sometimes an unneeded resetAuth trigger