### PR TITLE
fix(fe): remove speckle_type from FILTERS_POPULAR_PROPERTIES

### DIFF
--- a/packages/frontend-2/lib/viewer/helpers/filters/constants.ts
+++ b/packages/frontend-2/lib/viewer/helpers/filters/constants.ts
@@ -24,7 +24,6 @@ export const FILTER_CONDITION_CONFIG: Record<FilterCondition, { label: string }>
 
 // Popular Filter Properties
 export const FILTERS_POPULAR_PROPERTIES = [
-  'speckle_type',
   'name',
   'category',
   'family',


### PR DESCRIPTION
Bilal and Claire agree that we should remove `speckle_type` from the list of popular filter properties.

It is still available to filter on, but we don't want to push it