### PR TITLE
fix(acc): drop automation foreign key constraint

### DIFF
--- a/packages/server/modules/acc/migrations/20250806163108_drop_automation_id_fk.ts
+++ b/packages/server/modules/acc/migrations/20250806163108_drop_automation_id_fk.ts
@@ -1,0 +1,21 @@
+import type { Knex } from 'knex'
+
+const TABLE_NAME = 'acc_sync_items'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropForeign('automationId')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    // Note: This will fail if any sync items have been created with `automationId` values that violate the constraint.
+    // Handle those before running this migration.
+    table
+      .foreign('automationId')
+      .references('id')
+      .inTable('automations')
+      .onDelete('cascade')
+  })
+}


### PR DESCRIPTION
Project automations are regional data, but sync items are not. This means, often, the `automationId` column will not be able to satisfy the existing foreign key constraint: it is a valid id, but the sync item's main db row has no way to validate the reference to the automation in the regional db.

The constraint was not doing a lot of work for us, in any case, and is safe to drop while we think through longer-term solutions.