### PR TITLE
fix: publish server as latest too on release

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: boolean
         default: false
+      PUBLISH_LATEST:
+        required: false
+        type: boolean
+        default: false
     secrets:
       DATADOG_API_KEY:
         required: true
@@ -38,12 +42,19 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set image tags
+        id: set-tags
+        run: |
+          TAGS="${{ inputs.IMAGE_PREFIX }}/speckle-server:${{ inputs.IMAGE_VERSION_TAG }}"
+          if [[ "${{ inputs.PUBLISH_LATEST }}" == "true" ]]; then
+            TAGS="$TAGS,${{ inputs.IMAGE_PREFIX }}/speckle-server:latest"
+          fi
+          echo "TAGS=$TAGS" >> "$GITHUB_OUTPUT"
       - name: Build and push
         uses: useblacksmith/build-push-action@v1
         with:
           push: true
-          tags: |
-            ${{ inputs.IMAGE_PREFIX }}/speckle-server:${{ inputs.IMAGE_VERSION_TAG }}
+          tags: ${{ steps.set-tags.outputs.TAGS }}
           # TODO add docker hub tag, but only if we want to push to docker hub
           file: ./packages/server/Dockerfile
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       DOCKERHUB_USERNAME: 'speckledevops'
       IMAGE_PREFIX: 'speckle' # without an explicit host, Docker defaults to pushing Docker Hub
       PUBLISH: true # publish the sourcemaps and include the version in frontend-2 builds
+      PUBLISH_LATEST: ${{ startsWith(github.ref, 'refs/heads/main') }}
     secrets: inherit
 
   test-deployments:


### PR DESCRIPTION
The SDK integration tests rely on the `speckle-server:latest` image from dockerhub that we stop pushing affect moving the ci. This mr reenables this image push. 

It only runs on main and it also pushes the expected taged image too.

Checked on testing4 branch