### PR TITLE
fix(regions): return in project region move handler

### DIFF
--- a/packages/server/modules/multiregion/services/queue.ts
+++ b/packages/server/modules/multiregion/services/queue.ts
@@ -257,7 +257,7 @@ export const startQueue = async () => {
           // Wait for replication from regional db
           await waitForRegionProjectFactory({
             getProject: getProjectFactory({ db }),
-            deleteProject: deleteProjectFactory({ db })
+            deleteProject: deleteProjectFactory({ db: targetDb })
           })({
             projectId: project.id,
             regionKey,

--- a/packages/server/modules/multiregion/services/queue.ts
+++ b/packages/server/modules/multiregion/services/queue.ts
@@ -279,6 +279,8 @@ export const startQueue = async () => {
             }))
           })
         }
+
+        return
       }
       case 'delete-project-region-data':
       default:


### PR DESCRIPTION
No return here meant jobs fell through to "failed" in all cases, after work was successfully performed.