### PR TITLE
feat(fe2): more reslient app reboot on fatal network error

### DIFF
--- a/packages/frontend-2/lib/auth/composables/auth.ts
+++ b/packages/frontend-2/lib/auth/composables/auth.ts
@@ -265,6 +265,8 @@ export const useAuthManager = (
    * Trigger full redirect that causes a full reload, instead of an in-session navigation
    */
   const sendFullRedirect = async (relativeUrl: string) => {
+    if (isFullRedirectState.value) return
+
     isFullRedirectState.value = true
 
     if (import.meta.client) {

--- a/packages/frontend-2/lib/auth/composables/auth.ts
+++ b/packages/frontend-2/lib/auth/composables/auth.ts
@@ -27,6 +27,7 @@ import type { ActiveUserMainMetadataQuery } from '~~/lib/common/generated/gql/gr
 import { useScopedState } from '~/lib/common/composables/scopedState'
 import type { ApolloClient } from '@apollo/client/core'
 import { AuthFailedError } from '~/lib/auth/errors/errors'
+import { useAppErrorState } from '~/lib/core/composables/error'
 
 type UseOnAuthStateChangeCallback = (
   user: MaybeNullOrUndefined<ActiveUserMainMetadataQuery['activeUser']>,
@@ -220,6 +221,7 @@ export const useAuthManager = (
 ) => {
   const { deferredApollo } = options || {}
 
+  const ssrEvent = useRequestEvent()
   const apiOrigin = useApiOrigin()
   const resetAuthState = useResetAuthState({ deferredApollo })
   const route = useRoute()
@@ -230,6 +232,7 @@ export const useAuthManager = (
   const postAuthRedirect = usePostAuthRedirect()
   const { markLoggedOut } = useJustLoggedOutTracking()
   const { logger } = useSafeLogger()
+  const { isFullRedirectState } = useAppErrorState()
 
   /**
    * Invite token, if any
@@ -257,6 +260,22 @@ export const useAuthManager = (
   const effectiveAuthToken = computed(
     () => dashboardToken.value || embedToken.value || authToken.value
   )
+
+  /**
+   * Trigger full redirect that causes a full reload, instead of an in-session navigation
+   */
+  const sendFullRedirect = async (relativeUrl: string) => {
+    isFullRedirectState.value = true
+
+    if (import.meta.client) {
+      window.location.href = relativeUrl
+    } else if (ssrEvent) {
+      const { sendRedirect } = await import('h3')
+      await sendRedirect(ssrEvent, relativeUrl)
+    } else {
+      logger().fatal('Failed to send full redirect')
+    }
+  }
 
   /**
    * Set/clear new token value and redirect to home
@@ -512,10 +531,10 @@ export const useAuthManager = (
     }
 
     if (!options?.skipRedirect) {
-      if (options?.forceFullReload && import.meta.client) {
-        window.location.href = loginRoute
-      } else {
+      if (!options?.forceFullReload) {
         await goToLogin()
+      } else {
+        await sendFullRedirect(loginRoute)
       }
     }
   }

--- a/packages/frontend-2/lib/core/composables/error.ts
+++ b/packages/frontend-2/lib/core/composables/error.ts
@@ -15,7 +15,8 @@ const ENTER_STATE_AT_ERRORS_PER_MIN = 100
 export function useAppErrorState() {
   const state = useScopedState('appErrorState', () => ({
     inErrorState: ref(false),
-    errorRpm: Observability.simpleRpmCounter()
+    errorRpm: Observability.simpleRpmCounter(),
+    isFullRedirectState: ref(false)
   }))
   const nuxtApp = useNuxtApp()
 
@@ -32,7 +33,22 @@ export function useAppErrorState() {
         )
         state.inErrorState.value = true
       }
-    }
+    },
+    /**
+     * Similar to error state, except we don't show any UI elements to the user, we just stop processing
+     * API calls etc. because we're redirecting fully away
+     */
+    isFullRedirectState: state.isFullRedirectState,
+    /**
+     * Whether to prevent HTTP API calls
+     */
+    preventHttpCalls: computed(() => state.isFullRedirectState.value),
+    /**
+     * Whether to prevent websocket messaging
+     */
+    preventWebsocketMessaging: computed(
+      () => state.isFullRedirectState.value || state.inErrorState.value
+    )
   }
 }
 


### PR DESCRIPTION
should make it so that we do a full app clear/reboot/reload in case of fatal GQL network errors, to avoid reload loops