### PR TITLE
fix(fe): highlighting disable default click events

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/setup/highlighting.ts
+++ b/packages/frontend-2/lib/viewer/composables/setup/highlighting.ts
@@ -36,6 +36,10 @@ export class HighlightExtension extends SelectionExtension {
     }
     this.options = highlightMaterialData
   }
+
+  /** Disable default click events - highlighting is controlled through state only */
+  protected override onObjectClicked() {}
+  protected override onObjectDoubleClick() {}
 }
 
 /**


### PR DESCRIPTION
When I moved highlighting to frontend, I replicated the function in `LegacyViewer`.

I didn't think I needed to override `onObjectClicked` and `onObjectDoubleClicked` like LegacyViewer does, but this caused highlights to appear in measure mode. 