### PR TITLE
Fix: Dont show cantCreate reason while loading

### DIFF
--- a/packages/frontend-2/components/workspace/wizard/Wizard.vue
+++ b/packages/frontend-2/components/workspace/wizard/Wizard.vue
@@ -12,7 +12,7 @@
         </template>
       </CommonAlert>
       <CommonAlert
-        v-if="!canClickCreate"
+        v-if="!canClickCreate && !permissionLoading"
         color="danger"
         class="w-lg mb-6 max-w-lg mx-auto"
       >
@@ -64,7 +64,11 @@ const route = useRoute()
 const mixpanel = useMixpanel()
 const { goToStep, currentStep, isLoading, state } = useWorkspacesWizard()
 
-const { canClickCreate, cantClickCreateReason } = useCanCreateWorkspace()
+const {
+  canClickCreate,
+  cantClickCreateReason,
+  loading: permissionLoading
+} = useCanCreateWorkspace()
 
 const { loading: queryLoading, onResult } = useQuery(
   workspaceWizardQuery,

--- a/packages/frontend-2/lib/projects/composables/permissions.ts
+++ b/packages/frontend-2/lib/projects/composables/permissions.ts
@@ -59,7 +59,7 @@ graphql(`
 `)
 
 export const useCanCreateWorkspace = () => {
-  const { result } = useQuery(useCanCreateWorkspaceQuery)
+  const { result, loading } = useQuery(useCanCreateWorkspaceQuery)
 
   const {
     canClickAction: canClickCreate,
@@ -76,7 +76,8 @@ export const useCanCreateWorkspace = () => {
     canClickCreate,
     canActuallyCreate,
     cantClickCreateReason,
-    cantClickCreateCode
+    cantClickCreateCode,
+    loading
   }
 }
 


### PR DESCRIPTION
I noticed that if you create a new workspace the "cant create" alert shows for a second while it's loading