### PR TITLE
feat(fe): use isEqualTo when adding a single numeric filter

### DIFF
--- a/packages/frontend-2/components/viewer/selection/KeyValuePair.vue
+++ b/packages/frontend-2/components/viewer/selection/KeyValuePair.vue
@@ -78,6 +78,7 @@ import type { KeyValuePair } from '~/components/viewer/selection/types'
 import { isNumericPropertyInfo } from '~/lib/viewer/helpers/sceneExplorer'
 import {
   BooleanFilterCondition,
+  NumericFilterCondition,
   type ExtendedPropertyInfo
 } from '~/lib/viewer/helpers/filters/types'
 import { isBooleanProperty } from '~/lib/viewer/helpers/filters/utils'
@@ -158,10 +159,11 @@ const addFilterWithValue = (filter: ExtendedPropertyInfo, kvp: KeyValuePair) => 
   const filterId = addActiveFilter(filter)
 
   if (isNumericPropertyInfo(filter)) {
-    // For numeric filters, set the specific numeric value
+    // For numeric filters, set the specific numeric value with IsEqualTo condition
     const numericValue =
       typeof kvp.value === 'number' ? kvp.value : parseFloat(String(kvp.value))
     if (!isNaN(numericValue)) {
+      updateFilterCondition(filterId, NumericFilterCondition.IsEqualTo)
       setNumericRange(filterId, numericValue, numericValue)
     }
   } else if (isBooleanProperty(filter)) {


### PR DESCRIPTION
<img width="281" height="219" alt="image" src="https://github.com/user-attachments/assets/854c454c-cea2-495f-a5b0-92ca2d99a8f6" />

From selection info, if you try to "Add to filter" on a single number value, it will work, but it will use the DualInputRange with both handles set to the value:

<img width="293" height="253" alt="image" src="https://github.com/user-attachments/assets/acaad268-981c-4350-892a-b2b98f97841f" />

Now, it will load in the is equal too condition:

<img width="354" height="303" alt="image" src="https://github.com/user-attachments/assets/94414485-aa7c-4343-a29a-440d7da5e597" />


