### PR TITLE
feat(fe): preserveSelectionHighlightFilter

### DIFF
--- a/packages/frontend-2/components/viewer/filters/filter/Header.vue
+++ b/packages/frontend-2/components/viewer/filters/filter/Header.vue
@@ -95,10 +95,6 @@ import { useFilterUtilities } from '~/lib/viewer/composables/filtering/filtering
 import { useFilterColoringHelpers } from '~/lib/viewer/composables/filtering/coloringHelpers'
 import type { FilterData } from '~/lib/viewer/helpers/filters/types'
 import { FilterType } from '~/lib/viewer/helpers/filters/types'
-import {
-  useHighlightedObjectsUtilities,
-  useSelectionUtilities
-} from '~/lib/viewer/composables/ui'
 
 const props = defineProps<{
   filter: FilterData
@@ -112,8 +108,6 @@ const { removeActiveFilter, toggleFilterApplied, getPropertyName, filters } =
   useFilterUtilities()
 
 const { toggleColorFilter } = useFilterColoringHelpers()
-const { clearHighlightedObjects } = useHighlightedObjectsUtilities()
-const { clearSelection } = useSelectionUtilities()
 
 const emit = defineEmits<{
   swapProperty: [filterId: string]
@@ -124,8 +118,6 @@ const isColoringActive = computed(() => {
 })
 
 const removeFilter = () => {
-  clearHighlightedObjects()
-  clearSelection()
   removeActiveFilter(props.filter.id)
 }
 
@@ -134,8 +126,6 @@ const toggleVisibility = () => {
 }
 
 const toggleColors = () => {
-  clearHighlightedObjects()
-  clearSelection()
   toggleColorFilter(props.filter.id)
 }
 

--- a/packages/frontend-2/components/viewer/models/Card.vue
+++ b/packages/frontend-2/components/viewer/models/Card.vue
@@ -140,7 +140,7 @@ const { hideObjects, showObjects, isolateObjects, unIsolateObjects } =
 const { zoom } = useCameraUtilities()
 const { items } = useInjectedViewerRequestedResources()
 const { resourceItems } = useInjectedViewerLoadedResources()
-const { addToSelectionFromObjectIds, clearSelection } = useSelectionUtilities()
+const { addToSelectionFromObjectIds } = useSelectionUtilities()
 
 const {
   viewer: {
@@ -313,7 +313,6 @@ const handleClick = () => {
   if (!props.isExpanded) {
     emit('toggle-expansion')
   } else {
-    clearSelection()
     addToSelectionFromObjectIds(modelObjectIds.value)
   }
 }

--- a/packages/frontend-2/lib/viewer/composables/setup/filters.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/filters.ts
@@ -1,11 +1,12 @@
 import type { FilterData } from '~/lib/viewer/helpers/filters/types'
 import type { SpeckleObject } from '@speckle/viewer'
 import type { Raw } from 'vue'
-import { FilteringExtension } from '@speckle/viewer'
+import { FilteringExtension, SelectionExtension } from '@speckle/viewer'
 import { watchTriggerable } from '@vueuse/core'
 import { useInjectedViewerState } from '~/lib/viewer/composables/setup'
 import { useOnViewerLoadComplete } from '~/lib/viewer/composables/viewer'
 import { useFilteringDataStore } from '~/lib/viewer/composables/filtering/dataStore'
+import { getGlobalHighlightExtension } from '~/lib/viewer/composables/setup/highlighting'
 
 /**
  * Setup composable for filter-related state
@@ -62,6 +63,39 @@ export const useManualFilteringPostSetup = () => {
   const filteringExtension = () => instance.getExtension(FilteringExtension)
 
   /**
+   * Preserve selection and highlighting state during filtering operations
+   * This replicates LegacyViewer's preserveSelectionHighlightFilter function
+   */
+  const preserveSelectionHighlightFilter = <T>(filterFn: () => T): T => {
+    const selectionExtension = instance.getExtension(SelectionExtension)
+    const highlightExtension = getGlobalHighlightExtension()
+
+    // 1. SAVE current state from viewer extensions
+    const selectedObjects = selectionExtension
+      .getSelectedObjects()
+      .map((obj) => obj.id as string)
+    const highlightedObjects =
+      highlightExtension?.getSelectedObjects().map((obj) => obj.id as string) || []
+
+    // 2. CLEAR viewer extensions directly
+    if (selectedObjects.length) selectionExtension.clearSelection()
+    if (highlightedObjects.length && highlightExtension) {
+      highlightExtension.clearSelection()
+    }
+
+    // 3. EXECUTE the filtering operation
+    const result = filterFn()
+
+    // 4. RESTORE to viewer extensions directly
+    if (selectedObjects.length) selectionExtension.selectObjects(selectedObjects)
+    if (highlightedObjects.length && highlightExtension) {
+      highlightExtension.selectObjects(highlightedObjects)
+    }
+
+    return result
+  }
+
+  /**
    * Watch for changes to manually isolated object IDs
    */
   const { trigger: triggerIsolationWatch } = watchTriggerable(
@@ -69,17 +103,19 @@ export const useManualFilteringPostSetup = () => {
     (newIds, oldIds) => {
       if (!newIds || !oldIds) return
 
-      const extension = filteringExtension()
+      preserveSelectionHighlightFilter(() => {
+        const extension = filteringExtension()
 
-      const toIsolate = newIds.filter((id) => !oldIds.includes(id))
-      if (toIsolate.length > 0) {
-        extension.isolateObjects(toIsolate, 'manual-isolation', true, true)
-      }
+        const toIsolate = newIds.filter((id) => !oldIds.includes(id))
+        if (toIsolate.length > 0) {
+          extension.isolateObjects(toIsolate, 'manual-isolation', true, true)
+        }
 
-      const toUnIsolate = oldIds.filter((id) => !newIds.includes(id))
-      if (toUnIsolate.length > 0) {
-        extension.unIsolateObjects(toUnIsolate, 'manual-isolation', true, true)
-      }
+        const toUnIsolate = oldIds.filter((id) => !newIds.includes(id))
+        if (toUnIsolate.length > 0) {
+          extension.unIsolateObjects(toUnIsolate, 'manual-isolation', true, true)
+        }
+      })
     },
     { deep: true }
   )
@@ -92,17 +128,19 @@ export const useManualFilteringPostSetup = () => {
     (newIds, oldIds) => {
       if (!newIds || !oldIds) return
 
-      const extension = filteringExtension()
+      preserveSelectionHighlightFilter(() => {
+        const extension = filteringExtension()
 
-      const toHide = newIds.filter((id) => !oldIds.includes(id))
-      if (toHide.length > 0) {
-        extension.hideObjects(toHide, 'manual-hiding', false, false)
-      }
+        const toHide = newIds.filter((id) => !oldIds.includes(id))
+        if (toHide.length > 0) {
+          extension.hideObjects(toHide, 'manual-hiding', false, false)
+        }
 
-      const toShow = oldIds.filter((id) => !newIds.includes(id))
-      if (toShow.length > 0) {
-        extension.showObjects(toShow, 'manual-hiding', false)
-      }
+        const toShow = oldIds.filter((id) => !newIds.includes(id))
+        if (toShow.length > 0) {
+          extension.showObjects(toShow, 'manual-hiding', false)
+        }
+      })
     },
     { deep: true }
   )

--- a/packages/frontend-2/lib/viewer/composables/setup/filters.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/filters.ts
@@ -6,7 +6,7 @@ import { watchTriggerable } from '@vueuse/core'
 import { useInjectedViewerState } from '~/lib/viewer/composables/setup'
 import { useOnViewerLoadComplete } from '~/lib/viewer/composables/viewer'
 import { useFilteringDataStore } from '~/lib/viewer/composables/filtering/dataStore'
-import { getGlobalHighlightExtension } from '~/lib/viewer/composables/setup/highlighting'
+import { getHighlightExtension } from '~/lib/viewer/composables/setup/highlighting'
 
 /**
  * Setup composable for filter-related state
@@ -68,7 +68,7 @@ export const useManualFilteringPostSetup = () => {
    */
   const preserveSelectionHighlightFilter = <T>(filterFn: () => T): T => {
     const selectionExtension = instance.getExtension(SelectionExtension)
-    const highlightExtension = getGlobalHighlightExtension()
+    const highlightExtension = getHighlightExtension(instance)
 
     // 1. SAVE current state from viewer extensions
     const selectedObjects = selectionExtension

--- a/packages/frontend-2/lib/viewer/composables/setup/filters.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/filters.ts
@@ -6,7 +6,7 @@ import { watchTriggerable } from '@vueuse/core'
 import { useInjectedViewerState } from '~/lib/viewer/composables/setup'
 import { useOnViewerLoadComplete } from '~/lib/viewer/composables/viewer'
 import { useFilteringDataStore } from '~/lib/viewer/composables/filtering/dataStore'
-import { getHighlightExtension } from '~/lib/viewer/composables/setup/highlighting'
+import { HighlightExtension } from '~/lib/viewer/composables/setup/highlighting'
 
 /**
  * Setup composable for filter-related state
@@ -68,7 +68,7 @@ export const useManualFilteringPostSetup = () => {
    */
   const preserveSelectionHighlightFilter = <T>(filterFn: () => T): T => {
     const selectionExtension = instance.getExtension(SelectionExtension)
-    const highlightExtension = getHighlightExtension(instance)
+    const highlightExtension = instance.getExtension(HighlightExtension)
 
     // 1. SAVE current state from viewer extensions
     const selectedObjects = selectionExtension

--- a/packages/frontend-2/lib/viewer/composables/setup/highlighting.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/highlighting.ts
@@ -48,7 +48,11 @@ const useHighlightExtensionState = () =>
   )
 
 /**
- * Get the global highlight extension
+ * Get the global highlight extension instance.
+ *
+ * Unlike built-in extensions (SelectionExtension), our custom HighlightExtension
+ * must be stored globally to prevent multiple instances from being created,
+ * which would cause material storage conflicts and highlighting issues.
  */
 export const getGlobalHighlightExtension = (
   instance?: IViewer
@@ -107,4 +111,12 @@ export const useHighlightingPostSetup = () => {
     },
     { immediate: true, flush: 'sync' }
   )
+
+  // Clean up the global highlight extension on unmount
+  onBeforeUnmount(() => {
+    const highlightExtensionState = useHighlightExtensionState()
+    if (highlightExtensionState.value) {
+      highlightExtensionState.value = null
+    }
+  })
 }

--- a/packages/frontend-2/lib/viewer/composables/setup/highlighting.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/highlighting.ts
@@ -15,7 +15,7 @@ import { ViewerRenderPageType } from '~/lib/viewer/helpers/state'
  * Highlighting extension that replicates LegacyViewer's HighlightExtension
  * Uses SelectionExtension but disables default events for UI-only highlighting
  */
-class HighlightExtension extends SelectionExtension {
+export class HighlightExtension extends SelectionExtension {
   public constructor(viewer: IViewer, cameraProvider: CameraController) {
     super(viewer, cameraProvider)
 
@@ -39,14 +39,6 @@ class HighlightExtension extends SelectionExtension {
 }
 
 /**
- * Get the highlight extension instance from the viewer.
- * The extension is created once during setup and then retrieved everywhere else.
- */
-export const getHighlightExtension = (instance: IViewer): HighlightExtension | null => {
-  return instance.getExtension(HighlightExtension)
-}
-
-/**
  * Post-setup integration that sets up highlighting extension and watches state
  * This should only be called once during post-setup after the viewer is initialized.
  */
@@ -63,7 +55,7 @@ export const useHighlightingPostSetup = () => {
   instance.createExtension(HighlightExtension)
 
   // Get the highlighting extension instance
-  const getHighlightExtensionInstance = () => getHighlightExtension(instance)
+  const getHighlightExtensionInstance = () => instance.getExtension(HighlightExtension)
 
   useOnViewerLoadComplete(
     ({ isInitial }) => {

--- a/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
@@ -69,7 +69,7 @@ import { useFilterUtilities } from '~/lib/viewer/composables/filtering/filtering
 import { useFilteringSetup } from '~/lib/viewer/composables/filtering/setup'
 import {
   useHighlightingPostSetup,
-  getGlobalHighlightExtension
+  getHighlightExtension
 } from '~/lib/viewer/composables/setup/highlighting'
 
 function useViewerLoadCompleteEventHandler() {
@@ -582,7 +582,7 @@ function useViewerFiltersIntegration() {
       }
 
       state.ui.highlightedObjectIds.value = []
-      const highlightExtension = getGlobalHighlightExtension()
+      const highlightExtension = getHighlightExtension(instance)
       if (highlightExtension) {
         highlightExtension.clearSelection()
       }

--- a/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
@@ -574,7 +574,10 @@ function useViewerFiltersIntegration() {
         .getSelectedObjects()
         .map((obj) => obj.id as string)
 
-      if (arraysEqual(currentViewerSelection.sort(), newIds.sort())) {
+      if (
+        currentViewerSelection.length === newIds.length &&
+        difference(currentViewerSelection, newIds).length === 0
+      ) {
         return
       }
 

--- a/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
@@ -67,7 +67,10 @@ import {
 } from '~/lib/viewer/composables/setup/filters'
 import { useFilterUtilities } from '~/lib/viewer/composables/filtering/filtering'
 import { useFilteringSetup } from '~/lib/viewer/composables/filtering/setup'
-import { useHighlightingPostSetup } from '~/lib/viewer/composables/setup/highlighting'
+import {
+  useHighlightingPostSetup,
+  getGlobalHighlightExtension
+} from '~/lib/viewer/composables/setup/highlighting'
 
 function useViewerLoadCompleteEventHandler() {
   const state = useInjectedViewerState()
@@ -566,12 +569,22 @@ function useViewerFiltersIntegration() {
       ).filter(isNonNullable)
       if (arraysEqual(newIds, oldIds)) return
 
-      state.ui.highlightedObjectIds.value = []
-
       const selectionExtension = instance.getExtension(SelectionExtension)
+      const currentViewerSelection = selectionExtension
+        .getSelectedObjects()
+        .map((obj) => obj.id as string)
+
+      if (arraysEqual(currentViewerSelection.sort(), newIds.sort())) {
+        return
+      }
+
+      state.ui.highlightedObjectIds.value = []
+      const highlightExtension = getGlobalHighlightExtension()
+      if (highlightExtension) {
+        highlightExtension.clearSelection()
+      }
 
       selectionExtension.clearSelection()
-
       if (newVal.length > 0) {
         selectionExtension.selectObjects(newIds)
       }

--- a/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/postSetup.ts
@@ -69,7 +69,7 @@ import { useFilterUtilities } from '~/lib/viewer/composables/filtering/filtering
 import { useFilteringSetup } from '~/lib/viewer/composables/filtering/setup'
 import {
   useHighlightingPostSetup,
-  getHighlightExtension
+  HighlightExtension
 } from '~/lib/viewer/composables/setup/highlighting'
 
 function useViewerLoadCompleteEventHandler() {
@@ -582,7 +582,7 @@ function useViewerFiltersIntegration() {
       }
 
       state.ui.highlightedObjectIds.value = []
-      const highlightExtension = getHighlightExtension(instance)
+      const highlightExtension = instance.getExtension(HighlightExtension)
       if (highlightExtension) {
         highlightExtension.clearSelection()
       }


### PR DESCRIPTION
### Problem
Selection, highlighting, and filtering systems were conflicting, causing objects to remain highlighted after deselection and losing state during filtering operations.

### Solution
Implemented LegacyViewer's proven `preserveSelectionHighlightFilter` pattern to properly coordinate viewer extensions.

### Key Changes
- Added preservation pattern (`filters.ts`) - Save/clear/restore selection & highlighting state during filtering, exactly like `LegacyViewer`
- Global highlight extension (`highlighting.ts`) - Single instance using `useScopedState`
- Smart selection sync (`postSetup.ts`) - Prevent redundant calls that corrupted material storage
- Removed hacky clears - Let preservation pattern handle coordination instead of fighting sync loops

### Why This Works
- Direct extension coordination instead of circular frontend sync loops
- Protected material storage - `SelectionExtension` stores clean original materials, not highlight materials
- Proper state isolation - Selection and highlighting work independently but coordinate during filtering

### Test Scenarios Fixed
✅ Select → deselect → returns to original state
✅ Highlight → hide → unhighlight → preserves hidden state
✅ All filtering operations preserve selection/highlighting state