### PR TITLE
feat(fe): improve filter by property

### DIFF
--- a/packages/frontend-2/components/viewer/filters/Panel.vue
+++ b/packages/frontend-2/components/viewer/filters/Panel.vue
@@ -118,7 +118,7 @@ const {
   unApplyPropertyFilter,
   filters: { propertyFilter },
   getRelevantFilters,
-  isRevitProperty
+  getPropertyName
 } = useFilterUtilities()
 
 const {
@@ -212,24 +212,5 @@ const refreshColorsIfSetOrActiveFilterIsNumeric = () => {
 
   // removePropertyFilter()
   applyPropertyFilter()
-}
-
-const getPropertyName = (key: string): string => {
-  if (!key) return 'Loading'
-
-  if (key === 'level.name') return 'Level Name'
-  if (key === 'speckle_type') return 'Object Type'
-
-  if (isRevitProperty(key) && key.endsWith('.value')) {
-    const correspondingProperty = (allFilters.value || []).find(
-      (f: PropertyInfo) => f.key === key.replace('.value', '.name')
-    )
-    if (correspondingProperty && isStringPropertyInfo(correspondingProperty)) {
-      return correspondingProperty.valueGroups[0]?.value || key.split('.').pop() || key
-    }
-  }
-
-  // For all other properties, just return the last part of the path
-  return key.split('.').pop() || key
 }
 </script>

--- a/packages/frontend-2/components/viewer/selection/Object.vue
+++ b/packages/frontend-2/components/viewer/selection/Object.vue
@@ -194,7 +194,11 @@ const ignoredProps = [
 ]
 
 const keyValuePairs = computed(() => {
-  const kvps = [] as (Record<string, unknown> & { key: string; value: unknown })[]
+  const kvps = [] as (Record<string, unknown> & {
+    key: string
+    value: unknown
+    backendPath?: string
+  })[]
 
   // handle revit paramters
   if (props.title === 'parameters') {
@@ -252,7 +256,8 @@ const keyValuePairs = computed(() => {
       innerType,
       arrayLength,
       arrayPreview,
-      value: props.object[key]
+      value: props.object[key],
+      backendPath: key // For regular properties, key matches backend path
     })
   }
 

--- a/packages/frontend-2/lib/viewer/composables/ui.ts
+++ b/packages/frontend-2/lib/viewer/composables/ui.ts
@@ -27,6 +27,7 @@ import type {
 } from '~/lib/viewer/helpers/shortcuts/types'
 import { useTheme } from '~/lib/core/composables/theme'
 import { useMixpanel } from '~/lib/core/composables/mp'
+import { isStringPropertyInfo } from '~/lib/viewer/helpers/sceneExplorer'
 
 export function useSectionBoxUtilities() {
   const { instance } = useInjectedViewer()
@@ -346,6 +347,131 @@ export function useFilterUtilities(
     return !shouldExcludeFromFiltering(key)
   }
 
+  /**
+   * Gets a user-friendly display name for a property key
+   */
+  const getPropertyName = (key: string): string => {
+    if (!key) return 'Loading'
+
+    if (key === 'level.name') return 'Level Name'
+    if (key === 'speckle_type') return 'Object Type'
+
+    if (isRevitProperty(key) && key.endsWith('.value')) {
+      const correspondingProperty = (viewer.metadata.availableFilters.value || []).find(
+        (f: PropertyInfo) => f.key === key.replace('.value', '.name')
+      )
+      if (correspondingProperty && isStringPropertyInfo(correspondingProperty)) {
+        return (
+          correspondingProperty.valueGroups[0]?.value || key.split('.').pop() || key
+        )
+      }
+    }
+
+    // For all other properties, just return the last part of the path
+    return key.split('.').pop() || key
+  }
+
+  /**
+   * Finds a filter by matching display names (handles complex nested properties)
+   */
+  const findFilterByDisplayName = (
+    displayKey: string,
+    availableFilters: PropertyInfo[] | null | undefined
+  ): PropertyInfo | undefined => {
+    return availableFilters?.find((f) => {
+      const backendDisplayName = getPropertyName(f.key)
+      return backendDisplayName === displayKey || f.key.split('.').pop() === displayKey
+    })
+  }
+
+  /**
+   * Determines if a key-value pair is filterable (with smart matching for nested properties)
+   */
+  const isKvpFilterable = (
+    kvp: Record<string, unknown> & { key: string; backendPath?: string },
+    availableFilters: PropertyInfo[] | null | undefined
+  ): boolean => {
+    // Use backendPath if available, otherwise fall back to display key
+    const backendKey = (kvp.backendPath as string | undefined) || (kvp.key as string)
+
+    // First check direct match
+    const directMatch = availableFilters?.some((f) => f.key === backendKey)
+    if (directMatch) {
+      return isPropertyFilterable(backendKey, availableFilters)
+    }
+
+    // For complex nested properties, try to find a match by display name
+    const displayKey = kvp.key as string
+    const matchByDisplayName = findFilterByDisplayName(displayKey, availableFilters)
+
+    if (matchByDisplayName) {
+      return isPropertyFilterable(matchByDisplayName.key, availableFilters)
+    }
+
+    return false
+  }
+
+  /**
+   * Gets a detailed reason why a property is disabled for filtering
+   */
+  const getFilterDisabledReason = (
+    kvp: Record<string, unknown> & { key: string; backendPath?: string },
+    availableFilters: PropertyInfo[] | null | undefined
+  ): string => {
+    const backendKey = (kvp.backendPath as string | undefined) || (kvp.key as string)
+    const availableKeys = availableFilters?.map((f) => f.key) || []
+
+    // Check if it's not in available filters
+    if (!availableKeys.includes(backendKey)) {
+      // For debugging: show similar keys that might be available
+      const similarKeys = availableKeys.filter(
+        (key) =>
+          key.toLowerCase().includes('type') ||
+          key.toLowerCase().includes('category') ||
+          key.toLowerCase().includes('class')
+      )
+
+      const debugInfo =
+        similarKeys.length > 0
+          ? ` (Similar available: ${similarKeys.slice(0, 3).join(', ')})`
+          : ''
+
+      return `Property '${backendKey}' is not available in backend filters${debugInfo}`
+    }
+
+    // Check if it's excluded by filtering logic
+    if (shouldExcludeFromFiltering(backendKey)) {
+      return `Property '${backendKey}' is excluded from filtering (technical property)`
+    }
+
+    return 'This property is not available for filtering'
+  }
+
+  /**
+   * Applies a filter for a key-value pair (with smart matching)
+   */
+  const applyKvpFilter = (
+    kvp: Record<string, unknown> & { key: string; backendPath?: string },
+    availableFilters: PropertyInfo[] | null | undefined
+  ): void => {
+    // Use backendPath if available, otherwise fall back to display key
+    const backendKey = (kvp.backendPath as string | undefined) || (kvp.key as string)
+
+    // First try direct match
+    let filter = availableFilters?.find((f: PropertyInfo) => f.key === backendKey)
+
+    // If no direct match, try to find by display name using shared logic
+    if (!filter) {
+      const displayKey = kvp.key as string
+      filter = findFilterByDisplayName(displayKey, availableFilters)
+    }
+
+    if (filter) {
+      setPropertyFilter(filter)
+      applyPropertyFilter()
+    }
+  }
+
   return {
     isolateObjects,
     unIsolateObjects,
@@ -363,7 +489,12 @@ export function useFilterUtilities(
     isRevitProperty,
     shouldExcludeFromFiltering,
     getRelevantFilters,
-    isPropertyFilterable
+    isPropertyFilterable,
+    getPropertyName,
+    findFilterByDisplayName,
+    isKvpFilterable,
+    getFilterDisabledReason,
+    applyKvpFilter
   }
 }
 


### PR DESCRIPTION
- Consolidated filtering logic from `Panel` and `KeyValuePair` into shared `useFilterUtilities` composable
- Create reusable filter utilities (`isKvpFilterable`, `getFilterDisabledReason`, `applyKvpFilter`) to replace logic in `KeyValuePair`
- Fix limited filtering from selection info - previously only worked for properties with exact backend key matches, leaving many properties unfilterable
- Implement property matching that handles complex nested properties by matching display names to backend filter keys
