### PR TITLE
fix(fe): prevent native context menu on Windows

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/contextMenu.ts
+++ b/packages/frontend-2/lib/viewer/composables/contextMenu.ts
@@ -10,6 +10,7 @@ import {
   useFilterUtilities,
   useCameraUtilities
 } from '~~/lib/viewer/composables/ui'
+import { useEventListener } from '@vueuse/core'
 
 export type ViewerContextMenuModel = {
   isVisible: boolean
@@ -28,6 +29,17 @@ export function useViewerContextMenu(params: {
   const { isolateObjects, hideObjects, unIsolateObjects } = useFilterUtilities()
   const { copy } = useClipboard()
   const { zoomExtentsOrSelection } = useCameraUtilities()
+
+  // Prevent native context menu on the viewer
+  useEventListener(
+    parentEl,
+    'contextmenu',
+    (event: MouseEvent) => {
+      event.preventDefault()
+      event.stopPropagation()
+    },
+    { passive: false }
+  )
 
   const contextMenuState = ref<ViewerContextMenuModel>({
     isVisible: false,
@@ -145,9 +157,6 @@ export function useViewerContextMenu(params: {
     singleClickCallback: (event, { firstVisibleSelectionHit }) => {
       // Handle right-clicks to open context menu
       if (event?.event && event.event.button === 2) {
-        event.event.preventDefault()
-        event.event.stopPropagation()
-
         if (firstVisibleSelectionHit) {
           const clickLocation = firstVisibleSelectionHit.point.clone()
           const selectedObjectId = firstVisibleSelectionHit.node.model.id


### PR DESCRIPTION
Still getting reports of the default right click menu appearing in the viewer, when it should be prevented to allow our context menu. 

I don't have Windows, so can't test, but I'm assuming the problem is that `preventDefault()` is called too late in  the `ObjectClicked` handler, and the default menu has already been shown. 

Used `useEventListener` to catch this earlier. 