### PR TITLE
fix(fe): stop propagation of right clicks

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/contextMenu.ts
+++ b/packages/frontend-2/lib/viewer/composables/contextMenu.ts
@@ -146,6 +146,7 @@ export function useViewerContextMenu(params: {
       // Handle right-clicks to open context menu
       if (event?.event && event.event.button === 2) {
         event.event.preventDefault()
+        event.event.stopPropagation()
 
         if (firstVisibleSelectionHit) {
           const clickLocation = firstVisibleSelectionHit.point.clone()


### PR DESCRIPTION
Nikos reported the windows right click menu opening when he right clicks in viewer.

We do have a `preventDefault`, but I'm guessing we also needed a `stopPropagation` to stop this bubbling up. 