### PR TITLE
feat(tokens): enable resource limits for PAT creation

### DIFF
--- a/packages/frontend-2/lib/common/generated/gql/graphql.ts
+++ b/packages/frontend-2/lib/common/generated/gql/graphql.ts
@@ -250,6 +250,8 @@ export type ApiToken = {
 
 export type ApiTokenCreateInput = {
   lifespan?: InputMaybe<Scalars['BigInt']['input']>;
+  /** Optionally limit the token to only have access to specific resources */
+  limitResources?: InputMaybe<Array<TokenResourceIdentifierInput>>;
   name: Scalars['String']['input'];
   scopes: Array<Scalars['String']['input']>;
 };

--- a/packages/server/assets/core/typedefs/apitoken.graphql
+++ b/packages/server/assets/core/typedefs/apitoken.graphql
@@ -43,6 +43,10 @@ input ApiTokenCreateInput {
   scopes: [String!]!
   name: String!
   lifespan: BigInt
+  """
+  Optionally limit the token to only have access to specific resources
+  """
+  limitResources: [TokenResourceIdentifierInput!]
 }
 
 input AppTokenCreateInput {

--- a/packages/server/modules/auth/defaultApps.ts
+++ b/packages/server/modules/auth/defaultApps.ts
@@ -140,6 +140,7 @@ const SpecklePowerBi = {
     Scopes.Profile.Email,
     Scopes.Users.Read,
     Scopes.Users.Invite,
+    Scopes.Tokens.Write,
     ...workspaceScopes
   ]
 }

--- a/packages/server/modules/core/domain/tokens/operations.ts
+++ b/packages/server/modules/core/domain/tokens/operations.ts
@@ -104,7 +104,8 @@ export type CreateAndStorePersonalAccessToken = (
   userId: string,
   name: string,
   scopes: ServerScope[],
-  lifespan?: number | bigint
+  lifespan?: number | bigint,
+  limitResources?: TokenResourceIdentifierInput[] | null
 ) => Promise<string>
 
 export type CreateAndStoreEmbedToken = (args: {

--- a/packages/server/modules/core/graph/generated/graphql.ts
+++ b/packages/server/modules/core/graph/generated/graphql.ts
@@ -271,6 +271,8 @@ export type ApiToken = {
 
 export type ApiTokenCreateInput = {
   lifespan?: InputMaybe<Scalars['BigInt']['input']>;
+  /** Optionally limit the token to only have access to specific resources */
+  limitResources?: InputMaybe<Array<TokenResourceIdentifierInput>>;
   name: Scalars['String']['input'];
   scopes: Array<Scalars['String']['input']>;
 };

--- a/packages/server/modules/core/graph/resolvers/apitoken.ts
+++ b/packages/server/modules/core/graph/resolvers/apitoken.ts
@@ -51,7 +51,8 @@ const resolvers = {
             context.userId!,
             args.token.name,
             args.token.scopes.filter(isValidScope),
-            args.token.lifespan || undefined
+            args.token.lifespan || undefined,
+            args.token.limitResources || null
           ),
         {
           logger: context.log,

--- a/packages/server/modules/core/services/tokens.ts
+++ b/packages/server/modules/core/services/tokens.ts
@@ -24,6 +24,7 @@ import type {
   StoreTokenResourceAccessDefinitions,
   StoreTokenScopes,
   StoreUserServerAppToken,
+  TokenResourceIdentifierInput,
   UpdateApiToken,
   ValidateToken
 } from '@/modules/core/domain/tokens/operations'
@@ -128,13 +129,15 @@ export const createPersonalAccessTokenFactory =
     userId: string,
     name: string,
     scopes: ServerScope[],
-    lifespan?: number | bigint
+    lifespan?: number | bigint,
+    limitResources?: TokenResourceIdentifierInput[] | null
   ) => {
     const { id, token } = await createTokenFactory(deps)({
       userId,
       name,
       scopes,
-      lifespan
+      lifespan,
+      limitResources
     })
 
     // Store the relationship


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: adds metrics to component"

* "Fix: resolves duplication in comment thread"

* "Update: apollo v2.34.0"

-->

## Description & motivation

- PowerBI connector requires ability to:
  - Create tokens for the given user
  - Scope them to just a given project
- Ability to do this is largely written, just not exposed by the public API

## Changes:

- Make it available via gql
- Gives PowerBI default app `tokens:write` scope
