### PR TITLE
fix: protect message of activity stream beeing to long

### DIFF
--- a/packages/server/modules/activitystream/repositories/index.ts
+++ b/packages/server/modules/activitystream/repositories/index.ts
@@ -242,7 +242,7 @@ export const saveStreamActivityFactory =
       actionType, // "commit_receive"
       userId, // populated by the api
       info: JSON.stringify(info), // can be anything with conventions! (TBD)
-      message // something human understandable for frontend purposes mostly
+      message: message?.slice(0, 255) ?? message // something human understandable for frontend purposes mostly
     }
 
     await tables

--- a/packages/server/modules/activitystream/tests/integration/repository/activityStream.spec.ts
+++ b/packages/server/modules/activitystream/tests/integration/repository/activityStream.spec.ts
@@ -6,11 +6,10 @@ import cryptoRandomString from 'crypto-random-string'
 
 describe('Stream activity repository @activitystream', () => {
   const saveStreamActivity = saveStreamActivityFactory({ db })
-  const streamId = cryptoRandomString({ length: 10 })
   const resourceId = cryptoRandomString({ length: 10 })
   const userId = cryptoRandomString({ length: 10 })
   const exampleActivity = {
-    streamId,
+    streamId: null,
     resourceType: 'user' as const,
     resourceId,
     userId,
@@ -37,7 +36,6 @@ describe('Stream activity repository @activitystream', () => {
       .first()
 
     expect(activity).to.nested.include({
-      streamId,
       resourceType: 'user',
       resourceId,
       userId,
@@ -59,7 +57,6 @@ describe('Stream activity repository @activitystream', () => {
       .first()
 
     expect(activity).to.nested.include({
-      streamId,
       resourceType: 'user',
       resourceId,
       userId,

--- a/packages/server/modules/activitystream/tests/integration/repository/activityStream.spec.ts
+++ b/packages/server/modules/activitystream/tests/integration/repository/activityStream.spec.ts
@@ -33,6 +33,11 @@ describe('Stream activity repository @activitystream', () => {
     const activity = await db
       .table(StreamActivity.name)
       .select(StreamActivity.cols)
+      .where({
+        userId,
+        resourceId,
+        actionType: 'user_update'
+      })
       .first()
 
     expect(activity).to.nested.include({
@@ -54,6 +59,11 @@ describe('Stream activity repository @activitystream', () => {
     const activity = await db
       .table(StreamActivity.name)
       .select(StreamActivity.cols)
+      .where({
+        userId,
+        resourceId,
+        actionType: 'user_update'
+      })
       .first()
 
     expect(activity).to.nested.include({

--- a/packages/server/modules/activitystream/tests/integration/repository/activityStream.spec.ts
+++ b/packages/server/modules/activitystream/tests/integration/repository/activityStream.spec.ts
@@ -1,0 +1,70 @@
+import { db } from '@/db/knex'
+import { saveStreamActivityFactory } from '@/modules/activitystream/repositories'
+import { StreamActivity } from '@/modules/core/dbSchema'
+import { expect } from 'chai'
+import cryptoRandomString from 'crypto-random-string'
+
+describe('Stream activity repository @activitystream', () => {
+  const saveStreamActivity = saveStreamActivityFactory({ db })
+  const streamId = cryptoRandomString({ length: 10 })
+  const resourceId = cryptoRandomString({ length: 10 })
+  const userId = cryptoRandomString({ length: 10 })
+  const exampleActivity = {
+    streamId,
+    resourceType: 'user' as const,
+    resourceId,
+    userId,
+    actionType: 'user_update' as const,
+    info: {
+      new: {
+        name: 'user',
+        field: 'a'
+      },
+      old: {
+        name: 'user2',
+        field: 'b'
+      }
+    },
+    message: 'User plan updated'
+  }
+
+  it('stores an activity', async () => {
+    await saveStreamActivity(exampleActivity)
+
+    const activity = await db
+      .table(StreamActivity.name)
+      .select(StreamActivity.cols)
+      .first()
+
+    expect(activity).to.nested.include({
+      streamId,
+      resourceType: 'user',
+      resourceId,
+      userId,
+      actionType: 'user_update',
+      message: 'User plan updated'
+    })
+    expect(activity).to.have.a.property('time').that.is.a('Date')
+  })
+
+  it('trims the message in case its too long', async () => {
+    await saveStreamActivity({
+      ...exampleActivity,
+      message: cryptoRandomString({ length: 1000 })
+    })
+
+    const activity = await db
+      .table(StreamActivity.name)
+      .select(StreamActivity.cols)
+      .first()
+
+    expect(activity).to.nested.include({
+      streamId,
+      resourceType: 'user',
+      resourceId,
+      userId,
+      actionType: 'user_update'
+    })
+    expect(activity).to.have.a.property('time').that.is.a('Date')
+  })
+})


### PR DESCRIPTION
## Changes

We got a couple of errors were some field is to long in activity_stream insertion. Without digging too much and assuming that all ids are 10 length, the only field possible to archieve this is message as it's built sometimes on filenames that can get quite long.