### PR TITLE
fix(fe): only show resize handle at large breakpoint

### DIFF
--- a/packages/frontend-2/components/viewer/Sidebar.vue
+++ b/packages/frontend-2/components/viewer/Sidebar.vue
@@ -10,7 +10,7 @@
       <!-- Resize Handle -->
       <div
         ref="resizeHandle"
-        class="absolute h-full max-h-[calc(100dvh-3rem)] w-4 transition border-l sm:rounded-lg lg:rounded-none hover:border-l-[2px] border-outline-2 hover:border-primary hidden sm:flex items-center cursor-ew-resize z-30"
+        class="absolute h-full max-h-[calc(100dvh-3rem)] w-4 transition border-l sm:rounded-lg lg:rounded-none hover:border-l-[2px] border-outline-2 hover:border-primary hidden lg:flex items-center cursor-ew-resize z-30"
         @mousedown="startResizing"
       />
 


### PR DESCRIPTION
For more context see ticket:
https://linear.app/speckle/issue/WEB-4054/resizing-selected-panel-below-lg-results-in-view-controls-moving

Basically, we disable resize of viewer panels on anything smaller than large breakpoint. This responsive class was wrong, so we were still showing the handle for resize over `sm:`. 