### PR TITLE
fix(acc): return webhook id when found

### DIFF
--- a/packages/server/modules/acc/clients/autodesk.ts
+++ b/packages/server/modules/acc/clients/autodesk.ts
@@ -263,6 +263,8 @@ export const tryRegisterAccWebhook = async (
       logger.info({ location: response.headers.get('Location') })
       throw new Error('Webhook created but failed to parse id')
     }
+
+    return webhookId
   }
 
   const e = await response.json().catch(() => null)


### PR DESCRIPTION
missing return meant first-time sync item creation "failed" (fell through to failure case)