### PR TITLE
feat(fe): updated v-tippy configuration and new theme

### DIFF
--- a/packages/frontend-2/assets/css/vtippy.css
+++ b/packages/frontend-2/assets/css/vtippy.css
@@ -1,0 +1,8 @@
+.tippy-box[data-theme~='speckleTooltip'] {
+  background-color: #15161c;
+  border: 1px solid #282833;
+  border-radius: 4px;
+  font-size: 12px;
+  color: #fff;
+  box-shadow: 0 2px 2px 0 rgba(0 0 0 4%), 0 1px 4px 0 rgba(0 0 0 4%) inset;
+}

--- a/packages/frontend-2/assets/css/vtippy.css
+++ b/packages/frontend-2/assets/css/vtippy.css
@@ -1,8 +1,3 @@
 .tippy-box[data-theme~='speckleTooltip'] {
-  background-color: #15161c;
-  border: 1px solid #282833;
-  border-radius: 4px;
-  font-size: 12px;
-  color: #fff;
-  box-shadow: 0 2px 2px 0 rgba(0 0 0 4%), 0 1px 4px 0 rgba(0 0 0 4%) inset;
+  @apply bg-foundation border border-outline-2 rounded text-foreground text-xs shadow-sm;
 }

--- a/packages/frontend-2/components/viewer/Controls.vue
+++ b/packages/frontend-2/components/viewer/Controls.vue
@@ -7,7 +7,7 @@
     >
       <!-- Models -->
       <ViewerControlsButtonToggle
-        v-tippy="getShortcutDisplayText(shortcuts.ToggleModels)"
+        v-tippy="getShortcutDisplayText(shortcuts.ToggleModels, { format: 'separate' })"
         :active="activePanel === 'models'"
         @click="toggleActivePanel('models')"
       >
@@ -16,7 +16,9 @@
 
       <!-- Explorer -->
       <ViewerControlsButtonToggle
-        v-tippy="getShortcutDisplayText(shortcuts.ToggleExplorer)"
+        v-tippy="
+          getShortcutDisplayText(shortcuts.ToggleExplorer, { format: 'separate' })
+        "
         :active="activePanel === 'explorer'"
         @click="toggleActivePanel('explorer')"
       >
@@ -25,7 +27,9 @@
 
       <!-- Comment threads -->
       <ViewerControlsButtonToggle
-        v-tippy="getShortcutDisplayText(shortcuts.ToggleDiscussions)"
+        v-tippy="
+          getShortcutDisplayText(shortcuts.ToggleDiscussions, { format: 'separate' })
+        "
         :active="activePanel === 'discussions'"
         @click="toggleActivePanel('discussions')"
       >

--- a/packages/frontend-2/lib/viewer/composables/ui.ts
+++ b/packages/frontend-2/lib/viewer/composables/ui.ts
@@ -622,7 +622,7 @@ export function useViewerShortcuts() {
 
   const getShortcutDisplayText = (
     shortcut: ViewerShortcut,
-    options?: { hideName?: boolean }
+    options?: { hideName?: boolean; format?: 'default' | 'separate' }
   ) => {
     if (isSmallerOrEqualSm.value) return undefined
     if (isEmbedEnabled.value) return undefined
@@ -631,6 +631,31 @@ export function useViewerShortcuts() {
       ...shortcut.modifiers,
       formatKey(shortcut.key)
     ])
+
+    if (options?.format === 'separate') {
+      const modifiersText =
+        shortcut.modifiers.length > 0
+          ? getKeyboardShortcutTitle([...shortcut.modifiers])
+          : ''
+      const keyText = getKeyboardShortcutTitle([formatKey(shortcut.key)])
+
+      return {
+        content: `
+        <div class="flex flex-row gap-2 m-0 p-0">
+          <div class="text-body-2xs font-medium text-foreground">${shortcut.name}</div>
+          <div class="text-body-3xs text-foreground-3">
+            ${
+              modifiersText
+                ? `<kbd class="p-0.5 min-w-4 text-foreground-2 rounded-md text-body-3xs font-normal font-sans">${modifiersText}</kbd>`
+                : 'then'
+            }<kbd class="min-w-3 text-foreground-2 rounded-sm text-body-3xs font-medium font-sans">${keyText}</kbd>
+          </div>
+        </div>
+      `,
+        allowHTML: true,
+        theme: 'speckleTooltip'
+      }
+    }
 
     if (!options?.hideName) {
       return `${shortcut.name} (${shortcutText})`

--- a/packages/frontend-2/plugins/001-tippy.ts
+++ b/packages/frontend-2/plugins/001-tippy.ts
@@ -1,10 +1,16 @@
 import VueTippy from 'vue-tippy'
 import 'tippy.js/dist/tippy.css'
+import 'assets/css/vtippy.css'
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(VueTippy, {
     defaultProps: {
-      arrow: true
+      arrow: false,
+      delay: [1000, 0],
+      duration: [300, 0],
+      animation: 'fade',
+      theme: 'speckleTooltip',
+      offset: [0, 4]
     },
     flipDuration: 0
   })

--- a/packages/frontend-2/plugins/001-tippy.ts
+++ b/packages/frontend-2/plugins/001-tippy.ts
@@ -6,7 +6,6 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(VueTippy, {
     defaultProps: {
       arrow: false,
-      delay: [1000, 0],
       duration: [300, 0],
       animation: 'fade',
       theme: 'speckleTooltip',


### PR DESCRIPTION
https://github.com/user-attachments/assets/875d66fd-d9c0-4208-84d6-abd19ad5a28b

Changes to v-tippy config;
- removed arrow (imo takes too much space, adds little value)
- added delay 1000ms (as requested by many)
- added a quick fade transition 
- smaller offset 
- added new theme to make the tooltip more aligned with our own style (smaller, our own colors etc.)

What I wanted to do but didn't have time to figure out:
- explore how to include styled kbd elements via v-tippy-html

Update:
Added some changes to ui.ts to let me use a new template in a tooltip, but stopped for some sanity check on the code. This is how it looks now: 


https://github.com/user-attachments/assets/e340270f-2402-43e3-a7fe-deeb55b9ba50

