### PR TITLE
fix(fe): Members avatar group hydration mismatch

### DIFF
--- a/packages/frontend-2/components/workspace/sidebar/Members.vue
+++ b/packages/frontend-2/components/workspace/sidebar/Members.vue
@@ -13,6 +13,7 @@
       >
         <div class="flex gap-y-3 flex-col w-full">
           <UserAvatarGroup
+            v-if="workspace?.team"
             :overlap="false"
             :users="team.map((teamMember) => teamMember.user)"
             :max-avatars="5"
@@ -25,7 +26,9 @@
           />
           <div
             v-if="
-              isWorkspaceAdmin && (adminWorkspacesJoinRequestsCount || invitedTeamCount)
+              workspace?.team &&
+              isWorkspaceAdmin &&
+              (adminWorkspacesJoinRequestsCount || invitedTeamCount)
             "
             class="w-full flex items-center gap-x-2"
           >
@@ -55,7 +58,7 @@
           </div>
         </div>
         <FormButton
-          v-if="isWorkspaceAdmin"
+          v-if="workspace?.team && isWorkspaceAdmin"
           color="outline"
           size="sm"
           @click="showInviteDialog = true"


### PR DESCRIPTION
Fix hydration mismatch in WorkspaceSidebarMembers component by adding conditional rendering guards for AvatarGroup. The component was rendering team avatars during SSR when workspace data was available, but rendering empty during client hydration when workspace data hadn't loaded yet. Added `workspace?.team` checks to ensure proper rendering.