### PR TITLE
Fix embed viewer controls and tooltip

### DIFF
--- a/packages/frontend-2/components/viewer/selection/Sidebar.vue
+++ b/packages/frontend-2/components/viewer/selection/Sidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <ViewerCommentsPortalOrDiv class="relative" to="bottomPanel">
     <ViewerControlsRight
-      v-if="isGreaterThanSm"
+      v-if="isGreaterThanSm && showControls"
       :sidebar-open="sidebarOpen && shouldRenderSidebar"
       :sidebar-width="sidebarWidth"
     />
@@ -90,6 +90,7 @@ import { modelRoute } from '~/lib/common/helpers/route'
 import { TailwindBreakpoints } from '~~/lib/common/helpers/tailwind'
 import type { LayoutMenuItem } from '~~/lib/layout/helpers/components'
 import { Ellipsis } from 'lucide-vue-next'
+import { useEmbed } from '~/lib/viewer/composables/setup/embed'
 
 enum ActionTypes {
   OpenInNewTab = 'open-in-new-tab'
@@ -112,6 +113,7 @@ const breakpoints = useBreakpoints(TailwindBreakpoints)
 const isGreaterThanSm = breakpoints.greater('sm')
 const menuId = useId()
 const mp = useMixpanel()
+const { showControls } = useEmbed()
 
 const itemCount = ref(20)
 const sidebarOpen = ref(false)

--- a/packages/frontend-2/lib/viewer/composables/ui.ts
+++ b/packages/frontend-2/lib/viewer/composables/ui.ts
@@ -436,7 +436,7 @@ export function useViewModeUtilities() {
 export function useViewerShortcuts() {
   const { ui } = useInjectedViewerState()
   const { isSmallerOrEqualSm } = useIsSmallerOrEqualThanBreakpoint()
-  const { isEnabled: isEmbedEnabled } = useEmbed()
+  const { isEnabled: isEmbedEnabled, showControls } = useEmbed()
   const activeElement = useActiveElement()
 
   const isTypingComment = computed(() => {
@@ -468,7 +468,7 @@ export function useViewerShortcuts() {
     options?: { hideName?: boolean; format?: 'default' | 'separate' }
   ) => {
     if (isSmallerOrEqualSm.value) return undefined
-    if (isEmbedEnabled.value) return undefined
+    if (isEmbedEnabled.value && !showControls.value) return undefined
 
     const shortcutText = getKeyboardShortcutTitle([
       ...shortcut.modifiers,


### PR DESCRIPTION
## Fix: Resolves embed control hiding and tooltip issues (WEB-4321)

## Description & motivation

This PR addresses two bugs in the embed viewer (WEB-4321):

1.  **Camera controls not hiding:** When `hide_controls = true` in an embed, the camera control buttons were still visible on desktop. This was due to the `Sidebar.vue` component not checking the `showControls` embed option.
2.  **Broken tooltip:** When in embed mode with controls visible (`hide_controls = false`), the tooltip for the "fit to view" button was empty. This was because the `getShortcutDisplayText` function was unconditionally disabling all tooltips if `isEmbedEnabled` was true.

The changes ensure camera controls are correctly hidden when specified, and tooltips function as expected when controls are visible in embed mode.

Connects WEB-4321

## Changes:

-   **`packages/frontend-2/components/viewer/selection/Sidebar.vue`**:
    -   Imported `useEmbed` and destructured `showControls`.
    -   Updated the `v-if` condition for `ViewerControlsRight` to `isGreaterThanSm && showControls` to correctly hide controls based on embed options.
-   **`packages/frontend-2/lib/viewer/composables/ui.ts`**:
    -   Modified `useViewerShortcuts` to also import `showControls` from `useEmbed`.
    -   Updated the tooltip hiding logic in `getShortcutDisplayText` from `if (isEmbedEnabled.value)` to `if (isEmbedEnabled.value && !showControls.value)` to allow tooltips when controls are visible in embed mode.

## Screenshots:

Refer to the images in Linear issue WEB-4321 for before/after context.

## Validation of changes:

Manual testing was performed to verify:
-   When `hide_controls=true` in embed, camera controls are no longer visible.
-   When `hide_controls=false` in embed, camera controls are visible and the "Fit to View" tooltip displays correctly ("Fit Shift + Space").
-   Non-embed viewer functionality remains unchanged.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

---
Linear Issue: [WEB-4321](https://linear.app/speckle/issue/WEB-4321/buttons-not-hidden-in-embed)

<a href="https://cursor.com/background-agent?bcId=bc-802b0699-1d30-4cd4-adca-7ab2923bd6f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-802b0699-1d30-4cd4-adca-7ab2923bd6f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

