### PR TITLE
feat(fe): enable filtering for block instances

### DIFF
--- a/packages/frontend-2/lib/viewer/helpers/filters/constants.ts
+++ b/packages/frontend-2/lib/viewer/helpers/filters/constants.ts
@@ -83,6 +83,5 @@ export const NON_FILTERABLE_OBJECT_KEYS = [
   'vertices',
   'faces',
   'colors',
-  'transform',
   'bbox'
 ] as const

--- a/packages/frontend-2/lib/viewer/helpers/filters/utils.ts
+++ b/packages/frontend-2/lib/viewer/helpers/filters/utils.ts
@@ -31,6 +31,15 @@ export const isRevitProperty = (key: string): boolean => {
  * Determines if a property should be excluded from filtering based on its key
  */
 export const shouldExcludeFromFiltering = (key: string): boolean => {
+  // Whitelist essential instance properties
+  const pathParts = key.split('.')
+  const lastPart = pathParts[pathParts.length - 1]
+
+  // Always include these instance-related properties
+  if (['definitionId', 'transform', 'name', 'definitionName'].includes(lastPart)) {
+    return false
+  }
+
   if (
     key.endsWith('.units') ||
     key.endsWith('.speckle_type') ||


### PR DESCRIPTION
Fixing bug reported on forum:
https://speckle.community/t/no-properties-available-for-object-filtering-on-instance-object/20252

Enable filtering for block instances by allowing `InstanceProxy` objects to be processed and adding support for `definitionId` and `definitionName` properties.