### PR TITLE
refactor(fe): deselect object when closing comment

### DIFF
--- a/packages/frontend-2/components/viewer/anchored-point/Thread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/Thread.vue
@@ -200,7 +200,7 @@ import { ToastNotificationType, useGlobalToast } from '~~/lib/common/composables
 import { getLinkToThread } from '~~/lib/viewer/helpers/comments'
 import { useDisableGlobalTextSelection } from '~~/lib/common/composables/window'
 import { useMixpanel } from '~~/lib/core/composables/mp'
-import { useThreadUtilities } from '~~/lib/viewer/composables/ui'
+import { useThreadUtilities, useSelectionUtilities } from '~~/lib/viewer/composables/ui'
 import { useEmbed } from '~/lib/viewer/composables/setup/embed'
 import { graphql } from '~/lib/common/generated/gql'
 import type { ConcreteComponent } from 'vue'
@@ -252,6 +252,7 @@ const { ellipsis, controls } = useAnimatingEllipsis()
 const { threadResourceStatus, hasClickedFullContext, goBack, handleContextClick } =
   useCommentContext()
 const { isOpenThread, open, closeAllThreads } = useThreadUtilities()
+const { clearSelection } = useSelectionUtilities()
 const router = useSafeRouter()
 const menuId = useId()
 
@@ -430,6 +431,7 @@ const changeExpanded = async (newVal: boolean) => {
     await open(props.modelValue.id)
   } else {
     await closeAllThreads()
+    clearSelection()
   }
 
   emit('update:expanded', newVal)

--- a/packages/frontend-2/components/viewer/anchored-point/Thread.vue
+++ b/packages/frontend-2/components/viewer/anchored-point/Thread.vue
@@ -200,7 +200,7 @@ import { ToastNotificationType, useGlobalToast } from '~~/lib/common/composables
 import { getLinkToThread } from '~~/lib/viewer/helpers/comments'
 import { useDisableGlobalTextSelection } from '~~/lib/common/composables/window'
 import { useMixpanel } from '~~/lib/core/composables/mp'
-import { useThreadUtilities, useSelectionUtilities } from '~~/lib/viewer/composables/ui'
+import { useThreadUtilities } from '~~/lib/viewer/composables/ui'
 import { useEmbed } from '~/lib/viewer/composables/setup/embed'
 import { graphql } from '~/lib/common/generated/gql'
 import type { ConcreteComponent } from 'vue'
@@ -252,7 +252,6 @@ const { ellipsis, controls } = useAnimatingEllipsis()
 const { threadResourceStatus, hasClickedFullContext, goBack, handleContextClick } =
   useCommentContext()
 const { isOpenThread, open, closeAllThreads } = useThreadUtilities()
-const { clearSelection } = useSelectionUtilities()
 const router = useSafeRouter()
 const menuId = useId()
 
@@ -431,7 +430,6 @@ const changeExpanded = async (newVal: boolean) => {
     await open(props.modelValue.id)
   } else {
     await closeAllThreads()
-    clearSelection()
   }
 
   emit('update:expanded', newVal)

--- a/packages/frontend-2/lib/viewer/composables/commentBubbles.ts
+++ b/packages/frontend-2/lib/viewer/composables/commentBubbles.ts
@@ -278,9 +278,37 @@ export function useViewerThreadTracking() {
     if (newThread?.id !== oldThread?.id) {
       const newState = newThread?.viewerState
       if (newState && SpeckleViewer.ViewerState.isSerializedViewerState(newState)) {
+        // Save current state before applying thread state (only if no previous thread)
+        if (!oldThread) {
+          const currentState = serializeState()
+          oldState.value = {
+            ...currentState,
+            ui: {
+              ...currentState.ui,
+              threads: {
+                ...currentState.ui.threads,
+                openThread: {
+                  threadId: null,
+                  isTyping: false,
+                  newThreadEditor: false
+                }
+              }
+            }
+          }
+        }
         await refocus(newState)
-      } else {
-        resetState()
+      } else if (oldThread) {
+        // Closing a thread - restore old state if available
+        if (
+          oldState.value &&
+          SpeckleViewer.ViewerState.isSerializedViewerState(oldState.value)
+        ) {
+          await applyState(oldState.value, StateApplyMode.SavedView, {
+            loadOriginal: false
+          })
+        } else {
+          resetState()
+        }
       }
     }
   })


### PR DESCRIPTION
From ticket:
Objects stay selected after you close the comment window. When closing a comment we should also deselect the object connected to that comment.