### PR TITLE
fix(fe): replace nested loops in filter components

### DIFF
--- a/packages/frontend-2/components/viewer/compare-changes/ObjectGroup.vue
+++ b/packages/frontend-2/components/viewer/compare-changes/ObjectGroup.vue
@@ -46,7 +46,8 @@ const color = computed(() => {
 
 const isSelected = computed(() => {
   const selObjsIds = selectedObjects.value.map((o) => o.id as string)
-  return selObjsIds.some((id: string) => props.objectIds.includes(id))
+  const objectIdsSet = new Set(props.objectIds)
+  return selObjsIds.some((id: string) => objectIdsSet.has(id))
 })
 
 const objectCount = computed(() => {

--- a/packages/frontend-2/components/viewer/explorer/StringFilterItem.vue
+++ b/packages/frontend-2/components/viewer/explorer/StringFilterItem.vue
@@ -101,8 +101,10 @@ const isSelected = computed(() => hasIntersection(objectIds.value, props.item.id
 const availableTargetIds = computed(() => {
   let targets = props.item.ids
 
-  if (isolatedObjectIds.value.length)
-    targets = props.item.ids.filter((id) => isolatedObjectIds.value.includes(id))
+  if (isolatedObjectIds.value.length) {
+    const isolatedSet = new Set(isolatedObjectIds.value)
+    targets = props.item.ids.filter((id) => isolatedSet.has(id))
+  }
 
   return targets
 })
@@ -121,7 +123,8 @@ const isHidden = computed(() => {
 const isIsolated = computed(() => {
   if (!isolatedObjectIds.value.length) return true
   const ids = props.item.ids
-  return isolatedObjectIds.value.some((id) => ids.includes(id))
+  const isolatedSet = new Set(isolatedObjectIds.value)
+  return ids.some((id) => isolatedSet.has(id))
 })
 
 const color = computed(() => {


### PR DESCRIPTION
Filter interactions were extremely slow due to `some().includes()` patterns.
Switched to `Set.has()` for faster lookups.