### PR TITLE
feat(sso): allow sso session duration overrides

### DIFF
--- a/packages/server/modules/workspaces/domain/sso/logic.ts
+++ b/packages/server/modules/workspaces/domain/sso/logic.ts
@@ -9,9 +9,9 @@ import type { UnknownObject, UserinfoResponse } from 'openid-client'
  * Get the default expiration time for an SSO session based on the current time.
  * TODO: Is 7 days a good default session length?
  */
-export const getDefaultSsoSessionExpirationDate = (): Date => {
+export const getDefaultSsoSessionExpirationDate = (days = 7): Date => {
   const now = new Date()
-  now.setDate(now.getDate() + 7)
+  now.setDate(now.getDate() + days)
   return now
 }
 

--- a/packages/server/modules/workspaces/domain/sso/types.ts
+++ b/packages/server/modules/workspaces/domain/sso/types.ts
@@ -3,6 +3,7 @@ import type { infer as Infer } from 'zod'
 
 type ProviderBaseRecord = {
   id: string
+  sessionTimeoutDays?: number
   createdAt: Date
   updatedAt: Date
 }

--- a/packages/server/modules/workspaces/rest/sso.ts
+++ b/packages/server/modules/workspaces/rest/sso.ts
@@ -625,7 +625,9 @@ const handleOidcCallbackFactory =
         userId: req.user.id,
         providerId: decryptedOidcProvider.providerId,
         createdAt: new Date(),
-        validUntil: getDefaultSsoSessionExpirationDate()
+        validUntil: getDefaultSsoSessionExpirationDate(
+          decryptedOidcProvider.sessionTimeoutDays
+        )
       }
     })
 

--- a/packages/server/modules/workspacesCore/migrations/20250820151448_add_sso_timeout_override.ts
+++ b/packages/server/modules/workspacesCore/migrations/20250820151448_add_sso_timeout_override.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('sso_providers', (table) => {
+    table.integer('sessionTimeoutDays').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('sso_providers', (table) => {
+    table.dropColumn('sessionTimeoutDays')
+  })
+}


### PR DESCRIPTION
For Pelicad, see [forum thread](https://speckle.community/t/personal-access-token-stops-working-when-workspace-sso-session-expires/18858).

SSO sessions currently default to a (dubious but appropriate) 7 days because user visit the frontend enough to keep this up to date and easy to refresh. Pelicad drive some processes with "headless" users that won't ever visit the frontend and the 7 day limit is too punitive.

I am going to update this value for them manually, we can revisit exposing this publicly as a setting if it ever comes up again.

Tested on `testing2`