### PR TITLE
fix(fe2): Ensure NUXT_PUBLIC_FF_RHINO_FILE_IMPORTER_ENABLED is part of the deployment yml

### DIFF
--- a/utils/helm/speckle-server/templates/frontend_2/deployment.yml
+++ b/utils/helm/speckle-server/templates/frontend_2/deployment.yml
@@ -145,6 +145,8 @@ spec:
             value: {{ .Values.featureFlags.workspacesNewPlanEnabled | quote }}
           - name: NUXT_PUBLIC_FF_NEXT_GEN_FILE_IMPORTER_ENABLED
             value: {{ .Values.featureFlags.nextGenFileImporterEnabled | quote }}
+          - name: NUXT_PUBLIC_FF_RHINO_FILE_IMPORTER_ENABLED
+            value: {{ .Values.featureFlags.rhinoFileImporterEnabled | quote }}
           - name: NUXT_PUBLIC_FF_LEGACY_FILE_IMPORTS_ENABLED
             value: {{ .Values.featureFlags.legacyFileImportsEnabled | quote }}
           - name: NUXT_PUBLIC_FF_ACC_INTEGRATION_ENABLED


### PR DESCRIPTION
In [my last PR](https://github.com/specklesystems/speckle-server/pull/5181/files), I added logic to the FE to observe the `FF_RHINO_FILE_IMPORTER_ENABLED` feature flag. However, I forgot to ensure that the FF is being set by the helm chart
