### PR TITLE
fix(fe2): full cache reset on log out

### DIFF
--- a/packages/frontend-2/lib/auth/composables/auth.ts
+++ b/packages/frontend-2/lib/auth/composables/auth.ts
@@ -142,7 +142,7 @@ const useResetAuthState = (
   const authToken = useAuthCookie()
 
   return async (
-    resetOptions: Partial<{
+    resetOptions?: Partial<{
       /**
        * If true, won't await the full reset and return early after reset has started
        */

--- a/packages/frontend-2/pages/authn/login.vue
+++ b/packages/frontend-2/pages/authn/login.vue
@@ -11,4 +11,8 @@ useHead({ title: 'Log in' })
 onMounted(() => {
   mixpanel.track('Visit Log In')
 })
+
+definePageMeta({
+  name: 'login'
+})
 </script>

--- a/packages/frontend-2/pages/settings/workspaces/[slug]/general.vue
+++ b/packages/frontend-2/pages/settings/workspaces/[slug]/general.vue
@@ -157,7 +157,7 @@
           </div>
         </div>
       </template>
-      <template v-if="(isServerAdmin || isAdmin) && workspaceId">
+      <template v-if="workspaceResult?.workspaceBySlug?.id">
         <hr class="mb-6 mt-8 border-outline-2" />
         <p class="text-body-2xs text-foreground-2">
           Workspace ID: #{{ workspaceResult?.workspaceBySlug?.id }}
@@ -264,7 +264,6 @@ const config = useRuntimeConfig()
 const { hasSsoEnabled, needsSsoLogin } = useWorkspaceSsoStatus({
   workspaceSlug: computed(() => workspaceResult.value?.workspaceBySlug?.slug || '')
 })
-const { isAdmin: isServerAdmin } = useActiveUser()
 
 const name = ref('')
 const slug = ref('')
@@ -278,7 +277,6 @@ const isAdmin = computed(
   () => workspaceResult.value?.workspaceBySlug?.role === Roles.Workspace.Admin
 )
 const adminRef = toRef(isAdmin)
-const workspaceId = computed(() => workspaceResult.value?.workspaceBySlug?.id)
 const canDeleteWorkspace = computed(
   () =>
     isAdmin.value &&

--- a/packages/server/modules/gatekeeper/graph/resolvers/index.ts
+++ b/packages/server/modules/gatekeeper/graph/resolvers/index.ts
@@ -159,7 +159,6 @@ export default FF_GATEKEEPER_MODULE_ENABLED
             userId: context.userId
           })
 
-          // Defaults to Editor for old plans that don't have seat types
           return seat?.type || WorkspaceSeatType.Viewer
         },
         seats: async (parent) => {


### PR DESCRIPTION
we used to just evict activeUser, but there's a bunch of user-specific keys like Workspace.seatType that got retained and caused weird cache pollution where if you logged out and logged in to a different account, the new account would have some values cached from the previous one

the correct thing to do is to evict the entire cache on log out