### PR TITLE
feat(fe): models panel - zoom to fit on double click of model or tree item

### DIFF
--- a/packages/frontend-2/components/viewer/models/Card.vue
+++ b/packages/frontend-2/components/viewer/models/Card.vue
@@ -10,6 +10,7 @@
         @focusin="highlightObject"
         @focusout="unhighlightObject"
         @click="selectObject"
+        @dblclick="zoomToModel"
         @keydown.enter="selectObject"
       >
         <ViewerExpansionTriangle
@@ -86,7 +87,8 @@ import type { Get } from 'type-fest'
 import type { LayoutMenuItem } from '~~/lib/layout/helpers/components'
 import {
   useHighlightedObjectsUtilities,
-  useFilterUtilities
+  useFilterUtilities,
+  useCameraUtilities
 } from '~~/lib/viewer/composables/ui'
 import {
   useInjectedViewerState,
@@ -116,6 +118,7 @@ const props = defineProps<{
 const { highlightObjects, unhighlightObjects } = useHighlightedObjectsUtilities()
 const { hideObjects, showObjects, isolateObjects, unIsolateObjects } =
   useFilterUtilities()
+const { zoom } = useCameraUtilities()
 const { items } = useInjectedViewerRequestedResources()
 const { resourceItems } = useInjectedViewerLoadedResources()
 const {
@@ -287,6 +290,12 @@ const selectObject = () => {
   // Only expand if not already expanded
   if (!props.isExpanded) {
     emit('toggle-expansion')
+  }
+}
+
+const zoomToModel = () => {
+  if (modelObjectIds.value.length > 0) {
+    zoom(modelObjectIds.value)
   }
 }
 

--- a/packages/frontend-2/components/viewer/models/VirtualTreeItem.vue
+++ b/packages/frontend-2/components/viewer/models/VirtualTreeItem.vue
@@ -5,6 +5,7 @@
       class="group flex items-center w-full p-1 pr-2 cursor-pointer text-left justify-between"
       :class="[getItemBackgroundClass(), getItemOpacityClass()]"
       @click="handleItemClick($event)"
+      @dblclick="handleItemDoubleClick()"
       @mouseenter="handleItemMouseEnter()"
       @mouseleave="handleItemMouseLeave()"
       @focusin="handleItemMouseEnter()"
@@ -65,7 +66,8 @@ import {
 import {
   useSelectionUtilities,
   useFilterUtilities,
-  useHighlightedObjectsUtilities
+  useHighlightedObjectsUtilities,
+  useCameraUtilities
 } from '~~/lib/viewer/composables/ui'
 import { useInjectedViewerState } from '~~/lib/viewer/composables/setup'
 import type { UnifiedVirtualItem } from '~~/lib/viewer/composables/tree'
@@ -83,6 +85,7 @@ const { objects: selectedObjects } = useSelectionUtilities()
 const { hideObjects, showObjects, isolateObjects, unIsolateObjects } =
   useFilterUtilities()
 const { highlightObjects, unhighlightObjects } = useHighlightedObjectsUtilities()
+const { zoom } = useCameraUtilities()
 
 const {
   viewer: {
@@ -144,6 +147,11 @@ const toggleExpansion = () => {
 
 const handleItemClick = (event: MouseEvent | KeyboardEvent) => {
   emit('item-click', props.item, event)
+}
+
+const handleItemDoubleClick = () => {
+  if (!rawSpeckleData.value?.id) return
+  zoom([rawSpeckleData.value.id])
 }
 
 const handleItemMouseEnter = () => {


### PR DESCRIPTION
https://linear.app/speckle/issue/WEB-3964/fit-object-to-view-on-double-click-in-models-tab

Zoom to fit when you double click on a tree item or a model card.