### PR TITLE
fix(frontend-2): make workspace member list text colors consistent

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/members/GuestsTable.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/GuestsTable.vue
@@ -64,7 +64,7 @@
         />
       </template>
       <template #joined="{ item }">
-        <span class="text-foreground-2">
+        <span class="text-foreground">
           {{ formattedFullDate(item.joinDate) }}
         </span>
       </template>
@@ -88,7 +88,7 @@
           {{ item.projectRoles.length }}
           {{ item.projectRoles.length === 1 ? 'project' : 'projects' }}
         </FormButton>
-        <div v-else class="text-foreground-2 max-w-max text-body-2xs select-none">
+        <div v-else class="text-foreground max-w-max text-body-2xs select-none">
           {{ item.projectRoles.length }}
           {{ item.projectRoles.length === 1 ? 'project' : 'projects' }}
         </div>

--- a/packages/frontend-2/components/settings/workspaces/members/InvitesTable.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/InvitesTable.vue
@@ -47,12 +47,12 @@
         </div>
       </template>
       <template #role="{ item }">
-        <span class="text-body-xs text-foreground-2">
+        <span class="text-body-xs text-foreground">
           {{ roleDisplayName(item.role) }}
         </span>
       </template>
       <template #lastRemindedOn="{ item }">
-        <span class="text-body-xs text-foreground-2">
+        <span class="text-body-xs text-foreground">
           {{ formattedFullDate(item.updatedAt) }}
         </span>
       </template>

--- a/packages/frontend-2/components/settings/workspaces/members/MembersTable.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/MembersTable.vue
@@ -78,7 +78,7 @@
       </template>
       <template #email="{ item }">
         <div class="flex">
-          <span class="text-foreground-2 truncate">
+          <span class="text-foreground truncate">
             {{ item.email }}
           </span>
         </div>
@@ -90,7 +90,7 @@
         />
       </template>
       <template #joined="{ item }">
-        <span class="text-foreground-2">{{ formattedFullDate(item.joinDate) }}</span>
+        <span class="text-foreground">{{ formattedFullDate(item.joinDate) }}</span>
       </template>
       <template #actions="{ item }">
         <SettingsWorkspacesMembersActionsMenu


### PR DESCRIPTION
**Fix workspace member list text color inconsistencies**
Make all workspace member list components use consistent dark text colors (text-foreground) instead of mixing light and dark colors across different elements.