### PR TITLE
Add IFC importer to workspace

### DIFF
--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -69,6 +69,10 @@
       "name": "📊 monitor-deployment"
     },
     {
+      "path": "packages/ifc-import-service",
+      "name": "🛖 ifc-import-service"
+    },
+    {
       "path": ".",
       "name": "🏡 root"
     }


### PR DESCRIPTION
Makes the new IFC importer show up in the vs code terminal selector