### PR TITLE
chore(helm): mount encryption key file when `workspacesSSOEnabled` feature flag is enabled

### DIFF
--- a/utils/helm/speckle-server/templates/objects/deployment.yml
+++ b/utils/helm/speckle-server/templates/objects/deployment.yml
@@ -60,7 +60,7 @@ spec:
           - name: postgres-certificate
             mountPath: /postgres-certificate
         {{- end }}
-        {{- if .Values.featureFlags.automateModuleEnabled }}
+        {{- if (or .Values.featureFlags.automateModuleEnabled .Values.featureFlags.workspacesSSOEnabled) }}
           - name: encryption-keys
             readOnly: true
             mountPath: /encryption-keys
@@ -151,7 +151,7 @@ spec:
           configMap:
             name: postgres-certificate
       {{- end }}
-      {{- if .Values.featureFlags.automateModuleEnabled }}
+      {{- if (or .Values.featureFlags.automateModuleEnabled .Values.featureFlags.workspacesSSOEnabled) }}
         - name: encryption-keys
           secret:
             secretName: encryption-keys

--- a/utils/helm/speckle-server/templates/objects/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/objects/serviceaccount.yml
@@ -37,7 +37,7 @@ secrets:
 {{- if .Values.server.monitoring.apollo.enabled }}
   - name: {{ default .Values.secretName .Values.server.monitoring.apollo.key.secretName }}
 {{- end }}
-{{- if .Values.featureFlags.automateModuleEnabled }}
+{{- if (or .Values.featureFlags.automateModuleEnabled .Values.featureFlags.workspacesSSOEnabled) }}
   - name: encryption-keys
 {{- end }}
 {{- if .Values.featureFlags.workspacesModuleEnabled }}

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -60,7 +60,7 @@ spec:
           - name: postgres-certificate
             mountPath: /postgres-certificate
         {{- end }}
-        {{- if .Values.featureFlags.automateModuleEnabled }}
+        {{- if (or .Values.featureFlags.automateModuleEnabled .Values.featureFlags.workspacesSSOEnabled) }}
           - name: encryption-keys
             readOnly: true
             mountPath: /encryption-keys
@@ -151,7 +151,7 @@ spec:
           configMap:
             name: postgres-certificate
       {{- end }}
-      {{- if .Values.featureFlags.automateModuleEnabled }}
+      {{- if (or .Values.featureFlags.automateModuleEnabled .Values.featureFlags.workspacesSSOEnabled) }}
         - name: encryption-keys
           secret:
             secretName: encryption-keys

--- a/utils/helm/speckle-server/templates/server/serviceaccount.yml
+++ b/utils/helm/speckle-server/templates/server/serviceaccount.yml
@@ -37,7 +37,7 @@ secrets:
 {{- if .Values.server.monitoring.apollo.enabled }}
   - name: {{ default .Values.secretName .Values.server.monitoring.apollo.key.secretName }}
 {{- end }}
-{{- if .Values.featureFlags.automateModuleEnabled }}
+{{- if (or .Values.featureFlags.automateModuleEnabled .Values.featureFlags.workspacesSSOEnabled) }}
   - name: encryption-keys
 {{- end }}
 {{- if .Values.featureFlags.workspacesModuleEnabled }}


### PR DESCRIPTION
Encryption key file was not being placed at expected location when `workspacesSSOEnabled` was enabled.