### PR TITLE
refactor(fe): reset view mode onBeforeUnmount

### DIFF
--- a/packages/frontend-2/components/viewer/Base.vue
+++ b/packages/frontend-2/components/viewer/Base.vue
@@ -8,6 +8,7 @@
 <script setup lang="ts">
 import { useInjectedViewer } from '~~/lib/viewer/composables/setup'
 import { useCommentContext } from '~~/lib/viewer/composables/commentManagement'
+import { useViewModeUtilities } from '~/lib/viewer/composables/ui'
 
 const rendererparent = ref<HTMLElement>()
 const {
@@ -17,6 +18,7 @@ const {
 } = useInjectedViewer()
 
 const { cleanupThreadContext } = useCommentContext()
+const { resetViewMode } = useViewModeUtilities()
 
 onMounted(async () => {
   if (!import.meta.client) return
@@ -34,6 +36,7 @@ onBeforeUnmount(() => {
   if (!import.meta.client) return
   container.style.display = 'none'
   cleanupThreadContext()
+  resetViewMode()
   document.body.appendChild(container)
 })
 </script>

--- a/packages/frontend-2/components/viewer/Base.vue
+++ b/packages/frontend-2/components/viewer/Base.vue
@@ -8,7 +8,6 @@
 <script setup lang="ts">
 import { useInjectedViewer } from '~~/lib/viewer/composables/setup'
 import { useCommentContext } from '~~/lib/viewer/composables/commentManagement'
-import { useViewModeUtilities } from '~/lib/viewer/composables/ui'
 
 const rendererparent = ref<HTMLElement>()
 const {
@@ -18,7 +17,6 @@ const {
 } = useInjectedViewer()
 
 const { cleanupThreadContext } = useCommentContext()
-const { resetViewMode } = useViewModeUtilities()
 
 onMounted(async () => {
   if (!import.meta.client) return
@@ -36,7 +34,6 @@ onBeforeUnmount(() => {
   if (!import.meta.client) return
   container.style.display = 'none'
   cleanupThreadContext()
-  resetViewMode()
   document.body.appendChild(container)
 })
 </script>

--- a/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
@@ -54,7 +54,8 @@ import { areVectorsLooselyEqual } from '~~/lib/viewer/helpers/three'
 import { SafeLocalStorage, type Nullable } from '@speckle/shared'
 import {
   useCameraUtilities,
-  useMeasurementUtilities
+  useMeasurementUtilities,
+  useViewModeUtilities
 } from '~~/lib/viewer/composables/ui'
 import { setupDebugMode } from '~~/lib/viewer/composables/setup/dev'
 import { useEmbed } from '~/lib/viewer/composables/setup/embed'
@@ -1106,6 +1107,14 @@ function useViewerCursorIntegration() {
   })
 }
 
+function useViewerViewModesIntegration() {
+  const { resetViewMode } = useViewModeUtilities()
+
+  onBeforeUnmount(() => {
+    resetViewMode()
+  })
+}
+
 export function useViewerPostSetup() {
   if (import.meta.server) return
   useViewerObjectAutoLoading()
@@ -1126,5 +1135,6 @@ export function useViewerPostSetup() {
   useDisableZoomOnEmbed()
   useViewerCursorIntegration()
   useViewerTreeIntegration()
+  useViewerViewModesIntegration()
   setupDebugMode()
 }

--- a/packages/frontend-2/lib/viewer/composables/ui.ts
+++ b/packages/frontend-2/lib/viewer/composables/ui.ts
@@ -531,7 +531,6 @@ export function useViewModeUtilities() {
   const { viewMode } = useInjectedViewerInterfaceState()
   const { isLightTheme } = useTheme()
   const mp = useMixpanel()
-  const logger = useLogger()
 
   const edgesEnabled = ref(true)
   const edgesWeight = ref(1)
@@ -607,57 +606,14 @@ export function useViewModeUtilities() {
       color: color.toString(16).padStart(6, '0')
     })
   }
-  // Get the current view mode from the extension and sync the UI state
-  const initializeFromViewerState = () => {
-    try {
-      const viewModesExt = instance.getExtension(ViewModes)
-      if (viewModesExt) {
-        const extensionViewMode = viewModesExt.viewMode
-        if (extensionViewMode !== undefined) {
-          viewMode.value = extensionViewMode
-        }
 
-        const renderer = instance.getRenderer()
-        const currentPipeline = renderer?.pipeline
-
-        if (currentPipeline && currentPipeline.options) {
-          const currentOptions = currentPipeline.options as Record<string, unknown>
-
-          if (typeof currentOptions.edges === 'boolean') {
-            edgesEnabled.value = currentOptions.edges
-          }
-
-          const edgesPasses = currentPipeline.getPass('EDGES')
-          if (edgesPasses.length > 0) {
-            const edgesPass = edgesPasses[0] as unknown as Record<string, unknown>
-            const edgesPassOptions = edgesPass._options as Record<string, unknown>
-
-            if (
-              edgesPassOptions &&
-              typeof edgesPassOptions.outlineThickness === 'number'
-            ) {
-              edgesWeight.value = edgesPassOptions.outlineThickness
-            }
-            if (
-              edgesPassOptions &&
-              typeof edgesPassOptions.outlineOpacity === 'number'
-            ) {
-              outlineOpacity.value = edgesPassOptions.outlineOpacity
-            }
-            if (edgesPassOptions && typeof edgesPassOptions.outlineColor === 'number') {
-              edgesColor.value = edgesPassOptions.outlineColor
-            }
-          }
-        }
-      }
-    } catch (error) {
-      logger.warn('Could not initialize from viewer state, using defaults:', error)
-    }
+  const resetViewMode = () => {
+    setViewMode(ViewMode.DEFAULT)
+    edgesEnabled.value = true
+    edgesWeight.value = 1
+    outlineOpacity.value = 0.75
+    edgesColor.value = defaultColor.value
   }
-
-  onMounted(() => {
-    initializeFromViewerState()
-  })
 
   return {
     currentViewMode,
@@ -667,7 +623,8 @@ export function useViewModeUtilities() {
     edgesWeight,
     setEdgesWeight,
     setEdgesColor,
-    edgesColor
+    edgesColor,
+    resetViewMode
   }
 }
 


### PR DESCRIPTION
Remove sync between viewer state and fe ui on mount - this was needlessly complex and only went in because we knew this ticket was coming in a few days. 
Reset view mode between viewer sessions