### PR TITLE
feat(fe): add require-valid-model to viewer

### DIFF
--- a/packages/frontend-2/pages/projects/[id]/models/[modelId]/index.vue
+++ b/packages/frontend-2/pages/projects/[id]/models/[modelId]/index.vue
@@ -23,7 +23,7 @@ import type { InjectableViewerState } from '~~/lib/viewer/composables/setup/core
 
 definePageMeta({
   layout: 'viewer',
-  middleware: ['require-valid-project'],
+  middleware: ['require-valid-project', 'require-valid-model'],
   pageTransition: false, // NOTE: transitions fuck viewer up
   layoutTransition: false,
   key: '/projects/:id/models/resources', // To prevent controls flickering on resource url param changes


### PR DESCRIPTION
It was reported that pages never 404d on the viewer pages. I checked and we were missing the `require-valid-model` middleware. 