### PR TITLE
fix: codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -32,7 +32,7 @@ comment:
   after_n_builds: 2
   hide_project_coverage: true
   behavior: once
-  require_changes: true
+  require_changes: 'coverage_drop'
   require_base: true
   require_head: true
 


### PR DESCRIPTION
Forcing codecov 
- to only comment on coverage decrease
- disabled anotations on diffs
- required codecov to update the comments 
- no early commenting (2 builds aka two covarage pushes; shared and server)