### PR TITLE
handle errors when downloading in batchingQueue

### DIFF
--- a/packages/objectloader2/src/queues/batchingQueue.ts
+++ b/packages/objectloader2/src/queues/batchingQueue.ts
@@ -106,6 +106,7 @@ export default class BatchingQueue<T> {
     if (this.#isProcessing || this.#queue.size === 0) {
       return
     }
+    if (this.#disposed) return
     this.#isProcessing = true
 
     const batchToProcess = this.#getBatch(this.#batchSize)
@@ -113,7 +114,8 @@ export default class BatchingQueue<T> {
     try {
       await this.#processFunction(batchToProcess)
     } catch (error) {
-      this.#logger('Batch processing failed:', error)
+      console.error('Batch processing failed:', error)
+      this.#disposed = true
     } finally {
       this.#isProcessing = false
     }


### PR DESCRIPTION
This is the only location where something is caught but not really logged.  There is nothing to guarentee a log to log this caught exception to the console error.

Also, flush should pay attention to disposal and dispose when caught