### PR TITLE
feat(fe2): conditional cross origin isolation on viewer page

### DIFF
--- a/packages/frontend-2/server/middleware/004-sharedArrayBufferHeaders.ts
+++ b/packages/frontend-2/server/middleware/004-sharedArrayBufferHeaders.ts
@@ -1,0 +1,22 @@
+const viewerPathRgx = /^\/projects\/[\w\d]+\/models\/[\w\d]+$/i
+
+export default defineEventHandler((event) => {
+  // Only work on viewer page
+  const url = getRequestURL(event)
+  const path = url.pathname
+  if (!viewerPathRgx.test(path)) {
+    return
+  }
+
+  // Only set if query set `sharedArrayBufferHeaders=true`
+  const query = getQuery(event)
+  if (!query.sharedArrayBufferHeaders) {
+    return
+  }
+
+  // SharedArrayBuffer headers are required for performance optimizations in some browsers
+  setHeaders(event, {
+    'Cross-Origin-Opener-Policy': 'same-origin',
+    'Cross-Origin-Embedder-Policy': 'require-corp'
+  })
+})

--- a/packages/frontend-2/server/middleware/004-sharedArrayBufferHeaders.ts
+++ b/packages/frontend-2/server/middleware/004-sharedArrayBufferHeaders.ts
@@ -8,13 +8,12 @@ export default defineEventHandler((event) => {
     return
   }
 
-  // Only set if query set `sharedArrayBufferHeaders=true`
+  // Only set if query set `sharedArrayBufferHeaders=1`
   const query = getQuery(event)
-  if (!query.sharedArrayBufferHeaders) {
+  if (query.sharedArrayBufferHeaders !== '1') {
     return
   }
 
-  // SharedArrayBuffer headers are required for performance optimizations in some browsers
   setHeaders(event, {
     'Cross-Origin-Opener-Policy': 'same-origin',
     'Cross-Origin-Embedder-Policy': 'require-corp'

--- a/packages/server/modules/blobstorage/rest/router.ts
+++ b/packages/server/modules/blobstorage/rest/router.ts
@@ -31,7 +31,7 @@ import { processNewFileStreamFactory } from '@/modules/blobstorage/services/stre
 import { UserInputError } from '@/modules/core/errors/userinput'
 import { createBusboy } from '@/modules/blobstorage/rest/busboy'
 import contentDisposition from 'content-disposition'
-import { crossOriginResourcePolicyMiddleware } from '@/modules/shared/middleware/security'
+import { allowCrossOriginResourceAccessMiddelware } from '@/modules/shared/middleware/security'
 import cors from 'cors'
 
 export const blobStorageRouterFactory = (): Router => {
@@ -41,7 +41,6 @@ export const blobStorageRouterFactory = (): Router => {
 
   app.post(
     '/api/stream/:streamId/blob',
-
     async (req, res, next) => {
       await authMiddlewareCreator(
         streamCommentsWritePermissionsPipelineFactory({
@@ -109,7 +108,7 @@ export const blobStorageRouterFactory = (): Router => {
   app.get(
     '/api/stream/:streamId/blob/:blobId',
     cors(),
-    crossOriginResourcePolicyMiddleware('cross-origin'),
+    allowCrossOriginResourceAccessMiddelware(),
     async (req, res, next) => {
       await authMiddlewareCreator([
         ...streamReadPermissionsPipelineFactory({

--- a/packages/server/modules/blobstorage/rest/router.ts
+++ b/packages/server/modules/blobstorage/rest/router.ts
@@ -31,6 +31,8 @@ import { processNewFileStreamFactory } from '@/modules/blobstorage/services/stre
 import { UserInputError } from '@/modules/core/errors/userinput'
 import { createBusboy } from '@/modules/blobstorage/rest/busboy'
 import contentDisposition from 'content-disposition'
+import { crossOriginResourcePolicyMiddleware } from '@/modules/shared/middleware/security'
+import cors from 'cors'
 
 export const blobStorageRouterFactory = (): Router => {
   const processNewFileStream = processNewFileStreamFactory()
@@ -39,6 +41,7 @@ export const blobStorageRouterFactory = (): Router => {
 
   app.post(
     '/api/stream/:streamId/blob',
+
     async (req, res, next) => {
       await authMiddlewareCreator(
         streamCommentsWritePermissionsPipelineFactory({
@@ -105,6 +108,8 @@ export const blobStorageRouterFactory = (): Router => {
 
   app.get(
     '/api/stream/:streamId/blob/:blobId',
+    cors(),
+    crossOriginResourcePolicyMiddleware('cross-origin'),
     async (req, res, next) => {
       await authMiddlewareCreator([
         ...streamReadPermissionsPipelineFactory({

--- a/packages/server/modules/previews/rest/router.ts
+++ b/packages/server/modules/previews/rest/router.ts
@@ -46,7 +46,7 @@ import { requestObjectPreviewFactory } from '@/modules/previews/queues/previews'
 import type { Queue } from 'bull'
 import type { Knex } from 'knex'
 import { fileURLToPath } from 'url'
-import { crossOriginResourcePolicyMiddleware } from '@/modules/shared/middleware/security'
+import { allowCrossOriginResourceAccessMiddelware } from '@/modules/shared/middleware/security'
 
 const httpErrorImage = (httpErrorCode: number) =>
   fileURLToPath(
@@ -99,12 +99,12 @@ export const previewRouterFactory = ({
   app.options(
     '/preview/:streamId/:angle?',
     cors(),
-    crossOriginResourcePolicyMiddleware('cross-origin')
+    allowCrossOriginResourceAccessMiddelware()
   )
   app.get(
     '/preview/:streamId/:angle?',
     cors(),
-    crossOriginResourcePolicyMiddleware('cross-origin'),
+    allowCrossOriginResourceAccessMiddelware(),
     async (req, res) => {
       const projectDb = await getProjectDbClient({ projectId: req.params.streamId })
       const checkStreamPermissions = checkStreamPermissionsFactory({
@@ -165,12 +165,12 @@ export const previewRouterFactory = ({
   app.options(
     '/preview/:streamId/branches/:branchName/:angle?',
     cors(),
-    crossOriginResourcePolicyMiddleware('cross-origin')
+    allowCrossOriginResourceAccessMiddelware()
   )
   app.get(
     '/preview/:streamId/branches/:branchName/:angle?',
     cors(),
-    crossOriginResourcePolicyMiddleware('cross-origin'),
+    allowCrossOriginResourceAccessMiddelware(),
     async (req, res) => {
       const checkStreamPermissions = checkStreamPermissionsFactory({
         validateScopes,
@@ -241,12 +241,12 @@ export const previewRouterFactory = ({
   app.options(
     '/preview/:streamId/commits/:commitId/:angle?',
     cors(),
-    crossOriginResourcePolicyMiddleware('cross-origin')
+    allowCrossOriginResourceAccessMiddelware()
   )
   app.get(
     '/preview/:streamId/commits/:commitId/:angle?',
     cors(),
-    crossOriginResourcePolicyMiddleware('cross-origin'),
+    allowCrossOriginResourceAccessMiddelware(),
     async (req, res) => {
       const checkStreamPermissions = checkStreamPermissionsFactory({
         validateScopes,
@@ -299,12 +299,12 @@ export const previewRouterFactory = ({
   app.options(
     '/preview/:streamId/objects/:objectId/:angle?',
     cors(),
-    crossOriginResourcePolicyMiddleware('cross-origin')
+    allowCrossOriginResourceAccessMiddelware()
   )
   app.get(
     '/preview/:streamId/objects/:objectId/:angle?',
     cors(),
-    crossOriginResourcePolicyMiddleware('cross-origin'),
+    allowCrossOriginResourceAccessMiddelware(),
     async (req, res) => {
       const checkStreamPermissions = checkStreamPermissionsFactory({
         validateScopes,

--- a/packages/server/modules/shared/middleware/security.ts
+++ b/packages/server/modules/shared/middleware/security.ts
@@ -6,3 +6,6 @@ export const crossOriginResourcePolicyMiddleware =
     res.setHeader('Cross-Origin-Resource-Policy', value)
     next()
   }
+
+export const allowCrossOriginResourceAccessMiddelware = () =>
+  crossOriginResourcePolicyMiddleware('cross-origin')

--- a/packages/server/modules/shared/middleware/security.ts
+++ b/packages/server/modules/shared/middleware/security.ts
@@ -1,0 +1,8 @@
+import type express from 'express'
+
+export const crossOriginResourcePolicyMiddleware =
+  (value: 'same-origin' | 'cross-origin' | 'same-site'): express.RequestHandler =>
+  (req, res, next) => {
+    res.setHeader('Cross-Origin-Resource-Policy', value)
+    next()
+  }


### PR DESCRIPTION
Set `sharedArrayBufferHeaders=1` in querystring on viewer page, to enable