### PR TITLE
(fix) debug mode for viewer

### DIFF
--- a/packages/objectloader2/src/types/functions.spec.ts
+++ b/packages/objectloader2/src/types/functions.spec.ts
@@ -100,10 +100,14 @@ describe('take', () => {
   })
 })
 
-describe('getQueryParameter', () => {
+describe('getFeatureFlag', () => {
   describe('in a non-browser environment', () => {
     it('should return the default value', () => {
       expect(getFeatureFlag(ObjectLoader2Flags.USE_CACHE)).toBe('true')
+    })
+
+    it('should return undefined when useDefault is false', () => {
+      expect(getFeatureFlag(ObjectLoader2Flags.USE_CACHE, false)).toBe(undefined)
     })
   })
 
@@ -136,6 +140,16 @@ describe('getQueryParameter', () => {
     it('should return the default value if the URL has no query string', () => {
       mockWindow.location.search = ''
       expect(getFeatureFlag(ObjectLoader2Flags.DEBUG)).toBe('false')
+    })
+
+    it('should return undefined if useDefault is false and parameter is not in URL', () => {
+      mockWindow.location.search = '?otherparam=value'
+      expect(getFeatureFlag(ObjectLoader2Flags.DEBUG, false)).toBe(undefined)
+    })
+
+    it('should still return the parameter value from URL when useDefault is false', () => {
+      mockWindow.location.search = '?debug=custom'
+      expect(getFeatureFlag(ObjectLoader2Flags.DEBUG, false)).toBe('custom')
     })
   })
 })

--- a/packages/objectloader2/src/types/functions.ts
+++ b/packages/objectloader2/src/types/functions.ts
@@ -60,14 +60,14 @@ const defaultValues: Record<ObjectLoader2Flags, string> = {
   [ObjectLoader2Flags.USE_CACHE]: 'true'
 }
 
-export function getFeatureFlag(paramName: ObjectLoader2Flags): string {
+export function getFeatureFlag(paramName: ObjectLoader2Flags, useDefault: boolean = true): string | undefined{
   // Check if the code is running in a browser environment 🌐
   const isBrowser =
     typeof window !== 'undefined' && typeof window.document !== 'undefined'
 
   if (!isBrowser) {
     // If in Node.js or another server environment, return the default
-    return defaultValues[paramName]
+    return useDefault ? defaultValues[paramName] : undefined
   }
 
   // In a browser, parse the query string
@@ -76,5 +76,5 @@ export function getFeatureFlag(paramName: ObjectLoader2Flags): string {
   // .get() returns the value, or null if it's not found.
   // The nullish coalescing operator (??) provides the default value
   // if the left-hand side is null or undefined.
-  return params.get(paramName) ?? defaultValues[paramName]
+  return params.get(paramName) ?? (useDefault ? defaultValues[paramName] : undefined)
 }

--- a/packages/objectloader2/src/types/functions.ts
+++ b/packages/objectloader2/src/types/functions.ts
@@ -60,7 +60,10 @@ const defaultValues: Record<ObjectLoader2Flags, string> = {
   [ObjectLoader2Flags.USE_CACHE]: 'true'
 }
 
-export function getFeatureFlag(paramName: ObjectLoader2Flags, useDefault: boolean = true): string | undefined{
+export function getFeatureFlag(
+  paramName: ObjectLoader2Flags,
+  useDefault: boolean = true
+): string | undefined {
   // Check if the code is running in a browser environment 🌐
   const isBrowser =
     typeof window !== 'undefined' && typeof window.document !== 'undefined'

--- a/packages/viewer/src/modules/loaders/Speckle/SpeckleLoader.ts
+++ b/packages/viewer/src/modules/loaders/Speckle/SpeckleLoader.ts
@@ -192,7 +192,7 @@ export class SpeckleLoader extends Loader {
   }
 
   private progressListen(): void {
-    if (getFeatureFlag(ObjectLoader2Flags.DEBUG) !== 'true') {
+    if (getFeatureFlag(ObjectLoader2Flags.DEBUG, false) !== 'true') {
       return
     }
 


### PR DESCRIPTION
The logic for the viewer to log during debug mode was wrong

This pull request introduces enhancements to the `getFeatureFlag` function in `ObjectLoader2` to support an optional `useDefault` parameter, enabling more flexible handling of feature flags in both browser and non-browser environments. Additionally, related test cases and usage in other modules have been updated accordingly.

### Updates to `getFeatureFlag` functionality:

* [`packages/objectloader2/src/types/functions.ts`](diffhunk://#diff-7fe7db9d5a2f8056735e90b8b4c77df36ecb5f0165713d7e650b2fb8d155bd8eL63-R73): Modified the `getFeatureFlag` function to include a `useDefault` parameter, allowing the function to return `undefined` instead of a default value when `useDefault` is set to `false`. This change affects both non-browser and browser environments. [[1]](diffhunk://#diff-7fe7db9d5a2f8056735e90b8b4c77df36ecb5f0165713d7e650b2fb8d155bd8eL63-R73) [[2]](diffhunk://#diff-7fe7db9d5a2f8056735e90b8b4c77df36ecb5f0165713d7e650b2fb8d155bd8eL79-R82)

### Updates to test cases:

* [`packages/objectloader2/src/types/functions.spec.ts`](diffhunk://#diff-19a3ca1cbd8021191caa6e9fda4e045b6a329029c74778eb175d6c4219cb34deL103-R111): Updated test cases for `getFeatureFlag` to validate behavior when `useDefault` is `false`, including scenarios where the parameter is absent in the URL or explicitly provided. [[1]](diffhunk://#diff-19a3ca1cbd8021191caa6e9fda4e045b6a329029c74778eb175d6c4219cb34deL103-R111) [[2]](diffhunk://#diff-19a3ca1cbd8021191caa6e9fda4e045b6a329029c74778eb175d6c4219cb34deR144-R153)

### Integration updates:

* [`packages/viewer/src/modules/loaders/Speckle/SpeckleLoader.ts`](diffhunk://#diff-e593dfee40b75770bd9c1ccc114ffb503a18801e396b53bd871bbea5367d75e9L195-R195): Updated usage of `getFeatureFlag` in the `SpeckleLoader` class to explicitly pass `false` for the `useDefault` parameter during debug flag checks.