### PR TITLE
fix: getting all user projects on deletion and user filter

### DIFF
--- a/packages/server/modules/core/domain/streams/operations.ts
+++ b/packages/server/modules/core/domain/streams/operations.ts
@@ -103,6 +103,16 @@ export type GetImplicitUserProjectsCountFactory = (params: {
   userId: string
 }) => Promise<number>
 
+export type GetExplicitProjects = (params: {
+  cursor: string | null
+  limit: number
+  workspaceId?: string
+  userId?: string
+}) => Promise<{
+  items: StreamWithOptionalRole[]
+  cursor: string | null
+}>
+
 export type StoreStream = (
   input: StreamCreateInput | ProjectCreateArgs,
   options?: Partial<{

--- a/packages/server/modules/core/domain/streams/operations.ts
+++ b/packages/server/modules/core/domain/streams/operations.ts
@@ -106,8 +106,10 @@ export type GetImplicitUserProjectsCountFactory = (params: {
 export type GetExplicitProjects = (params: {
   cursor: string | null
   limit: number
-  workspaceId?: string
-  userId?: string
+  filter: {
+    workspaceId?: string
+    userId?: string
+  }
 }) => Promise<{
   items: StreamWithOptionalRole[]
   cursor: string | null

--- a/packages/server/modules/core/graph/resolvers/users.ts
+++ b/packages/server/modules/core/graph/resolvers/users.ts
@@ -33,8 +33,8 @@ import {
 } from '@/modules/core/services/users/management'
 import {
   deleteStreamFactory,
-  getUserDeletableStreamsFactory,
-  legacyGetStreamsFactory
+  getExplicitProjects,
+  getUserDeletableStreamsFactory
 } from '@/modules/core/repositories/streams'
 import { dbLogger } from '@/observability/logging'
 import { getAdminUsersListCollectionFactory } from '@/modules/core/services/users/legacyAdminUsersList'
@@ -71,7 +71,7 @@ const deleteUser = deleteUserFactory({
   isLastAdminUser: isLastAdminUserFactory({ db }),
   getUserDeletableStreams: getUserDeletableStreamsFactory({ db }),
   queryAllProjects: queryAllProjectsFactory({
-    getStreams: legacyGetStreamsFactory({ db })
+    getExplicitProjects: getExplicitProjects({ db })
   }),
   getUserWorkspaceSeats: getUserWorkspaceSeatsFactory({ db }),
   deleteAllUserInvites: deleteAllUserInvitesFactory({ db }),

--- a/packages/server/modules/core/repositories/streams.ts
+++ b/packages/server/modules/core/repositories/streams.ts
@@ -108,7 +108,8 @@ import {
   GetStreamsCollaborators,
   GetStreamsCollaboratorCounts,
   GetImplicitUserProjectsCountFactory,
-  GrantProjectPermissions
+  GrantProjectPermissions,
+  GetExplicitProjects
 } from '@/modules/core/domain/streams/operations'
 import { generateProjectName } from '@/modules/core/domain/projects/logic'
 import { WorkspaceAcl } from '@/modules/workspacesCore/helpers/db'
@@ -1488,4 +1489,47 @@ export const getImplicitUserProjectsCountFactory =
 
     const [{ count }] = await q
     return parseInt(count)
+  }
+
+/**
+ * Batch the explicit projects givent by the workspace, the user or both
+ */
+export const getExplicitProjects =
+  (deps: { db: Knex }): GetExplicitProjects =>
+  async ({ userId, limit, cursor, workspaceId }) => {
+    if (!userId && !workspaceId) throw new LogicError('A filter must be provided')
+
+    const cursorTarget = Streams.col.id
+    const q = tables
+      .streams(deps.db)
+      .select<StreamWithOptionalRole[]>([
+        ...Object.values(Streams.col),
+        ...(userId ? [StreamAcl.col.role] : [])
+      ])
+      .limit(limit)
+      .orderBy(cursorTarget, 'desc')
+
+    if (userId) {
+      q.join(StreamAcl.name, (j) => {
+        j.on(StreamAcl.col.resourceId, Streams.col.id).andOnVal(
+          StreamAcl.col.userId,
+          userId
+        )
+      })
+    }
+
+    if (cursor) {
+      q.where(cursorTarget, '<', decodeCursor(cursor))
+    }
+
+    if (workspaceId) {
+      q.where(Streams.col.workspaceId, workspaceId)
+    }
+
+    const rows = await q
+
+    return {
+      items: rows,
+      cursor: rows.length ? encodeCursor(rows[rows.length - 1].id) : null
+    }
   }

--- a/packages/server/modules/core/repositories/streams.ts
+++ b/packages/server/modules/core/repositories/streams.ts
@@ -1496,7 +1496,7 @@ export const getImplicitUserProjectsCountFactory =
  */
 export const getExplicitProjects =
   (deps: { db: Knex }): GetExplicitProjects =>
-  async ({ userId, limit, cursor, workspaceId }) => {
+  async ({ limit, cursor, filter: { userId, workspaceId } }) => {
     if (!userId && !workspaceId) throw new LogicError('A filter must be provided')
 
     const cursorTarget = Streams.col.id

--- a/packages/server/modules/core/services/projects.ts
+++ b/packages/server/modules/core/services/projects.ts
@@ -148,8 +148,10 @@ export const queryAllProjectsFactory = ({
       const { items, cursor } = await getExplicitProjects({
         cursor: currentCursor,
         limit: 100,
-        workspaceId,
-        userId
+        filter: {
+          workspaceId,
+          userId
+        }
       })
 
       yield items

--- a/packages/server/modules/core/tests/integration/repositories/project.spec.ts
+++ b/packages/server/modules/core/tests/integration/repositories/project.spec.ts
@@ -13,6 +13,9 @@ import {
   buildBasicTestWorkspace,
   createTestWorkspace
 } from '@/modules/workspaces/tests/helpers/creation'
+import { getFeatureFlags } from '@/modules/shared/helpers/envHelper'
+
+const { FF_WORKSPACES_MODULE_ENABLED } = getFeatureFlags()
 
 describe('projects repository', () => {
   const workspace = buildBasicTestWorkspace()
@@ -48,16 +51,18 @@ describe('projects repository', () => {
 
     expect(first.value).to.be.an('array').that.has.lengthOf(2)
   })
+  ;(FF_WORKSPACES_MODULE_ENABLED ? it : it.skip)(
+    'is able to query by workspaceId',
+    async () => {
+      const asyncQueryGenerator = queryAllProjects({
+        workspaceId: workspace.id
+      })
 
-  it('is able to query by workspaceId', async () => {
-    const asyncQueryGenerator = queryAllProjects({
-      workspaceId: workspace.id
-    })
+      const first = await asyncQueryGenerator.next()
 
-    const first = await asyncQueryGenerator.next()
-
-    expect(first.value).to.be.an('array').that.has.lengthOf(1)
-  })
+      expect(first.value).to.be.an('array').that.has.lengthOf(1)
+    }
+  )
 
   it('yield projects in groups of 100', async () => {
     const asyncQueryGenerator = queryAllProjects({

--- a/packages/server/modules/core/tests/integration/repositories/project.spec.ts
+++ b/packages/server/modules/core/tests/integration/repositories/project.spec.ts
@@ -1,0 +1,75 @@
+import { BasicTestUser, buildBasicTestUser, createTestUser } from '@/test/authHelper'
+import { buildBasicTestProject } from '@/modules/core/tests/helpers/creation'
+import {
+  BasicTestStream,
+  createTestStream,
+  createTestStreams
+} from '@/test/speckle-helpers/streamHelper'
+import { queryAllProjectsFactory } from '@/modules/core/services/projects'
+import { getExplicitProjects } from '@/modules/core/repositories/streams'
+import { expect } from 'chai'
+import { db } from '@/db/knex'
+import {
+  buildBasicTestWorkspace,
+  createTestWorkspace
+} from '@/modules/workspaces/tests/helpers/creation'
+
+describe('projects repository', () => {
+  const workspace = buildBasicTestWorkspace()
+  const user = buildBasicTestUser()
+  const user2 = buildBasicTestUser()
+
+  before(async () => {
+    await createTestUser(user)
+    await createTestUser(user2)
+
+    await createTestWorkspace(workspace, user)
+
+    await createTestStream(buildBasicTestProject({ workspaceId: workspace.id }), user)
+    await createTestStream(buildBasicTestProject(), user)
+
+    const pairs: [BasicTestStream, BasicTestUser][] = []
+    for (let i = 0; i < 150; i++) {
+      pairs.push([buildBasicTestProject(), user2])
+    }
+    await createTestStreams(pairs)
+  })
+
+  const queryAllProjects = queryAllProjectsFactory({
+    getExplicitProjects: getExplicitProjects({ db })
+  })
+
+  it('does not mixup projects from different users', async () => {
+    const asyncQueryGenerator = queryAllProjects({
+      userId: user.id
+    })
+
+    const first = await asyncQueryGenerator.next()
+
+    expect(first.value).to.be.an('array').that.has.lengthOf(2)
+  })
+
+  it('is able to query by workspaceId', async () => {
+    const asyncQueryGenerator = queryAllProjects({
+      workspaceId: workspace.id
+    })
+
+    const first = await asyncQueryGenerator.next()
+
+    expect(first.value).to.be.an('array').that.has.lengthOf(1)
+  })
+
+  it('yield projects in groups of 100', async () => {
+    const asyncQueryGenerator = queryAllProjects({
+      userId: user2.id
+    })
+
+    const first = await asyncQueryGenerator.next()
+    const second = await asyncQueryGenerator.next()
+    const third = await asyncQueryGenerator.next()
+
+    expect(first.value).to.be.an('array').that.has.lengthOf(100)
+    expect(second.value).to.be.an('array').that.has.lengthOf(50)
+    expect(third.value).to.be.an('array').that.has.lengthOf(0)
+  })
+})

--- a/packages/server/modules/core/tests/users.spec.ts
+++ b/packages/server/modules/core/tests/users.spec.ts
@@ -39,7 +39,7 @@ import {
   deleteStreamFactory,
   getUserDeletableStreamsFactory,
   getStreamRolesFactory,
-  legacyGetStreamsFactory
+  getExplicitProjects
 } from '@/modules/core/repositories/streams'
 import {
   getObjectFactory,
@@ -285,7 +285,7 @@ const deleteUser = deleteUserFactory({
   isLastAdminUser: isLastAdminUserFactory({ db }),
   getUserDeletableStreams: getUserDeletableStreamsFactory({ db }),
   queryAllProjects: queryAllProjectsFactory({
-    getStreams: legacyGetStreamsFactory({ db })
+    getExplicitProjects: getExplicitProjects({ db })
   }),
   getUserWorkspaceSeats: getUserWorkspaceSeatsFactory({ db }),
   deleteAllUserInvites: deleteAllUserInvitesFactory({ db }),

--- a/packages/server/modules/core/tests/usersAdmin.spec.ts
+++ b/packages/server/modules/core/tests/usersAdmin.spec.ts
@@ -38,8 +38,8 @@ import {
 } from '@/modules/serverinvites/repositories/serverInvites'
 import {
   deleteStreamFactory,
-  getUserDeletableStreamsFactory,
-  legacyGetStreamsFactory
+  getExplicitProjects,
+  getUserDeletableStreamsFactory
 } from '@/modules/core/repositories/streams'
 import { dbLogger } from '@/observability/logging'
 import { getServerInfoFactory } from '@/modules/core/repositories/server'
@@ -85,7 +85,7 @@ const deleteUser = deleteUserFactory({
   isLastAdminUser: isLastAdminUserFactory({ db }),
   getUserDeletableStreams: getUserDeletableStreamsFactory({ db }),
   queryAllProjects: queryAllProjectsFactory({
-    getStreams: legacyGetStreamsFactory({ db })
+    getExplicitProjects: getExplicitProjects({ db })
   }),
   getUserWorkspaceSeats: getUserWorkspaceSeatsFactory({ db }),
   deleteAllUserInvites: deleteAllUserInvitesFactory({ db }),

--- a/packages/server/modules/gatekeeper/graph/resolvers/index.ts
+++ b/packages/server/modules/gatekeeper/graph/resolvers/index.ts
@@ -55,7 +55,7 @@ import {
 import { assignWorkspaceSeatFactory } from '@/modules/workspaces/services/workspaceSeat'
 import { getEventBus } from '@/modules/shared/services/eventBus'
 import { getTotalSeatsCountByPlanFactory } from '@/modules/gatekeeper/services/subscriptions'
-import { legacyGetStreamsFactory } from '@/modules/core/repositories/streams'
+import { getExplicitProjects } from '@/modules/core/repositories/streams'
 import { getWorkspaceModelCountFactory } from '@/modules/workspaces/services/workspaceLimits'
 import { getProjectDbClient } from '@/modules/multiregion/utils/dbSelector'
 import { getPaginatedProjectModelsTotalCountFactory } from '@/modules/core/repositories/branches'
@@ -208,7 +208,7 @@ export default FF_GATEKEEPER_MODULE_ENABLED
 
           return await getWorkspaceModelCountFactory({
             queryAllProjects: queryAllProjectsFactory({
-              getStreams: legacyGetStreamsFactory({ db })
+              getExplicitProjects: getExplicitProjects({ db })
             }),
             getPaginatedProjectModelsTotalCount: async (projectId, params) => {
               const regionDb = await getProjectDbClient({ projectId })

--- a/packages/server/modules/workspaces/authz/loaders/index.ts
+++ b/packages/server/modules/workspaces/authz/loaders/index.ts
@@ -1,6 +1,6 @@
 import { db } from '@/db/knex'
 import { getPaginatedProjectModelsTotalCountFactory } from '@/modules/core/repositories/branches'
-import { legacyGetStreamsFactory } from '@/modules/core/repositories/streams'
+import { getExplicitProjects } from '@/modules/core/repositories/streams'
 import { getWorkspacePlanFactory } from '@/modules/gatekeeper/repositories/billing'
 import { defineModuleLoaders } from '@/modules/loaders'
 import { getProjectDbClient } from '@/modules/multiregion/utils/dbSelector'
@@ -59,7 +59,7 @@ export default defineModuleLoaders(async () => {
       // TODO: Dataloader that has to dynamically pick regional dbs?
       return await getWorkspaceModelCountFactory({
         queryAllProjects: queryAllProjectsFactory({
-          getStreams: legacyGetStreamsFactory({ db })
+          getExplicitProjects: getExplicitProjects({ db })
         }),
         getPaginatedProjectModelsTotalCount: async (projectId, params) => {
           const regionDb = await getProjectDbClient({ projectId })

--- a/packages/server/modules/workspaces/events/eventListener.ts
+++ b/packages/server/modules/workspaces/events/eventListener.ts
@@ -1,9 +1,9 @@
 import {
+  getExplicitProjects,
   getStreamFactory,
   getStreamRolesFactory,
   getStreamsCollaboratorCountsFactory,
   grantStreamPermissionsFactory,
-  legacyGetStreamsFactory,
   revokeStreamPermissionsFactory,
   upsertProjectRoleFactory
 } from '@/modules/core/repositories/streams'
@@ -861,7 +861,6 @@ export const initializeEventListenersFactory =
   ({ db }: { db: Knex }) =>
   () => {
     const eventBus = getEventBus()
-    const getStreams = legacyGetStreamsFactory({ db })
     const getWorkspace = getWorkspaceFactory({ db })
     const emitWorkspaceGraphqlSubscriptions = emitWorkspaceGraphqlSubscriptionsFactory({
       getWorkspace,
@@ -929,7 +928,9 @@ export const initializeEventListenersFactory =
           getWorkspacePlan,
           getWorkspaceSubscription: getWorkspaceSubscriptionFactory({ db }),
           getWorkspaceModelCount: getWorkspaceModelCountFactory({
-            queryAllProjects: queryAllProjectsFactory({ getStreams }),
+            queryAllProjects: queryAllProjectsFactory({
+              getExplicitProjects: getExplicitProjects({ db })
+            }),
             getPaginatedProjectModelsTotalCount:
               getPaginatedProjectModelsTotalCountFactory({ db })
           }),
@@ -947,7 +948,9 @@ export const initializeEventListenersFactory =
           getWorkspacePlan,
           getWorkspaceSubscription: getWorkspaceSubscriptionFactory({ db }),
           getWorkspaceModelCount: getWorkspaceModelCountFactory({
-            queryAllProjects: queryAllProjectsFactory({ getStreams }),
+            queryAllProjects: queryAllProjectsFactory({
+              getExplicitProjects: getExplicitProjects({ db })
+            }),
             getPaginatedProjectModelsTotalCount:
               getPaginatedProjectModelsTotalCountFactory({ db })
           }),
@@ -986,7 +989,9 @@ export const initializeEventListenersFactory =
         await withTransaction(
           async ({ db: trx }) => {
             const onWorkspaceRoleDeleted = onWorkspaceRoleDeletedFactory({
-              queryAllProjects: queryAllProjectsFactory({ getStreams }),
+              queryAllProjects: queryAllProjectsFactory({
+                getExplicitProjects: getExplicitProjects({ db })
+              }),
               deleteWorkspaceSeat: deleteWorkspaceSeatFactory({ db: trx }),
               getStreamsCollaboratorCounts: getStreamsCollaboratorCountsFactory({ db }),
               getWorkspaceCollaborators: getWorkspaceCollaboratorsFactory({ db }),
@@ -1020,7 +1025,9 @@ export const initializeEventListenersFactory =
         await withTransaction(
           async ({ db: trx }) => {
             const onWorkspaceRoleUpdated = onWorkspaceRoleUpdatedFactory({
-              queryAllProjects: queryAllProjectsFactory({ getStreams }),
+              queryAllProjects: queryAllProjectsFactory({
+                getExplicitProjects: getExplicitProjects({ db })
+              }),
               setStreamCollaborator: setStreamCollaboratorFactory({
                 getUser: getUserFactory({ db }),
                 validateStreamAccess: validateStreamAccessFactory({
@@ -1065,7 +1072,9 @@ export const initializeEventListenersFactory =
                 revokeStreamPermissions: revokeStreamPermissionsFactory({ db: trx }),
                 getStreamRoles: getStreamRolesFactory({ db: trx })
               }),
-              queryAllProjects: queryAllProjectsFactory({ getStreams }),
+              queryAllProjects: queryAllProjectsFactory({
+                getExplicitProjects: getExplicitProjects({ db })
+              }),
               getWorkspaceWithPlan: getWorkspaceWithPlanFactory({ db }),
               getWorkspaceRoleForUser: getWorkspaceRoleForUserFactory({ db }),
               getWorkspaceSeatTypeToProjectRoleMapping:

--- a/packages/server/modules/workspaces/graph/resolvers/regions.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/regions.ts
@@ -20,7 +20,7 @@ import {
 import { Roles } from '@speckle/shared'
 import { WorkspacesNotYetImplementedError } from '@/modules/workspaces/errors/workspace'
 import { scheduleJob } from '@/modules/multiregion/services/queue'
-import { legacyGetStreamsFactory } from '@/modules/core/repositories/streams'
+import { getExplicitProjects } from '@/modules/core/repositories/streams'
 import { getFeatureFlags } from '@/modules/shared/helpers/envHelper'
 import { withOperationLogging } from '@/observability/domain/businessLogging'
 import { queryAllProjectsFactory } from '@/modules/core/services/projects'
@@ -77,7 +77,7 @@ export default {
       // Move existing workspace projects to new target region
       if (FF_MOVE_PROJECT_REGION_ENABLED) {
         const queryAllProjects = queryAllProjectsFactory({
-          getStreams: legacyGetStreamsFactory({ db })
+          getExplicitProjects: getExplicitProjects({ db })
         })
         for await (const projects of queryAllProjects({
           workspaceId

--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -10,9 +10,9 @@ import {
   deleteStreamFactory,
   revokeStreamPermissionsFactory,
   grantStreamPermissionsFactory,
-  legacyGetStreamsFactory,
   getStreamCollaboratorsFactory,
-  getStreamRolesFactory
+  getStreamRolesFactory,
+  getExplicitProjects
 } from '@/modules/core/repositories/streams'
 import { InviteCreateValidationError } from '@/modules/serverinvites/errors'
 import {
@@ -775,7 +775,7 @@ export default FF_WORKSPACES_MODULE_ENABLED
               deleteProject: deleteStreamFactory({ db }),
               deleteAllResourceInvites: deleteAllResourceInvitesFactory({ db }),
               queryAllProjects: queryAllProjectsFactory({
-                getStreams: legacyGetStreamsFactory({ db })
+                getExplicitProjects: getExplicitProjects({ db })
               }),
               deleteSsoProvider: deleteSsoProviderFactory({ db }),
               emitWorkspaceEvent: getEventBus().emit

--- a/packages/server/modules/workspaces/index.ts
+++ b/packages/server/modules/workspaces/index.ts
@@ -21,7 +21,7 @@ import { getWorkspacesNonCompleteFactory } from '@/modules/workspaces/repositori
 import { deleteWorkspacesNonCompleteFactory } from '@/modules/workspaces/services/workspaceCreationState'
 import {
   deleteStreamFactory,
-  legacyGetStreamsFactory
+  getExplicitProjects
 } from '@/modules/core/repositories/streams'
 import { deleteSsoProviderFactory } from '@/modules/workspaces/repositories/sso'
 import { getEventBus } from '@/modules/shared/services/eventBus'
@@ -63,7 +63,7 @@ const scheduleDeleteWorkspacesNonComplete = ({
       deleteProject: deleteStreamFactory({ db }),
       deleteAllResourceInvites: deleteAllResourceInvitesFactory({ db }),
       queryAllProjects: queryAllProjectsFactory({
-        getStreams: legacyGetStreamsFactory({ db })
+        getExplicitProjects: getExplicitProjects({ db })
       }),
       deleteSsoProvider: deleteSsoProviderFactory({ db }),
       emitWorkspaceEvent: getEventBus().emit

--- a/packages/server/modules/workspaces/services/tracking.ts
+++ b/packages/server/modules/workspaces/services/tracking.ts
@@ -34,7 +34,7 @@ import {
 import { db } from '@/db/knex'
 import { getPaginatedProjectModelsTotalCountFactory } from '@/modules/core/repositories/branches'
 import { getWorkspaceModelCountFactory } from '@/modules/workspaces/services/workspaceLimits'
-import { legacyGetStreamsFactory } from '@/modules/core/repositories/streams'
+import { getExplicitProjects } from '@/modules/core/repositories/streams'
 import { queryAllProjectsFactory } from '@/modules/core/services/projects'
 
 export type WorkspaceTrackingProperties = {
@@ -216,7 +216,7 @@ export const scheduleUpdateAllWorkspacesTracking = ({
       getWorkspaceSubscription: getWorkspaceSubscriptionFactory({ db }),
       getWorkspaceModelCount: getWorkspaceModelCountFactory({
         queryAllProjects: queryAllProjectsFactory({
-          getStreams: legacyGetStreamsFactory({ db })
+          getExplicitProjects: getExplicitProjects({ db })
         }),
         getPaginatedProjectModelsTotalCount: getPaginatedProjectModelsTotalCountFactory(
           {

--- a/packages/server/modules/workspaces/tests/integration/tracking.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/tracking.spec.ts
@@ -16,7 +16,7 @@ import {
   getWorkspaceSubscriptionFactory
 } from '@/modules/gatekeeper/repositories/billing'
 import { getWorkspaceModelCountFactory } from '@/modules/workspaces/services/workspaceLimits'
-import { legacyGetStreamsFactory } from '@/modules/core/repositories/streams'
+import { getExplicitProjects } from '@/modules/core/repositories/streams'
 import { db } from '@/db/knex'
 import { getPaginatedProjectModelsTotalCountFactory } from '@/modules/core/repositories/branches'
 import { updateAllWorkspacesTackingPropertiesFactory } from '@/modules/workspaces/services/tracking'
@@ -42,7 +42,7 @@ describe('Tracking Workspaces', () => {
       getWorkspaceSubscription: getWorkspaceSubscriptionFactory({ db }),
       getWorkspaceModelCount: getWorkspaceModelCountFactory({
         queryAllProjects: queryAllProjectsFactory({
-          getStreams: legacyGetStreamsFactory({ db })
+          getExplicitProjects: getExplicitProjects({ db })
         }),
         getPaginatedProjectModelsTotalCount: getPaginatedProjectModelsTotalCountFactory(
           {

--- a/packages/server/modules/workspaces/tests/integration/workspacesCreationState.spec.ts
+++ b/packages/server/modules/workspaces/tests/integration/workspacesCreationState.spec.ts
@@ -16,7 +16,7 @@ import { deleteWorkspacesNonCompleteFactory } from '@/modules/workspaces/service
 import { logger } from '@/observability/logging'
 import {
   deleteStreamFactory,
-  legacyGetStreamsFactory
+  getExplicitProjects
 } from '@/modules/core/repositories/streams'
 import { deleteSsoProviderFactory } from '@/modules/workspaces/repositories/sso'
 import { getEventBus } from '@/modules/shared/services/eventBus'
@@ -45,7 +45,7 @@ describe('WorkspaceCreationState services', () => {
       deleteProject: deleteStreamFactory({ db }),
       deleteAllResourceInvites: deleteAllResourceInvitesFactory({ db }),
       queryAllProjects: queryAllProjectsFactory({
-        getStreams: legacyGetStreamsFactory({ db })
+        getExplicitProjects: getExplicitProjects({ db })
       }),
       deleteSsoProvider: deleteSsoProviderFactory({ db }),
       emitWorkspaceEvent: getEventBus().emit

--- a/packages/server/modules/workspaces/tests/unit/services/projects.spec.ts
+++ b/packages/server/modules/workspaces/tests/unit/services/projects.spec.ts
@@ -15,6 +15,7 @@ import { ProjectUpdateRoleInput } from '@/modules/core/graph/generated/graphql'
 import { Roles, StreamRoles, WorkspaceRoles } from '@speckle/shared'
 import { expect } from 'chai'
 import cryptoRandomString from 'crypto-random-string'
+import { StreamWithOptionalRole } from '@/modules/core/repositories/streams'
 
 describe('Project retrieval services', () => {
   describe('queryAllWorkspaceProjectFactory returns a generator, that', () => {
@@ -25,11 +26,10 @@ describe('Project retrieval services', () => {
       const storedProjects: StreamRecord[] = [{ workspaceId } as StreamRecord]
 
       const queryAllWorkspaceProjectsGenerator = queryAllProjectsFactory({
-        getStreams: async () => {
+        getExplicitProjects: async () => {
           return {
-            streams: storedProjects,
-            totalCount: storedProjects.length,
-            cursorDate: null
+            items: storedProjects,
+            cursor: null
           }
         }
       })
@@ -45,17 +45,17 @@ describe('Project retrieval services', () => {
     it('returns all streams for a workspace if the query requires multiple pages of results', async () => {
       const workspaceId = cryptoRandomString({ length: 10 })
 
-      const foundProjects: StreamRecord[] = []
-      const storedProjects: StreamRecord[] = [
+      const foundProjects: StreamWithOptionalRole[] = []
+      const storedProjects: StreamWithOptionalRole[] = [
         { workspaceId } as StreamRecord,
         { workspaceId } as StreamRecord
       ]
 
       const queryAllWorkspaceProjectsGenerator = queryAllProjectsFactory({
-        getStreams: async ({ cursor }) => {
+        getExplicitProjects: async ({ cursor }) => {
           return cursor
-            ? { streams: [storedProjects[1]], totalCount: 1, cursorDate: null }
-            : { streams: [storedProjects[0]], totalCount: 1, cursorDate: new Date() }
+            ? { items: [storedProjects[1]], cursor: null }
+            : { items: [storedProjects[0]], cursor: new Date().toISOString() }
         }
       })
 
@@ -73,8 +73,8 @@ describe('Project retrieval services', () => {
       const foundProjects: StreamRecord[] = []
 
       const queryAllWorkspaceProjectsGenerator = queryAllProjectsFactory({
-        getStreams: async () => {
-          return { streams: [], totalCount: 0, cursorDate: null }
+        getExplicitProjects: async () => {
+          return { items: [], cursor: null }
         }
       })
 


### PR DESCRIPTION
## Changes
- Created new repo method for iterating over projects via userId or workspaceId _(filtering them)_
- This fixes iterating over all projects on user delete and hitting the timeout