### PR TITLE
fix(server/previews): verify owner exists and throw specific error

### DIFF
--- a/packages/server/modules/previews/errors/errors.ts
+++ b/packages/server/modules/previews/errors/errors.ts
@@ -1,0 +1,7 @@
+import { BaseError } from '@/modules/shared/errors'
+
+export class PreviewProjectOwnerNotFoundError extends BaseError {
+  static code = 'PREVIEW_PROJECT_OWNER_NOT_FOUND'
+  static defaultMessage =
+    'Unable to find an owner of the Project in which we wish to create a preview.'
+}

--- a/packages/server/modules/previews/services/createObjectPreview.ts
+++ b/packages/server/modules/previews/services/createObjectPreview.ts
@@ -9,6 +9,7 @@ import type {
 import { Roles, Scopes, TIME_MS } from '@speckle/shared'
 import { TokenResourceIdentifierType } from '@/modules/core/domain/tokens/types'
 import { toJobId } from '@speckle/shared/workers/previews'
+import { PreviewProjectOwnerNotFoundError } from '@/modules/previews/errors/errors'
 
 export const createObjectPreviewFactory =
   ({
@@ -26,7 +27,10 @@ export const createObjectPreviewFactory =
   }): CreateObjectPreview =>
   async ({ streamId, objectId, priority }) => {
     const owners = await getStreamCollaborators(streamId, Roles.Stream.Owner)
-    // there is always an owner, this is safe
+    if (!owners || owners.length === 0) {
+      throw new PreviewProjectOwnerNotFoundError('No project owners found')
+    }
+
     const userId = owners[0].id
 
     // use the database as a lock to prevent multiple jobs being created


### PR DESCRIPTION
## Description & motivation

We have received a number of errors retrieving previews where the stack trace is as follows:

```
TypeError: Cannot read properties of undefined (reading 'id')
    at Object.createObjectPreview (file:///speckle-server/packages/server/dist/modules/previews/services/createObjectPreview.js:8:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Object.getObjectPreviewBufferOrFilepath (file:///speckle-server/packages/server/dist/modules/previews/services/management.js:33:34)
    at async file:///speckle-server/packages/server/dist/modules/previews/services/management.js:69:31
```

This PR aims to better handle this error.

Note that this doesn't yet resolve the root cause.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
