### PR TITLE
fix(fe): Objects.Data.DataObject not appearing in scene explorer

### DIFF
--- a/packages/viewer/src/modules/loaders/Speckle/SpeckleConverter.ts
+++ b/packages/viewer/src/modules/loaders/Speckle/SpeckleConverter.ts
@@ -226,7 +226,12 @@ export default class SpeckleConverter {
             this.activePromises -= childrenConversionPromisses.length
           }
 
-          return
+          // Return early unless this object has displayValue but no/empty elements
+          const hasUsefulElements =
+            elements && (!Array.isArray(elements) || elements.length > 0)
+          if (hasUsefulElements || !displayValue) {
+            return
+          }
         }
       }
 


### PR DESCRIPTION
Objects with `displayValue` but empty `@elements` arrays were returning early and getting filtered out of the scene explorer tree.

Allow these objects to continue to general children processing so they appear in the tree.