### PR TITLE
fix(fe): disable bottom viewer buttons until load complete

### DIFF
--- a/packages/frontend-2/components/viewer/controls/Bottom.vue
+++ b/packages/frontend-2/components/viewer/controls/Bottom.vue
@@ -10,6 +10,7 @@
         :key="panel.id"
         v-tippy="getTooltipProps(panel.tooltip)"
         :active="activePanel === panel.id"
+        :disabled="!viewerLoaded"
         :dot="shouldShowDot(panel.id)"
         :icon="panel.icon"
         :class="panel.extraClasses"
@@ -68,6 +69,7 @@ import { useEmbed } from '~/lib/viewer/composables/setup/embed'
 import { TailwindBreakpoints } from '~~/lib/common/helpers/tailwind'
 import { useMixpanel } from '~~/lib/core/composables/mp'
 import { Ruler, Scissors, Sun, Layers2, Glasses } from 'lucide-vue-next'
+import { useOnViewerLoadComplete } from '~/lib/viewer/composables/viewer'
 
 enum ActivePanel {
   none = 'none',
@@ -109,6 +111,7 @@ const isMobile = breakpoints.smaller('sm')
 const mixpanel = useMixpanel()
 
 const activePanel = ref<ActivePanel>(ActivePanel.none)
+const viewerLoaded = ref(false)
 
 const panels = shallowRef({
   [ActivePanel.measurements]: {
@@ -283,6 +286,13 @@ onKeyStroke('Escape', () => {
   }
   activePanel.value = ActivePanel.none
 })
+
+useOnViewerLoadComplete(
+  () => {
+    viewerLoaded.value = true
+  },
+  { initialOnly: true, waitForLoadingOver: true }
+)
 
 watch(activePanel, (newVal) => {
   // Using 'controls' here to stick to the old naming convention

--- a/packages/frontend-2/components/viewer/controls/ButtonToggle.vue
+++ b/packages/frontend-2/components/viewer/controls/ButtonToggle.vue
@@ -1,13 +1,8 @@
 <template>
   <button
     class="relative transition rounded-md w-8 h-8 shrink-0 flex items-center justify-center outline-none"
-    :class="
-      active
-        ? 'bg-info-lighter text-primary-focus dark:text-foreground-on-primary'
-        : `bg-foundation ${
-            secondary ? 'text-foreground-3' : 'text-foreground'
-          } md:hover:bg-primary-muted md:focus-visible:border-foundation`
-    "
+    :disabled="disabled"
+    :class="buttonClasses"
   >
     <component :is="icon" v-if="icon" class="size-5" />
     <slot />
@@ -21,10 +16,27 @@
 <script setup lang="ts">
 import type { ConcreteComponent } from 'vue'
 
-defineProps<{
+const props = defineProps<{
   active?: boolean
   icon?: ConcreteComponent
   secondary?: boolean
   dot?: boolean
+  disabled?: boolean
 }>()
+
+const buttonClasses = computed(() => {
+  const baseClasses =
+    'relative transition rounded-md w-8 h-8 shrink-0 flex items-center justify-center outline-none'
+  const disabledClasses = props.disabled ? 'opacity-50' : ''
+
+  const stateClasses = props.active
+    ? 'bg-info-lighter text-primary-focus dark:text-foreground-on-primary'
+    : `bg-foundation ${props.secondary ? 'text-foreground-3' : 'text-foreground'} ${
+        !props.disabled
+          ? 'md:hover:bg-primary-muted md:focus-visible:border-foundation'
+          : ''
+      }`
+
+  return `${baseClasses} ${disabledClasses} ${stateClasses}`
+})
 </script>


### PR DESCRIPTION
When you try to use the bottom controls in the viewer, before the model has finished loading, it can cause strange bugs. 

Like when using section box, it will show the gizmo, but when the model loads, it will not apply the section box on the model. 