### PR TITLE
feat(fe): improve viewer shortcuts

### DIFF
--- a/packages/frontend-2/components/viewer/controls/Bottom.vue
+++ b/packages/frontend-2/components/viewer/controls/Bottom.vue
@@ -92,7 +92,7 @@ const {
 const { getActiveMeasurement, removeMeasurement, enableMeasurements, hasMeasurements } =
   useMeasurementUtilities()
 const { resetExplode } = useFilterUtilities()
-const { currentViewMode } = useViewModeUtilities()
+const { currentViewMode, setViewMode } = useViewModeUtilities()
 const {
   ui: { explodeFactor }
 } = useInjectedViewerState()
@@ -128,21 +128,23 @@ const panels = shallowRef({
     id: ActivePanel.explode,
     name: 'Explode',
     icon: 'IconViewerExplode',
-    tooltip: 'Explode',
+    tooltip: getShortcutDisplayText(shortcuts.ToggleExplode, { format: 'separate' }),
     extraClasses: 'hidden md:flex'
   },
   [ActivePanel.viewModes]: {
     id: ActivePanel.viewModes,
     name: 'View modes',
     icon: 'IconViewerViewModes',
-    tooltip: 'View modes',
+    tooltip: getShortcutDisplayText(shortcuts.ToggleViewModes, { format: 'separate' }),
     extraClasses: ''
   },
   [ActivePanel.lightControls]: {
     id: ActivePanel.lightControls,
     name: 'Light controls',
     icon: 'IconViewerLightControls',
-    tooltip: 'Light controls',
+    tooltip: getShortcutDisplayText(shortcuts.ToggleLightControls, {
+      format: 'separate'
+    }),
     extraClasses: 'hidden md:flex'
   }
 })
@@ -195,6 +197,11 @@ const toggleMeasurements = () => {
   activePanel.value = isMeasurementsActive ? ActivePanel.none : ActivePanel.measurements
 }
 
+const toggleExplode = () => {
+  activePanel.value =
+    activePanel.value === ActivePanel.explode ? ActivePanel.none : ActivePanel.explode
+}
+
 const toggleSectionBoxPanel = () => {
   if (activePanel.value === ActivePanel.measurements) {
     enableMeasurements(false)
@@ -205,6 +212,20 @@ const toggleSectionBoxPanel = () => {
       ? ActivePanel.none
       : ActivePanel.sectionBox
   toggleSectionBox()
+}
+
+const toggleViewModes = () => {
+  activePanel.value =
+    activePanel.value === ActivePanel.viewModes
+      ? ActivePanel.none
+      : ActivePanel.viewModes
+}
+
+const toggleLightControls = () => {
+  activePanel.value =
+    activePanel.value === ActivePanel.lightControls
+      ? ActivePanel.none
+      : ActivePanel.lightControls
 }
 
 const onActivePanelClose = () => {
@@ -230,9 +251,21 @@ const forceClosePanels = () => {
   activePanel.value = ActivePanel.none
 }
 
+const handleViewModeChange = (mode: ViewMode) => {
+  setViewMode(mode)
+}
+
 registerShortcuts({
   ToggleMeasurements: () => toggleMeasurements(),
-  ToggleSectionBox: () => toggleSectionBoxPanel()
+  ToggleExplode: () => toggleExplode(),
+  ToggleSectionBox: () => toggleSectionBoxPanel(),
+  ToggleViewModes: () => toggleViewModes(),
+  ToggleLightControls: () => toggleLightControls(),
+  SetViewModeDefault: () => handleViewModeChange(ViewMode.DEFAULT),
+  SetViewModeSolid: () => handleViewModeChange(ViewMode.SOLID),
+  SetViewModePen: () => handleViewModeChange(ViewMode.PEN),
+  SetViewModeArctic: () => handleViewModeChange(ViewMode.ARCTIC),
+  SetViewModeShaded: () => handleViewModeChange(ViewMode.SHADED)
 })
 
 onKeyStroke('Escape', () => {

--- a/packages/frontend-2/components/viewer/view-modes/Menu.vue
+++ b/packages/frontend-2/components/viewer/view-modes/Menu.vue
@@ -92,12 +92,10 @@
 
 <script setup lang="ts">
 import { ViewMode } from '@speckle/viewer'
-import { useViewerShortcuts, useViewModeUtilities } from '~~/lib/viewer/composables/ui'
+import { useViewModeUtilities } from '~~/lib/viewer/composables/ui'
 import { ViewModeShortcuts } from '~/lib/viewer/helpers/shortcuts/shortcuts'
 import { FormSwitch } from '@speckle/ui-components'
 import { useTheme } from '~/lib/core/composables/theme'
-
-const open = defineModel<boolean>('open', { default: false })
 
 const {
   setViewMode,
@@ -109,18 +107,9 @@ const {
   setEdgesColor,
   edgesColor
 } = useViewModeUtilities()
-const { registerShortcuts } = useViewerShortcuts()
 const { isLightTheme } = useTheme()
 
 const showSettings = ref(false)
-
-registerShortcuts({
-  SetViewModeDefault: () => handleViewModeChange(ViewMode.DEFAULT, true),
-  SetViewModeSolid: () => handleViewModeChange(ViewMode.SOLID, true),
-  SetViewModePen: () => handleViewModeChange(ViewMode.PEN, true),
-  SetViewModeArctic: () => handleViewModeChange(ViewMode.ARCTIC, true),
-  SetViewModeShaded: () => handleViewModeChange(ViewMode.SHADED, true)
-})
 
 const isActiveMode = (mode: ViewMode) => mode === currentViewMode.value
 
@@ -135,11 +124,7 @@ const edgesColorOptions = computed(() => [
   0xf43f5e //rose-500
 ])
 
-const handleViewModeChange = (mode: ViewMode, isShortcut = false) => {
+const handleViewModeChange = (mode: ViewMode) => {
   setViewMode(mode)
-
-  if (isShortcut) {
-    open.value = true
-  }
 }
 </script>

--- a/packages/frontend-2/lib/viewer/helpers/shortcuts/shortcuts.ts
+++ b/packages/frontend-2/lib/viewer/helpers/shortcuts/shortcuts.ts
@@ -27,15 +27,22 @@ export const PanelShortcuts = {
     name: 'Dev Mode',
     description: 'Toggle dev mode',
     modifiers: [ModifierKeys.Shift],
-    key: 'E',
+    key: 'X',
     action: 'ToggleDevMode'
   },
   ToggleSavedViews: {
     name: 'Saved Views',
     description: 'Toggle saved views panel',
     modifiers: [ModifierKeys.Shift],
-    key: 'V',
+    key: 'S',
     action: 'ToggleSavedViews'
+  },
+  ToggleViewModes: {
+    name: 'View modes',
+    description: 'Toggle view modes panel',
+    modifiers: [ModifierKeys.Shift],
+    key: 'V',
+    action: 'ToggleViewModes'
   }
 } as const
 
@@ -61,12 +68,26 @@ export const ToolShortcuts = {
     key: 'B',
     action: 'ToggleSectionBox'
   },
+  ToggleExplode: {
+    name: 'Explode',
+    description: 'Toggle explode mode',
+    modifiers: [ModifierKeys.Shift],
+    key: 'E',
+    action: 'ToggleExplode'
+  },
   ZoomExtentsOrSelection: {
     name: 'Fit',
     description: 'Zoom to fit selection or entire model',
     modifiers: [ModifierKeys.Shift],
     key: 'space',
     action: 'ZoomExtentsOrSelection'
+  },
+  ToggleLightControls: {
+    name: 'Light controls',
+    description: 'Toggle light controls panel',
+    modifiers: [ModifierKeys.Shift],
+    key: 'L',
+    action: 'ToggleLightControls'
   }
 } as const
 


### PR DESCRIPTION
Added new shortcuts to tools that were missing them. 

I noticed view mode shortcuts no longer worked, unless you had the view mode panel open. 
I moved this logic to the parent to handle this. 