### PR TITLE
Snap section box rotation to nearest 15 degrees

### DIFF
--- a/packages/viewer/src/modules/extensions/sections/SectionTool.ts
+++ b/packages/viewer/src/modules/extensions/sections/SectionTool.ts
@@ -136,6 +136,9 @@ export class SectionTool extends Extension {
     return [CameraController]
   }
 
+  /** Configurable rotation snap angle in radians. Set to null to disable snapping */
+  public rotationSnapAngle: number | null = Math.PI / 12 // 15 degrees by default
+
   /** This is our data model. All we need is an OBB */
   protected obb: OBB = new OBB()
 
@@ -961,7 +964,7 @@ export class SectionTool extends Extension {
   }
 
   /**
-   * Snaps a quaternion to the nearest 15-degree grid.
+   * Snaps a quaternion to the nearest grid based on rotationSnapAngle.
    * This is useful for rotation snapping.
    * @param q The quaternion to snap.
    * @returns The snapped quaternion.
@@ -970,11 +973,15 @@ export class SectionTool extends Extension {
     /** Convert quaternion to Euler angles using pooled object */
     _tempEuler.setFromQuaternion(q)
 
-    /** Snap each axis to 15-degree increments (π/12 radians) */
-    const snapAngle = Math.PI / 12 // 15 degrees
-    _tempEuler.x = Math.round(_tempEuler.x / snapAngle) * snapAngle
-    _tempEuler.y = Math.round(_tempEuler.y / snapAngle) * snapAngle
-    _tempEuler.z = Math.round(_tempEuler.z / snapAngle) * snapAngle
+    /** Snap each axis to the configured angle increments */
+    if (this.rotationSnapAngle !== null) {
+      _tempEuler.x =
+        Math.round(_tempEuler.x / this.rotationSnapAngle) * this.rotationSnapAngle
+      _tempEuler.y =
+        Math.round(_tempEuler.y / this.rotationSnapAngle) * this.rotationSnapAngle
+      _tempEuler.z =
+        Math.round(_tempEuler.z / this.rotationSnapAngle) * this.rotationSnapAngle
+    }
 
     /** Convert back to quaternion using pooled object */
     _tempQuaternion.setFromEuler(_tempEuler)

--- a/packages/viewer/src/modules/extensions/sections/SectionTool.ts
+++ b/packages/viewer/src/modules/extensions/sections/SectionTool.ts
@@ -57,6 +57,8 @@ export interface SectionToolEventPayload {
 const _matrix4 = new Matrix4()
 const _quaternion = new Quaternion()
 const _vector3 = new Vector3()
+const _tempEuler = new Euler()
+const _tempQuaternion = new Quaternion()
 
 const unitCube = [
   -1 * 0.5,
@@ -201,8 +203,6 @@ export class SectionTool extends Extension {
   protected raycaster: Raycaster
   protected dragging = false
   protected shiftKeyPressed = false
-  protected tempEuler = new Euler()
-  protected tempQuaternion = new Quaternion()
   protected keydownHandler: (e: KeyboardEvent) => void
   protected keyupHandler: (e: KeyboardEvent) => void
 
@@ -968,17 +968,17 @@ export class SectionTool extends Extension {
    */
   protected snapQuaternionToGrid(q: Quaternion): Quaternion {
     /** Convert quaternion to Euler angles using pooled object */
-    this.tempEuler.setFromQuaternion(q)
+    _tempEuler.setFromQuaternion(q)
 
     /** Snap each axis to 15-degree increments (π/12 radians) */
     const snapAngle = Math.PI / 12 // 15 degrees
-    this.tempEuler.x = Math.round(this.tempEuler.x / snapAngle) * snapAngle
-    this.tempEuler.y = Math.round(this.tempEuler.y / snapAngle) * snapAngle
-    this.tempEuler.z = Math.round(this.tempEuler.z / snapAngle) * snapAngle
+    _tempEuler.x = Math.round(_tempEuler.x / snapAngle) * snapAngle
+    _tempEuler.y = Math.round(_tempEuler.y / snapAngle) * snapAngle
+    _tempEuler.z = Math.round(_tempEuler.z / snapAngle) * snapAngle
 
     /** Convert back to quaternion using pooled object */
-    this.tempQuaternion.setFromEuler(this.tempEuler)
-    return this.tempQuaternion
+    _tempQuaternion.setFromEuler(_tempEuler)
+    return _tempQuaternion
   }
 
   /**

--- a/packages/viewer/src/modules/extensions/sections/SectionTool.ts
+++ b/packages/viewer/src/modules/extensions/sections/SectionTool.ts
@@ -139,6 +139,11 @@ export class SectionTool extends Extension {
   /** Configurable rotation snap angle in radians. Set to null to disable snapping */
   public rotationSnapAngle: number | null = Math.PI / 12 // 15 degrees by default
 
+  /** Note: Rotation snapping only applies to mouse interactions via TransformControls.
+   *  Programmatic calls to setBox() will not apply rotation snapping.
+   *  For complete snapping support, programmatic rotations will need to be handled separately.
+   */
+
   /** This is our data model. All we need is an OBB */
   protected obb: OBB = new OBB()
 


### PR DESCRIPTION
This adds the ability to snap rotation to a 15-degree grid when holding the shift key during section box rotation.

Cursor and I made it so that the snapping always aligns to the standard grid (0°, 15°, 30°, 45°, ...) rather than snapping relative to the initial rotation position.

@AlexandruPopovici I'm unsure if you actually want this to be part of the sectiontool extension or if this snapping should instead be implemented in the frontend. Let me know...

