### PR TITLE
fix(server/emails): move guard to caller and fix circular reference

### DIFF
--- a/packages/server/modules/shared/helpers/envHelper.ts
+++ b/packages/server/modules/shared/helpers/envHelper.ts
@@ -3,7 +3,6 @@ import { has, trimEnd } from 'lodash-es'
 import * as Environment from '@speckle/shared/environment'
 import type { Nullable } from '@speckle/shared'
 import { ensureError } from '@speckle/shared'
-import { logger } from '@/observability/logging'
 
 export function getStringFromEnv(
   envVarKey: string,
@@ -385,23 +384,11 @@ export function getEmailPort() {
 }
 
 export function isSSLEmailEnabled() {
-  const sslRequired = getBooleanFromEnv('EMAIL_SECURE', false) // see EMAIL_REQUIRE_TLS
-  if (sslRequired && isTLSEmailRequired()) {
-    throw new MisconfiguredEnvironmentError(
-      'EMAIL_SECURE and EMAIL_REQUIRE_TLS cannot both be true. TLS would typically be preferred over SSL.'
-    )
-  }
-  return sslRequired
+  return getBooleanFromEnv('EMAIL_SECURE', false) // see EMAIL_REQUIRE_TLS
 }
 
 export function isTLSEmailRequired() {
-  const tlsRequired = getBooleanFromEnv('EMAIL_REQUIRE_TLS', true) // default to true
-  if (!tlsRequired && !isSSLEmailEnabled()) {
-    logger.warn(
-      'Neither EMAIL_SECURE and EMAIL_REQUIRE_TLS are true. Client will attempt to upgrade to TLS on connect, but will default to whatever the server supports which may be insecure.'
-    )
-  }
-  return tlsRequired
+  return getBooleanFromEnv('EMAIL_REQUIRE_TLS', true) // default to true
 }
 
 export function getEmailUsername() {


### PR DESCRIPTION
## Description & motivation

Fixes a circular reference which occurred under some configuration settings. Was not caught in testing.

Guards moved to caller, and out of `envHelper`. This prevents the circular reference.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
