### PR TITLE
Always support drag and drop in the Models panel 

### DIFF
--- a/packages/frontend-2/components/project/page/models/Tab.vue
+++ b/packages/frontend-2/components/project/page/models/Tab.vue
@@ -36,15 +36,9 @@
 
         <div
           v-if="isDraggingFiles && canCreateModel"
-          class="absolute inset-0 bg-primary/10 border border-dashed border-primary rounded-lg flex items-center justify-center z-10"
+          class="absolute inset-0 bg-primary/10 border border-dashed border-primary rounded-lg flex items-center justify-center z-10 bg-white/50 dark:bg-black/50 text-center text-heading text-primary"
         >
-          <div class="text-center p-8">
-            <div class="text-heading-lg text-primary mb-2">Drop file to upload</div>
-            <div class="text-body-sm text-foreground-2">
-              Drop your IFC/OBJ/STL{{ isNextGenFileImporterEnabled ? '/SKP' : '' }} file
-              here to create a new model
-            </div>
-          </div>
+          Drop file to upload
         </div>
       </div>
     </FormFileUploadZone>
@@ -80,7 +74,6 @@ import {
   useFileImport,
   useGlobalFileImportManager
 } from '~~/lib/core/composables/fileImport'
-import { useIsNextGenFileImporterEnabled } from '~/composables/globals'
 import type { ProjectPageLatestItemsModelItemFragment } from '~/lib/common/generated/gql/graphql'
 
 const route = useRoute()
@@ -99,7 +92,6 @@ const { result } = useQuery(projectModelsPageQuery, () => ({
 const project = computed(() => result.value?.project)
 
 // File upload logic
-const isNextGenFileImporterEnabled = useIsNextGenFileImporterEnabled()
 const { addFailedJob } = useGlobalFileImportManager()
 const showNewModelDialog = ref(false)
 


### PR DESCRIPTION
At the moment you can only drag and drop a file into a project if it's empty. This PR wraps a file upload drop zone around the model list (both card view and list view) so that you can also drag and drop files into the Models tab when it already has models. You can only drop one file at a time.  

<img width="2940" height="1468" alt="CleanShot 2025-08-18 at 17 40 32@2x" src="https://github.com/user-attachments/assets/90c29cba-ed1c-4300-8e8d-b7bb89414710" />
