### PR TITLE
feat(helm chart): allow rolling update to be configured

### DIFF
--- a/utils/helm/speckle-server/templates/objects/deployment.yml
+++ b/utils/helm/speckle-server/templates/objects/deployment.yml
@@ -14,6 +14,9 @@ spec:
       project: speckle-server
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.objects.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.objects.rollingUpdate.maxSurge }}
   template:
     metadata:
       labels:

--- a/utils/helm/speckle-server/templates/server/deployment.yml
+++ b/utils/helm/speckle-server/templates/server/deployment.yml
@@ -14,6 +14,9 @@ spec:
       project: speckle-server
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.server.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.server.rollingUpdate.maxSurge }}
   template:
     metadata:
       labels:

--- a/utils/helm/speckle-server/values.schema.json
+++ b/utils/helm/speckle-server/values.schema.json
@@ -917,6 +917,21 @@
           "description": "The Docker image to be used for the Speckle Server component. If blank, defaults to speckle/speckle-server:{{ .Values.docker_image_tag }}. If provided, this value should be the full path including tag. The docker_image_tag value will be ignored.",
           "default": ""
         },
+        "rollingUpdate": {
+          "type": "object",
+          "properties": {
+            "maxUnavailable": {
+              "type": "string",
+              "description": "The maximum number or percentage of pods that can be unavailable during the update process. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable",
+              "default": "25%"
+            },
+            "maxSurge": {
+              "type": "string",
+              "description": "The maximum number or percentage of pods that can be created above the desired number of pods during the update process. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-surge",
+              "default": "25%"
+            }
+          }
+        },
         "enableFe2Messaging": {
           "type": "boolean",
           "description": "If enabled, the related FE1 deployment will show banners/messages about the new frontend",
@@ -1729,6 +1744,21 @@
               "type": "string",
               "description": "The port on which the nodejs inspect feature should be exposed",
               "default": "7000"
+            }
+          }
+        },
+        "rollingUpdate": {
+          "type": "object",
+          "properties": {
+            "maxUnavailable": {
+              "type": "string",
+              "description": "The maximum number or percentage of pods that can be unavailable during the update process. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable",
+              "default": "25%"
+            },
+            "maxSurge": {
+              "type": "string",
+              "description": "The maximum number or percentage of pods that can be created above the desired number of pods during the update process. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-surge",
+              "default": "25%"
             }
           }
         },

--- a/utils/helm/speckle-server/values.yaml
+++ b/utils/helm/speckle-server/values.yaml
@@ -609,6 +609,13 @@ server:
   ##
   image: ''
 
+  rollingUpdate:
+    ## @param server.rollingUpdate.maxUnavailable The maximum number or percentage of pods that can be unavailable during the update process. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable
+    ##
+    maxUnavailable: 25%
+    ## @param server.rollingUpdate.maxSurge The maximum number or percentage of pods that can be created above the desired number of pods during the update process. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-surge
+    maxSurge: 25%
+
   ## @param server.enableFe2Messaging If enabled, the related FE1 deployment will show banners/messages about the new frontend
   ##
   enableFe2Messaging: false
@@ -1026,6 +1033,13 @@ objects:
     enabled: false
     ## @param objects.inspect.port The port on which the nodejs inspect feature should be exposed
     port: '7000'
+
+  rollingUpdate:
+    ## @param objects.rollingUpdate.maxUnavailable The maximum number or percentage of pods that can be unavailable during the update process. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-unavailable
+    ##
+    maxUnavailable: 25%
+    ## @param objects.rollingUpdate.maxSurge The maximum number or percentage of pods that can be created above the desired number of pods during the update process. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-surge
+    maxSurge: 25%
 
   requests:
     ## @param objects.requests.cpu The CPU that should be available on a node when scheduling this pod.


### PR DESCRIPTION
## Description & motivation

This PR allows configuration of the max surge and max unavailable during a rolling deployment of the server & objects pods.

25% is the existing default, so this should represent a no-op to existing deployments.

## Changes:

<!---

- Item 1
- Item 2

-->

## To-do before merge:

<!---

(Optional -- remove this section if not needed)

Include any notes about things that need to happen before this PR is merged, e.g.:

- [ ] Change the base branch

- [ ] Ensure PR #56 is merged

-->

## Screenshots:

<!---

Include a screenshot the before and after.  This can be a screenshot of a plugin, web frontend, or output in a terminal.

-->

## Validation of changes:

<!---

Describe what tests have been added or amended, and why these demonstrate it works and will prevent this feature being accidentally broken by future changes.

-->

## Checklist:

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` between the square brackets, e.g. [x], for all the items that apply,

make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.

-->

- [ ] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [ ] My commits are related to the pull request and do not amend unrelated code or documentation.
- [ ] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

<!---

(Optional -- remove this section if not needed )

Include **important** links regarding the implementation of this PR.

This usually includes a RFC or an aggregation of issues and/or individual conversations

that helped put this solution together. This helps ensure we retain and share knowledge

regarding the implementation, and may help others understand motivation and design decisions etc..

-->
