### PR TITLE
Fix speckle-server health check in docker-compose.yml

### DIFF
--- a/docker-compose-speckle.yml
+++ b/docker-compose-speckle.yml
@@ -50,7 +50,7 @@ services:
         - CMD
         - /nodejs/bin/node
         - -e
-        - "try { require('node:http').request({headers: {'Content-Type': 'application/json'}, port:3000, hostname:'127.0.0.1', path:'/readiness', method: 'GET', timeout: 2000 }, (res) => { body = ''; res.on('data', (chunk) => {body += chunk;}); res.on('end', () => {process.exit(res.statusCode != 200 || body.toLowerCase().includes('error'));}); }).end(); } catch { process.exit(1); }"
+        - "try { require('node:http').request({headers: {'Content-Type': 'application/json'}, port:3000, hostname:'127.0.0.1', path:'/readiness', method: 'GET', timeout: 2000 }, (res) => { body = ''; res.on('data', (chunk) => {body += chunk;}); res.on('end', () => {process.exit(res.statusCode != 200 || body.toLowerCase().includes('error') ? 1 : 0);}); }).end(); } catch { process.exit(1); }"
       interval: 10s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
The `docker-compose-speckle.yml` file contains a health check for the `speckle-server` service. The health check contains an error, causing the health check to always fail.

Please see this Community post:

https://speckle.community/t/file-uploads-does-s3-need-to-be-publically-accessible/19905/5