### PR TITLE
fix(fe): preload navigationWorkspaceSwitcherQuery

### DIFF
--- a/packages/frontend-2/plugins/060-dataPreload.ts
+++ b/packages/frontend-2/plugins/060-dataPreload.ts
@@ -5,6 +5,7 @@ import {
 } from '~/lib/auth/graphql/queries'
 import { usePreloadApolloQueries } from '~/lib/common/composables/graphql'
 import { mainServerInfoDataQuery } from '~/lib/core/composables/server'
+import { navigationWorkspaceSwitcherQuery } from '~/lib/navigation/graphql/queries'
 
 /**
  * Prefetches data for specific routes to avoid the problem of serial API requests
@@ -26,7 +27,17 @@ export default defineNuxtPlugin(async (ctx) => {
   // Standard/global
   promises.push(
     preload({
-      queries: [{ query: activeUserQuery }, { query: mainServerInfoDataQuery }]
+      queries: [
+        { query: activeUserQuery },
+        { query: mainServerInfoDataQuery },
+        ...(isWorkspacesEnabled.value
+          ? [
+              {
+                query: navigationWorkspaceSwitcherQuery
+              }
+            ]
+          : [])
+      ]
     })
   )
 


### PR DESCRIPTION
<img width="327" height="193" alt="image" src="https://github.com/user-attachments/assets/5e2d0860-a81d-495f-a6df-29c5b805ce2e" />

Preload navigationWorkspaceSwitcherQuery to avoid empty workspace switcher on refresh. 