### PR TITLE
fix(viewer): raise MIN_CLICK_TIMING to improve single clicks

### DIFF
--- a/packages/viewer/src/modules/input/Input.ts
+++ b/packages/viewer/src/modules/input/Input.ts
@@ -26,7 +26,7 @@ export interface InputEventPayload {
 //TO DO: Define proper interface for InputEvent data
 export default class Input extends EventEmitter {
   private static readonly MAX_DOUBLE_CLICK_TIMING = 500
-  private static readonly MIN_CLICK_TIMING = 150
+  private static readonly MIN_CLICK_TIMING = 200
   private tapTimeout: number = 0
   private lastTap = 0
   private lastClick = 0


### PR DESCRIPTION
Single clicks are often not registered (especially using the mac trackpad click).

This is especially annoying in measure mode and when trying to launch the right click menu. 

@AlexandruPopovici said that this value was originally `250ms` but @didimitrie asked him to lower it to 150ms. 

@didimitrie Can you remember why? I think we've went too low, causing a lot of clicks to be missed. I tried `200ms` and it works a lot better, but I'm worried about reintroducing the bug you were trying to fix when requesting this change. 