### PR TITLE
fix(server/fileuploads): garbage collector should collect queued jobs which have reached max attempts

### DIFF
--- a/packages/server/modules/backgroundjobs/repositories/backgroundjobs.ts
+++ b/packages/server/modules/backgroundjobs/repositories/backgroundjobs.ts
@@ -76,25 +76,26 @@ export const failBackgroundJobsWhichExceedMaximumAttemptsOrNoRemainingComputeBud
               db.raw('"maxAttempt"') // camelCase requires the column name to be wrapped in double quotes
             )
           })
-          this.where(function () {
-            this.where(
-              BackgroundJobs.withoutTablePrefix.col.status,
-              BackgroundJobStatus.Queued
-            ).andWhere(
-              BackgroundJobs.withoutTablePrefix.col.attempt,
-              '>=', // greater or equal than because queued jobs cannot be picked up by a worker when they reach maxAttempt
-              db.raw('"maxAttempt"') // camelCase requires the column name to be wrapped in double quotes
-            )
-          }).orWhere(function () {
-            this.whereIn(BackgroundJobs.withoutTablePrefix.col.status, [
-              BackgroundJobStatus.Queued,
-              BackgroundJobStatus.Processing
-            ]).where(
-              BackgroundJobs.withoutTablePrefix.col.remainingComputeBudgetSeconds,
-              '<=',
-              0
-            )
-          })
+            .orWhere(function () {
+              this.where(
+                BackgroundJobs.withoutTablePrefix.col.status,
+                BackgroundJobStatus.Queued
+              ).andWhere(
+                BackgroundJobs.withoutTablePrefix.col.attempt,
+                '>=', // greater or equal than because queued jobs cannot be picked up by a worker when they reach maxAttempt
+                db.raw('"maxAttempt"') // camelCase requires the column name to be wrapped in double quotes
+              )
+            })
+            .orWhere(function () {
+              this.whereIn(BackgroundJobs.withoutTablePrefix.col.status, [
+                BackgroundJobStatus.Queued,
+                BackgroundJobStatus.Processing
+              ]).where(
+                BackgroundJobs.withoutTablePrefix.col.remainingComputeBudgetSeconds,
+                '<=',
+                0
+              )
+            })
         })
         .update({
           [BackgroundJobs.withoutTablePrefix.col.status]: BackgroundJobStatus.Failed

--- a/packages/server/modules/backgroundjobs/tests/integration/repositories.spec.ts
+++ b/packages/server/modules/backgroundjobs/tests/integration/repositories.spec.ts
@@ -174,10 +174,10 @@ describe('Background Jobs repositories @backgroundjobs', () => {
   })
 
   describe('failQueuedBackgroundJobsWhichExceedMaximumAttemptsOrNoRemainingComputeBudgetFactory', () => {
-    it('should fail queued background jobs that exceed maximum attempts', async () => {
+    it('should fail queued background jobs that meet or exceed maximum attempts', async () => {
       const job = createTestJob({
         status: BackgroundJobStatus.Queued,
-        attempt: 3,
+        attempt: 2,
         maxAttempt: 2
       })
       await storeBackgroundJob({ job })

--- a/packages/server/modules/fileuploads/tests/integration/tasks.spec.ts
+++ b/packages/server/modules/fileuploads/tests/integration/tasks.spec.ts
@@ -179,7 +179,7 @@ describe('File import garbage collection @fileuploads integration', () => {
           testData: identifiableData,
           blobId: fileTwo.fileId
         }),
-        attempt: 4,
+        attempt: 3,
         maxAttempt: 3
       })
       await saveUploadFile(fileOne)


### PR DESCRIPTION
## Description & motivation

Queued jobs which had reached max attempts were neither being picked up by a worker nor garbage collected. In this case they should be garbage collected, as they have already had sufficient attempts.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
