### PR TITLE
Fix: Pass embed token to preview

### DIFF
--- a/packages/frontend-2/components/viewer/embed/ManualLoad.vue
+++ b/packages/frontend-2/components/viewer/embed/ManualLoad.vue
@@ -19,11 +19,14 @@
 
 <script setup lang="ts">
 import { PlayIcon } from '@heroicons/vue/20/solid'
+import { useAuthManager } from '~/lib/auth/composables/auth'
 
 const route = useRoute()
 const {
   public: { apiOrigin }
 } = useRuntimeConfig()
+
+const { embedToken } = useAuthManager()
 
 const projectUrl = route.path
 
@@ -33,9 +36,15 @@ const modelId = route.params.modelId as string
 const previewUrl = computed(() => {
   if (modelId) {
     const url = new URL(`/preview/${projectId}/commits/${modelId}`, apiOrigin)
+    if (embedToken.value) {
+      url.searchParams.set('embedToken', embedToken.value)
+    }
     return url.toString()
   } else if (projectId) {
     const url = new URL(`/preview/${projectId}`, apiOrigin)
+    if (embedToken.value) {
+      url.searchParams.set('embedToken', embedToken.value)
+    }
     return url.toString()
   } else return null
 })

--- a/packages/server/modules/shared/middleware/index.ts
+++ b/packages/server/modules/shared/middleware/index.ts
@@ -76,6 +76,9 @@ export const getTokenFromRequest = (req: Request | null | undefined): string | n
   const fromCookie = (req?.cookies?.authn as Nullable<string>) || null
   if (fromCookie?.length) return removeBearerPrefix(fromCookie)
 
+  const fromQuery = (req?.query?.embedToken as Nullable<string>) || null
+  if (fromQuery?.length) return fromQuery
+
   return null
 }
 


### PR DESCRIPTION
Previews were not loading because the token wasn't passed through, so it would show the "this project is private" red cube instead of the actual preview image