### PR TITLE
Fix: Improve truncations for hover actions on view cards

### DIFF
--- a/packages/frontend-2/components/viewer/saved-views/panel/View.vue
+++ b/packages/frontend-2/components/viewer/saved-views/panel/View.vue
@@ -18,54 +18,11 @@
       </div>
     </div>
     <div class="flex flex-col min-w-0 grow">
-      <div class="text-body-2xs font-medium text-foreground truncate grow-0 pr-1.5">
+      <div class="text-body-2xs font-medium text-foreground truncate grow-0">
         {{ view.name }}
       </div>
-      <div class="flex gap-1 items-center justify-between">
-        <div class="text-body-2xs text-foreground-3 truncate">
-          {{ view.author?.name }}
-        </div>
-        <div class="flex gap-0.5 items-center" @click.stop>
-          <LayoutMenu
-            v-model:open="showMenu"
-            :items="menuItems"
-            :menu-id="menuId"
-            mount-menu-on-body
-            show-ticks="right"
-            :size="230"
-            class="shrink-0 opacity-0 group-hover:opacity-100"
-            @chosen="({ item: actionItem }) => onActionChosen(actionItem)"
-          >
-            <FormButton
-              size="sm"
-              color="subtle"
-              :icon-left="Ellipsis"
-              hide-text
-              name="viewActions"
-              class="shrink-0"
-              @click="showMenu = !showMenu"
-            />
-          </LayoutMenu>
-          <div
-            v-tippy="
-              getTooltipProps(
-                canUpdate?.authorized ? 'Edit view' : canUpdate?.errorMessage
-              )
-            "
-            class="shrink-0 opacity-0 group-hover:opacity-100"
-          >
-            <FormButton
-              size="sm"
-              color="subtle"
-              :icon-left="SquarePen"
-              hide-text
-              name="editView"
-              class="shrink-0"
-              :disabled="!canUpdate?.authorized || isLoading"
-              @click="onEdit"
-            />
-          </div>
-        </div>
+      <div class="text-body-2xs text-foreground-3 truncate">
+        {{ view.author?.name }}
       </div>
       <div class="w-full flex items-center gap-1">
         <Component
@@ -88,6 +45,48 @@
         >
           {{ formattedRelativeDate(view.updatedAt, { capitalize: true }) }}
         </div>
+      </div>
+    </div>
+    <div
+      class="flex gap-0.5 items-center opacity-0 w-0 group-hover:opacity-100 group-hover:w-auto"
+      @click.stop
+    >
+      <LayoutMenu
+        v-model:open="showMenu"
+        :items="menuItems"
+        :menu-id="menuId"
+        mount-menu-on-body
+        show-ticks="right"
+        :size="230"
+        class="shrink-0"
+        @chosen="({ item: actionItem }) => onActionChosen(actionItem)"
+      >
+        <FormButton
+          size="sm"
+          color="subtle"
+          :icon-left="Ellipsis"
+          hide-text
+          name="viewActions"
+          class="shrink-0"
+          @click="showMenu = !showMenu"
+        />
+      </LayoutMenu>
+      <div
+        v-tippy="
+          getTooltipProps(canUpdate?.authorized ? 'Edit view' : canUpdate?.errorMessage)
+        "
+        class="shrink-0 opacity-0 group-hover:opacity-100"
+      >
+        <FormButton
+          size="sm"
+          color="subtle"
+          :icon-left="SquarePen"
+          hide-text
+          name="editView"
+          class="shrink-0"
+          :disabled="!canUpdate?.authorized || isLoading"
+          @click="onEdit"
+        />
       </div>
     </div>
   </div>
@@ -252,7 +251,9 @@ const menuItems = computed((): LayoutMenuItem<MenuItems>[][] => [
 ])
 
 const wrapperClasses = computed(() => {
-  const classParts = ['flex gap-2 p-1.5 w-full group rounded-md cursor-pointer']
+  const classParts = [
+    'flex items-center gap-2 p-1.5 w-full group rounded-md cursor-pointer'
+  ]
 
   if (isActive.value) {
     classParts.push('bg-highlight-2 hover:bg-highlight-3')

--- a/packages/frontend-2/components/viewer/saved-views/panel/views/group/Inner.vue
+++ b/packages/frontend-2/components/viewer/saved-views/panel/views/group/Inner.vue
@@ -7,7 +7,7 @@
       <template v-if="views.length">
         <div
           v-if="views.length"
-          class="flex flex-col gap-[1px] overflow-y-auto simple-scrollbar"
+          class="flex flex-col gap-[1px] overflow-y-auto overflow-x-hidden simple-scrollbar"
         >
           <ViewerSavedViewsPanelView
             v-for="view in views"


### PR DESCRIPTION
Change the markup and group hover action so that lines correctly truncate.

Before:

<img width="530" height="324" alt="CleanShot 2025-09-01 at 20 52 01@2x" src="https://github.com/user-attachments/assets/356c7086-8559-46a6-8d18-9e1e840ca21a" />

After:

![CleanShot 2025-09-01 at 20 43 18](https://github.com/user-attachments/assets/f1d9395c-9187-4d1c-afa4-33774e0732cf)
