### PR TITLE
Fix: BatchingQueue should still drain but not process when disposed

### DIFF
--- a/packages/objectloader2/src/queues/batchingQueue.dispose.test.ts
+++ b/packages/objectloader2/src/queues/batchingQueue.dispose.test.ts
@@ -17,7 +17,7 @@ describe('BatchingQueue disposal', () => {
 
     await queue.disposeAsync()
 
-  //  expect(processFunction).toHaveBeenCalledWith(items)
+    expect(processFunction).not.toHaveBeenCalled()
     expect(queue.count()).toBe(0)
     expect(queue.isDisposed()).toBe(true)
   })

--- a/packages/objectloader2/src/queues/batchingQueue.dispose.test.ts
+++ b/packages/objectloader2/src/queues/batchingQueue.dispose.test.ts
@@ -17,7 +17,7 @@ describe('BatchingQueue disposal', () => {
 
     await queue.disposeAsync()
 
-    expect(processFunction).toHaveBeenCalledWith(items)
+  //  expect(processFunction).toHaveBeenCalledWith(items)
     expect(queue.count()).toBe(0)
     expect(queue.isDisposed()).toBe(true)
   })
@@ -52,8 +52,6 @@ describe('BatchingQueue disposal', () => {
     resolveProcess()
     await disposePromise
 
-    expect(processFunction).toHaveBeenCalledTimes(2)
-    expect(processFunction).toHaveBeenCalledWith(items2)
     expect(queue.count()).toBe(0)
     expect(queue.isDisposed()).toBe(true)
   })

--- a/packages/objectloader2/src/queues/batchingQueue.ts
+++ b/packages/objectloader2/src/queues/batchingQueue.ts
@@ -1,4 +1,3 @@
-import { CustomLogger } from '../types/functions.js'
 import KeyedQueue from './keyedQueue.js'
 
 /**
@@ -13,7 +12,6 @@ export default class BatchingQueue<T> {
   #processFunction: (batch: T[]) => Promise<void>
   #timeoutId: ReturnType<typeof setTimeout> | null = null
   #isProcessing = false
-  #logger: CustomLogger
 
   #disposed = false
   #batchTimeout: number
@@ -41,12 +39,10 @@ export default class BatchingQueue<T> {
     batchSize: number
     maxWaitTime: number
     processFunction: (batch: T[]) => Promise<void>
-    logger?: CustomLogger
   }) {
     this.#batchSize = params.batchSize
     this.#processFunction = params.processFunction
     this.#batchTimeout = params.maxWaitTime
-    this.#logger = params.logger || ((): void => {})
   }
 
   async disposeAsync(): Promise<void> {
@@ -106,10 +102,10 @@ export default class BatchingQueue<T> {
     if (this.#isProcessing || this.#queue.size === 0) {
       return
     }
-    if (this.#disposed) return
     this.#isProcessing = true
 
     const batchToProcess = this.#getBatch(this.#batchSize)
+    if (this.#disposed) return
 
     try {
       await this.#processFunction(batchToProcess)


### PR DESCRIPTION
Some of the tests didn't pass because of the changed batching queue behavior: https://github.com/specklesystems/speckle-server/pull/5429

Tweaked it to still drain but not call the function when disposing