### PR TITLE
fix(helm): webhook service allows input of full image uri

### DIFF
--- a/utils/helm/speckle-server/templates/webhook_service/deployment.yml
+++ b/utils/helm/speckle-server/templates/webhook_service/deployment.yml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: speckle/speckle-webhook-service:{{ .Values.docker_image_tag }}
+        image: {{ default (printf "speckle/speckle-webhook-service:%s" .Values.docker_image_tag) .Values.webhook_service.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
 
         ports:


### PR DESCRIPTION
## Description & motivation

Helm chart supports entry of the entire image uri for all deployments except webhook service. This was an omission, as the `values.yaml` definition exists but it was not used in the deployment template.

This PR adds the same for the webhook service.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
