### PR TITLE
Feat: Support for undo/redo in section tool

### DIFF
--- a/packages/viewer/src/modules/extensions/sections/SectionTool.ts
+++ b/packages/viewer/src/modules/extensions/sections/SectionTool.ts
@@ -222,7 +222,7 @@ export class SectionTool extends Extension {
   protected keydownHandler: (e: KeyboardEvent) => void
   protected keyupHandler: (e: KeyboardEvent) => void
   protected sectionBoxHistory: SectionBoxState[] = []
-  protected currentHistoryIndex = -1
+  protected currentHistoryIndex = 0
   protected maxHistorySize = 100
   protected initialSectionBoxState: SectionBoxState | null = null
   protected hasInitialized = false
@@ -677,7 +677,7 @@ export class SectionTool extends Extension {
         /** Reset initial state for new session */
         this.initialSectionBoxState = null
         /** Reset cursor for new session */
-        this.currentHistoryIndex = -1
+        this.currentHistoryIndex = 0
       }
 
       /** Store initial state when drag starts */

--- a/packages/viewer/src/modules/extensions/sections/SectionTool.ts
+++ b/packages/viewer/src/modules/extensions/sections/SectionTool.ts
@@ -536,9 +536,9 @@ export class SectionTool extends Extension {
   }
 
   /**
-   * Creates an OBB copy from the current OBB
+   * Creates an OBB state from the current OBB
    */
-  protected createObbCopy(): OBB {
+  protected createObbState(): OBB {
     return new OBB().copy(this.obb)
   }
 
@@ -553,7 +553,7 @@ export class SectionTool extends Extension {
    * Saves the current section box state to history
    */
   protected saveToHistory(): void {
-    const currentState = this.createObbCopy()
+    const currentState = this.createObbState()
 
     /** If we're not at the latest state and make a new change, remove all future states */
     if (
@@ -657,7 +657,7 @@ export class SectionTool extends Extension {
     if (this.dragging) {
       /** Save initial state when interaction starts (if this is the first change) */
       if (this.sectionBoxHistory.length === 0) {
-        this.sectionBoxHistory.push(this.createObbCopy())
+        this.sectionBoxHistory.push(this.createObbState())
         this.currentHistoryIndex = 0
       }
 

--- a/packages/viewer/src/modules/extensions/sections/SectionTool.ts
+++ b/packages/viewer/src/modules/extensions/sections/SectionTool.ts
@@ -40,6 +40,7 @@ import SpeckleLineMaterial from '../../materials/SpeckleLineMaterial.js'
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js'
 import SpeckleStandardMaterial from '../../materials/SpeckleStandardMaterial.js'
 import { Extension } from '../Extension.js'
+import { SectionOutlines } from './SectionOutlines.js'
 
 export enum SectionToolEvent {
   DragStart = 'section-box-drag-start',
@@ -1121,6 +1122,13 @@ export class SectionTool extends Extension {
         this.updatePlanes()
         this.updateVisual()
         this.updateFaceControls(this.draggingFace)
+
+        /** Update section outlines */
+        const sectionOutlines = this.viewer.getExtension(SectionOutlines)
+        if (sectionOutlines && sectionOutlines.enabled) {
+          sectionOutlines.requestUpdate(true)
+        }
+
         this.viewer.requestRender()
       }
     }
@@ -1144,6 +1152,13 @@ export class SectionTool extends Extension {
         this.updatePlanes()
         this.updateVisual()
         this.updateFaceControls(this.draggingFace)
+
+        /** Update section outlines */
+        const sectionOutlines = this.viewer.getExtension(SectionOutlines)
+        if (sectionOutlines && sectionOutlines.enabled) {
+          sectionOutlines.requestUpdate(true)
+        }
+
         this.viewer.requestRender()
       }
     }

--- a/packages/viewer/src/modules/extensions/sections/SectionTool.ts
+++ b/packages/viewer/src/modules/extensions/sections/SectionTool.ts
@@ -223,7 +223,7 @@ export class SectionTool extends Extension {
   protected keyupHandler: (e: KeyboardEvent) => void
   protected sectionBoxHistory: SectionBoxState[] = []
   protected currentHistoryIndex = -1
-  protected maxHistorySize = 20
+  protected maxHistorySize = 100
   protected initialSectionBoxState: SectionBoxState | null = null
   protected hasInitialized = false
   protected hasSavedForCurrentDrag = false

--- a/packages/viewer/src/modules/extensions/sections/SectionTool.ts
+++ b/packages/viewer/src/modules/extensions/sections/SectionTool.ts
@@ -577,12 +577,12 @@ export class SectionTool extends Extension {
       this.sectionBoxHistory.push(this.initialSectionBoxState)
     }
 
-    /** Truncate history if we're not at the end and we have more than just the initial state */
+    /** If we're not at the latest state and make a new change, remove all future states */
     if (
       this.currentHistoryIndex < this.sectionBoxHistory.length - 1 &&
       this.sectionBoxHistory.length > 1
     ) {
-      /** Always preserve the initial state (index 0) and states up to current cursor */
+      /** Keep the initial state and all states up to the current position */
       this.sectionBoxHistory = this.sectionBoxHistory.slice(
         0,
         this.currentHistoryIndex + 1
@@ -593,7 +593,7 @@ export class SectionTool extends Extension {
     this.sectionBoxHistory.push(currentState)
     this.currentHistoryIndex = this.sectionBoxHistory.length - 1
 
-    /** Limit history size to prevent memory issues */
+    /** Remove oldest states if we exceed the history limit */
     if (this.sectionBoxHistory.length > this.maxHistorySize) {
       this.sectionBoxHistory.shift()
       this.currentHistoryIndex = Math.max(0, this.currentHistoryIndex - 1)

--- a/packages/viewer/src/modules/extensions/sections/SectionTool.ts
+++ b/packages/viewer/src/modules/extensions/sections/SectionTool.ts
@@ -593,14 +593,20 @@ export class SectionTool extends Extension {
 
       /** Handle Cmd/Ctrl+Z for section box undo */
       if ((e.metaKey || e.ctrlKey) && e.key === 'z' && !e.shiftKey) {
-        e.preventDefault()
-        this.undoSectionBox()
+        /** Only allow undo/redo when section box controls are visible */
+        if (this.enabled && this.visible) {
+          e.preventDefault()
+          this.undoSectionBox()
+        }
       }
 
       /** Handle Cmd/Ctrl+Shift+Z for section box redo */
       if ((e.metaKey || e.ctrlKey) && e.key === 'z' && e.shiftKey) {
-        e.preventDefault()
-        this.redoSectionBox()
+        /** Only allow undo/redo when section box controls are visible */
+        if (this.enabled && this.visible) {
+          e.preventDefault()
+          this.redoSectionBox()
+        }
       }
     }
 

--- a/packages/viewer/src/modules/extensions/sections/SectionTool.ts
+++ b/packages/viewer/src/modules/extensions/sections/SectionTool.ts
@@ -214,7 +214,7 @@ export class SectionTool extends Extension {
   protected keydownHandler: (e: KeyboardEvent) => void
   protected keyupHandler: (e: KeyboardEvent) => void
   protected rotationHistory: Quaternion[] = []
-  protected currentHistoryIndex = -1
+  protected currentHistoryIndex = 0
   protected maxHistorySize = 10
   protected initialRotationState: Quaternion | null = null
   protected isUndoing = false
@@ -642,11 +642,13 @@ export class SectionTool extends Extension {
         /** If this is the first rotation, save the initial state first */
         if (this.rotationHistory.length === 0) {
           this.rotationHistory.push(this.initialRotationForCurrentDrag)
-          this.currentHistoryIndex = 0
         }
 
-        /** Truncate history if we're not at the end (i.e., we've undone and are making a new change) */
-        if (this.currentHistoryIndex < this.rotationHistory.length - 1) {
+        /** Truncate history if we're not at the end and we have more than just the initial state */
+        if (
+          this.currentHistoryIndex < this.rotationHistory.length - 1 &&
+          this.rotationHistory.length > 1
+        ) {
           /** Always preserve the initial state (index 0) and states up to current cursor */
           this.rotationHistory = this.rotationHistory.slice(
             0,


### PR DESCRIPTION
This PR makes it possible to undo and redo changes when using the section tool.

- Complete section tool state tracking including saving the rotation, translation, and movement of the section box. A new `SectionBoxState` interface is introduced for complete OBB state storage.
- Press `Cmd/Ctrl+Z` to undo an edit, and press `Cmd/Ctrl+Shift+Z` to redo. If you undo to a previous state, and then make a change to the section box, then this change becomes the last entry in the history timeline (all future edits are cleared).
- There's a history limit of 100 entries right now, but this can probably be increased or removed if it's an issue. I don't know. 
- Section outlines are also updated as you undo/redo.