### PR TITLE
fix(fe): right click hide selection

### DIFF
--- a/packages/frontend-2/components/viewer/AnchoredPoints.vue
+++ b/packages/frontend-2/components/viewer/AnchoredPoints.vue
@@ -120,11 +120,11 @@
 
     <!-- Shows up when filters are applied for an easy return to normality -->
     <div
-      v-if="hasAnyFiltersApplied"
       class="z-20 absolute left-1/2 -translate-x-1/2"
       :class="showFollowerMessage ? 'top-24' : 'top-14'"
     >
-      <ViewerGlobalFilterReset />
+      <ViewerGlobalFilterReset v-if="hasAnyFiltersApplied" />
+      <ViewerGlobalIsolationReset v-else-if="hasAnyIsolationsApplied" />
     </div>
   </div>
 </template>
@@ -162,7 +162,8 @@ const { sessionId } = viewerState
 const { users } = useViewerUserActivityTracking({ parentEl })
 const { isOpenThread, open, closeAllThreads } = useThreadUtilities()
 const {
-  filters: { hasAnyFiltersApplied }
+  filters: { hasAnyFiltersApplied },
+  hasAnyIsolationsApplied
 } = useFilterUtilities({ state: viewerState })
 const canPostComment = useCheckViewerCommentingAccess()
 const breakpoints = useBreakpoints(TailwindBreakpoints)

--- a/packages/frontend-2/components/viewer/GlobalIsolationReset.vue
+++ b/packages/frontend-2/components/viewer/GlobalIsolationReset.vue
@@ -1,0 +1,22 @@
+<template>
+  <FormButton
+    size="sm"
+    color="outline"
+    class="pointer-events-auto"
+    @click="trackAndResetIsolations"
+  >
+    Reset isolations
+  </FormButton>
+</template>
+<script setup lang="ts">
+import { useMixpanel } from '~~/lib/core/composables/mp'
+import { useFilterUtilities } from '~/lib/viewer/composables/filtering/filtering'
+
+const { resetIsolations } = useFilterUtilities()
+
+const mp = useMixpanel()
+const trackAndResetIsolations = () => {
+  resetIsolations()
+  mp.track('Viewer Action', { type: 'action', name: 'isolations', action: 'reset' })
+}
+</script>

--- a/packages/frontend-2/lib/viewer/composables/filtering/filtering.ts
+++ b/packages/frontend-2/lib/viewer/composables/filtering/filtering.ts
@@ -37,7 +37,10 @@ import {
   findFilterByKvp
 } from '~/lib/viewer/helpers/filters/utils'
 import { useFilterColoringHelpers } from '~/lib/viewer/composables/filtering/coloringHelpers'
-import { useHighlightedObjectsUtilities } from '~/lib/viewer/composables/ui'
+import {
+  useHighlightedObjectsUtilities,
+  useSelectionUtilities
+} from '~/lib/viewer/composables/ui'
 
 export function useFilterUtilities(
   options?: Partial<{ state: InjectableViewerState }>
@@ -50,6 +53,7 @@ export function useFilterUtilities(
   const dataStore = useFilteringDataStore()
   const { removeColorFilter } = useFilterColoringHelpers({ state })
   const { clearHighlightedObjects } = useHighlightedObjectsUtilities()
+  const { clearSelection } = useSelectionUtilities()
 
   const isolateObjects = (
     objectIds: string[],
@@ -74,6 +78,15 @@ export function useFilterUtilities(
     )
   }
 
+  const resetIsolations = () => {
+    clearHighlightedObjects()
+    filters.isolatedObjectIds.value = []
+  }
+
+  const hasAnyIsolationsApplied = computed(() => {
+    return filters.isolatedObjectIds.value.length > 0
+  })
+
   const hideObjects = (
     objectIds: string[],
     options?: Partial<{
@@ -81,6 +94,7 @@ export function useFilterUtilities(
     }>
   ) => {
     clearHighlightedObjects()
+    clearSelection()
 
     filters.hiddenObjectIds.value = uniq([
       ...(options?.replace ? [] : filters.hiddenObjectIds.value),
@@ -878,8 +892,10 @@ export function useFilterUtilities(
   return {
     isolateObjects,
     unIsolateObjects,
+    resetIsolations,
     hideObjects,
     showObjects,
+    hasAnyIsolationsApplied,
     filters,
     addActiveFilter,
     updateFilterProperty,


### PR DESCRIPTION
Fix bug reported by dim in discord. We need to clear selection before hiding the object. 

Also added a "reset isolations" button cause it was easy to find yourself in a state where this was useful