### PR TITLE
chore(fe2): make viewer ssr capable again

### DIFF
--- a/packages/frontend-2/nuxt.config.ts
+++ b/packages/frontend-2/nuxt.config.ts
@@ -221,9 +221,8 @@ export default defineNuxtConfig({
         statusCode: 301
       }
     },
-    // CSR only viewer, we cant preload much because of the url hash state which is CSR only
     '/projects/:id/models/:modelId': {
-      ssr: false
+      ssr: true // TODO: Should experiment w/ false, but this breaks SSR script injection like for RUM
     }
   },
 


### PR DESCRIPTION
we have to use SSR because we conditionally inject and set up various scripts that **have to** load as early as possible (e.g. RUM)