### PR TITLE
fix(fileUpload): Ensure fileType is lowercase

### DIFF
--- a/packages/server/modules/fileuploads/repositories/fileUploads.ts
+++ b/packages/server/modules/fileuploads/repositories/fileUploads.ts
@@ -121,7 +121,7 @@ export const saveUploadFileFactory =
       branchName,
       userId,
       fileName,
-      fileType,
+      fileType: fileType.toLowerCase(),
       fileSize,
       uploadComplete: true,
       modelId
@@ -149,7 +149,7 @@ export const saveUploadFileFactoryV2 =
       userId,
       modelId,
       fileName,
-      fileType,
+      fileType: fileType.toLowerCase(),
       fileSize,
       uploadComplete: true
     }


### PR DESCRIPTION
fix a bug where file uploads with upper case letters in the extension would be queued, but not processed due to the way we're filtering jobs based on their file extension.

I've fixed it by ensuring that the jobs are always created with the lower cased file extension.

<img width="4494" height="1131" alt="image" src="https://github.com/user-attachments/assets/a5ab836c-5d49-432e-8221-1d6dfedca17e" />
