### PR TITLE
Fix people settings count update bug

### DIFF
--- a/packages/frontend-2/components/settings/workspaces/members/actions/RemoveFromWorkspaceDialog.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/actions/RemoveFromWorkspaceDialog.vue
@@ -56,7 +56,8 @@ const handleConfirm = async () => {
     await updateUserRole({
       userId: props.user.id,
       role: null,
-      workspaceId: props.workspace.id
+      workspaceId: props.workspace.id,
+      previousRole: props.user.role
     })
 
     open.value = false

--- a/packages/frontend-2/components/settings/workspaces/members/actions/UpdateAdminDialog.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/actions/UpdateAdminDialog.vue
@@ -149,7 +149,8 @@ const handleConfirm = async () => {
     await updateUserRole({
       userId: props.user.id,
       role: props.action === 'make' ? Roles.Workspace.Admin : Roles.Workspace.Member,
-      workspaceId: props.workspace.id
+      workspaceId: props.workspace.id,
+      previousRole: props.user.role
     })
 
     if (!isUnpaidPaidUpgrade.value) {

--- a/packages/frontend-2/components/settings/workspaces/members/actions/UpdateRoleDialog.vue
+++ b/packages/frontend-2/components/settings/workspaces/members/actions/UpdateRoleDialog.vue
@@ -105,7 +105,8 @@ const handleConfirm = async () => {
     await updateUserRole({
       userId: props.user.id,
       role: props.newRole as string,
-      workspaceId: props.workspace.id
+      workspaceId: props.workspace.id,
+      previousRole: props.user.role
     })
 
     open.value = false


### PR DESCRIPTION
Fix: WEB-4311 - Update People settings counts reactively

## Description & motivation

This PR resolves an issue where the member counts in the People settings navigation (e.g., Members, Guests tabs) did not update immediately after a user was removed or their role was changed. A hard refresh was previously required to see the correct counts.

The problem stemmed from the `useWorkspaceUpdateRole` composable not properly updating the GraphQL cache for the `teamByRole` field, which provides the counts for the navigation tabs. Instead of decrementing/incrementing specific role counts, it was either evicting the entire field or not handling role changes comprehensively.

This fix modifies the cache update logic in `useWorkspaceUpdateRole` to intelligently decrement the previous role's count and increment the new role's count (or just decrement if a user is removed), ensuring the UI reflects the changes instantly without a hard refresh.

Fixes #WEB-4311

## Changes:

-   **`packages/frontend-2/lib/workspaces/composables/management.ts`**:
    -   Modified `useWorkspaceUpdateRole` to accept an optional `previousRole` parameter.
    -   Implemented logic to decrement the `totalCount` of the `previousRole` and increment the `totalCount` of the `newRole` within the `teamByRole` cache field when a user's role is updated or a user is removed.
    -   Added safeguards (`Math.max(0, count - 1)`) to prevent negative counts.
    -   Maintained backward compatibility by falling back to evicting the entire `teamByRole` field if `previousRole` is not provided.
-   **`packages/frontend-2/components/settings/workspaces/members/actions/RemoveFromWorkspaceDialog.vue`**:
    -   Updated the call to `useWorkspaceUpdateRole` to pass `props.user.role` as `previousRole` when removing a user.
-   **`packages/frontend-2/components/settings/workspaces/members/actions/UpdateAdminDialog.vue`**:
    -   Updated the call to `useWorkspaceUpdateRole` to pass `props.user.role` as `previousRole` when changing admin status.
-   **`packages/frontend-2/components/settings/workspaces/members/actions/UpdateRoleDialog.vue`**:
    -   Updated the call to `useWorkspaceUpdateRole` to pass `props.user.role` as `previousRole` when changing a user's role.

## Validation of changes:

The changes ensure that the GraphQL cache for workspace member counts (`teamByRole.admins.totalCount`, `teamByRole.members.totalCount`, `teamByRole.guests.totalCount`) is correctly updated when a user is removed or their role is modified. This makes the counts displayed in the People settings navigation reactive and consistent with the actual state without requiring a page refresh.

## Checklist:

-   [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
-   [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
-   [x] My commits are related to the pull request and do not amend unrelated code or documentation.
-   [x] My code follows a similar style to existing code.
-   [ ] I have added appropriate tests.
-   [ ] I have updated or added relevant documentation.

---
Linear Issue: [WEB-4311](https://linear.app/speckle/issue/WEB-4311/counts-in-people-settings-dont-update-until-hard-refresh)

<a href="https://cursor.com/background-agent?bcId=bc-cdc2afc4-65b7-460b-a74c-a51b571d54d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cdc2afc4-65b7-460b-a74c-a51b571d54d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

