### PR TITLE
fix: remove reactive wrapper from tree cache to prevent recursive updates

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/tree.ts
+++ b/packages/frontend-2/lib/viewer/composables/tree.ts
@@ -51,7 +51,7 @@ export type UnifiedVirtualItem = {
 }
 
 function createTreeStateManager() {
-  const flattenedTreeCache = reactive(new Map<string, UnifiedVirtualItem[]>())
+  const flattenedTreeCache = new Map<string, UnifiedVirtualItem[]>()
   const lastCacheKey = ref('')
   const isInitialized = ref(false)
 


### PR DESCRIPTION
The `flattenedTreeCache` was incorrectly wrapped in `reactive()`, causing infinite recursion during hot reloads when the computed property accessing the cache would trigger itself. Cache should be plain Map.