### PR TITLE
Fix: Show icon only if private

### DIFF
--- a/packages/frontend-2/components/viewer/saved-views/panel/View.vue
+++ b/packages/frontend-2/components/viewer/saved-views/panel/View.vue
@@ -69,8 +69,9 @@
       </div>
       <div class="w-full flex items-center gap-1">
         <Component
-          :is="isOnlyVisibleToMe ? User : Globe"
-          v-tippy="getTooltipProps(isOnlyVisibleToMe ? 'Private' : 'Shared')"
+          :is="User"
+          v-if="isOnlyVisibleToMe"
+          v-tippy="getTooltipProps('Only visible to you')"
           :size="12"
           :stroke-width="1.5"
           :absolute-stroke-width="true"
@@ -102,7 +103,7 @@ import {
 import type { LayoutMenuItem } from '@speckle/ui-components'
 import { useMutationLoading } from '@vue/apollo-composable'
 import { difference } from 'lodash-es'
-import { Ellipsis, SquarePen, Bookmark, Globe, User } from 'lucide-vue-next'
+import { Ellipsis, SquarePen, Bookmark, User } from 'lucide-vue-next'
 import { graphql } from '~/lib/common/generated/gql'
 import {
   SavedViewVisibility,

--- a/packages/frontend-2/lib/viewer/composables/savedViews/validation.ts
+++ b/packages/frontend-2/lib/viewer/composables/savedViews/validation.ts
@@ -5,7 +5,7 @@ import {
   SavedViewVisibility,
   type UseSavedViewValidationHelpers_SavedViewFragment
 } from '~/lib/common/generated/gql/graphql'
-import { Globe, Lock } from 'lucide-vue-next'
+import { Globe, User } from 'lucide-vue-next'
 import type { FormRadioGroupItem } from '@speckle/ui-components'
 import { useMutationLoading } from '@vue/apollo-composable'
 import { useInjectedViewerState } from '~/lib/viewer/composables/setup'
@@ -57,7 +57,7 @@ export const useSavedViewValidationHelpers = (params: {
       value: SavedViewVisibility.AuthorOnly,
       title: 'Private',
       introduction: 'Visible only to the view author',
-      icon: Lock,
+      icon: User,
       ...(params.view.value?.isHomeView
         ? {
             disabled: true,


### PR DESCRIPTION
Only show an icon if a view is private. Also use a user icon instead of a lock in the view details modal.

<img width="734" height="704" alt="CleanShot 2025-09-01 at 15 35 01@2x" src="https://github.com/user-attachments/assets/4d0a3c03-173f-4504-8adb-600ebedcb77e" />
