### PR TITLE
fix(frontend-2): update workspace switcher cache when joining from discoverable workspaces

### DIFF
--- a/packages/frontend-2/lib/workspaces/composables/discoverableWorkspaces.ts
+++ b/packages/frontend-2/lib/workspaces/composables/discoverableWorkspaces.ts
@@ -159,6 +159,21 @@ export const useDiscoverableWorkspaces = () => {
     if (result?.data) {
       await refetch()
 
+      modifyObjectField(
+        apollo.cache,
+        getCacheId('User', activeUserId),
+        'workspaces',
+        ({ helpers: { createUpdatedValue, ref } }) => {
+          return createUpdatedValue(({ update }) => {
+            update('totalCount', (totalCount) => totalCount + 1)
+            update('items', (items) => [...items, ref('Workspace', workspace.id)])
+          })
+        },
+        {
+          autoEvictFiltered: true
+        }
+      )
+
       apollo.query({
         query: activeUserWorkspaceExistenceCheckQuery,
         variables: {


### PR DESCRIPTION
**Fix workspace switcher not updating when joining from discoverable workspaces modal**
Updates Apollo cache to include newly joined workspace in workspace list, ensuring immediate UI update without requiring hard refresh.