### PR TITLE
feat(authPolicies): add demo project as a publicly loadable override

### DIFF
--- a/packages/shared/src/authz/policies/project/canLoad.spec.ts
+++ b/packages/shared/src/authz/policies/project/canLoad.spec.ts
@@ -38,6 +38,21 @@ const buildCanLoadPolicy = (overrides?: Partial<Parameters<typeof canLoadPolicy>
   })
 
 describe('canLoad', () => {
+  it('returns ok if anyone is trying to load a publicly loadable project', async () => {
+    const canLoad = buildCanLoadPolicy()
+
+    // this is a deliberate copy pasta, if anyone removes from the baked in list,
+    // the test should fail
+    const publiclyLoadableProjects = ['8be1007be1']
+
+    for (const projectId of publiclyLoadableProjects) {
+      const result = await canLoad({
+        userId: undefined,
+        projectId
+      })
+      expect(result).toBeAuthOKResult()
+    }
+  })
   it('returns error if user is not logged in', async () => {
     const canLoad = buildCanLoadPolicy()
 

--- a/packages/shared/src/authz/policies/project/canLoad.ts
+++ b/packages/shared/src/authz/policies/project/canLoad.ts
@@ -45,6 +45,9 @@ type PolicyErrors = InstanceType<
 export const canLoadPolicy: AuthPolicy<PolicyLoaderKeys, PolicyArgs, PolicyErrors> =
   (loaders) =>
   async ({ userId, projectId }) => {
+    if (publiclyLoadableProjects.includes(projectId)) {
+      return ok()
+    }
     const hasAdminAccess = await checkIfAdminOverrideEnabledFragment(loaders)({
       userId
     })
@@ -70,3 +73,7 @@ export const canLoadPolicy: AuthPolicy<PolicyLoaderKeys, PolicyArgs, PolicyError
 
     return ok()
   }
+
+const publiclyLoadableProjects = [
+  '8be1007be1' // Demo models
+]


### PR DESCRIPTION
allows specifying projects, that can be publicly loaded.

For now, this is just a baked in value, to provide a quick fix. It can be expanded with a loader and environment variables later down the line