### PR TITLE
feat: delete workspace if it does not have more users

### DIFF
--- a/packages/server/modules/core/domain/users/events.ts
+++ b/packages/server/modules/core/domain/users/events.ts
@@ -1,5 +1,6 @@
 import type { User, UserSignUpContext } from '@/modules/core/domain/users/types'
 import type { UserUpdateInput } from '@/modules/core/graph/generated/graphql'
+import type { WorkspaceSeat } from '@/modules/workspacesCore/domain/types'
 import type { Optional } from '@speckle/shared'
 
 export const userEventsNamespace = 'users' as const
@@ -22,6 +23,7 @@ export type UserEventsPayloads = {
   [UserEvents.Deleted]: {
     targetUserId: string
     invokerUserId: string
+    deletedSeats: WorkspaceSeat[]
   }
   [UserEvents.Updated]: {
     oldUser: User

--- a/packages/server/modules/core/graph/resolvers/users.ts
+++ b/packages/server/modules/core/graph/resolvers/users.ts
@@ -62,6 +62,11 @@ import {
 import { getAllRegisteredDbs } from '@/modules/multiregion/utils/dbSelector'
 import { deleteProjectFactory } from '@/modules/core/repositories/projects'
 import { deleteProjectCommitsFactory } from '@/modules/core/repositories/commits'
+import { getWorkspacePlanFactory } from '@/modules/gatekeeper/repositories/billing'
+import {
+  countWorkspaceUsersFactory,
+  getUserWorkspacesWithRoleFactory
+} from '@/modules/workspaces/repositories/workspaces'
 
 const getUser = legacyGetUserFactory({ db })
 const getUserByEmail = legacyGetUserByEmailFactory({ db })
@@ -349,7 +354,10 @@ export default {
 
               return res
             },
-            emitEvent: emit
+            emitEvent: emit,
+            getUserWorkspacesWithRole: getUserWorkspacesWithRoleFactory({ db: mainDb }),
+            countWorkspaceUsers: countWorkspaceUsersFactory({ db: mainDb }),
+            getWorkspacePlan: getWorkspacePlanFactory({ db: mainDb })
           })
 
           return deleteUser(user.id, context.userId)
@@ -408,7 +416,10 @@ export default {
 
               return res
             },
-            emitEvent: emit
+            emitEvent: emit,
+            getWorkspacePlan: getWorkspacePlanFactory({ db: mainDb }),
+            getUserWorkspacesWithRole: getUserWorkspacesWithRoleFactory({ db: mainDb }),
+            countWorkspaceUsers: countWorkspaceUsersFactory({ db: mainDb })
           })
 
           return deleteUser(user.id, context.userId)

--- a/packages/server/modules/core/tests/usersAdmin.spec.ts
+++ b/packages/server/modules/core/tests/usersAdmin.spec.ts
@@ -56,6 +56,11 @@ import { deleteProjectFactory } from '@/modules/core/repositories/projects'
 import type { DeleteUser } from '@/modules/core/domain/users/operations'
 import { asMultiregionalOperation, replicateFactory } from '@/modules/shared/command'
 import { getAllRegisteredTestDbs } from '@/modules/multiregion/tests/helpers'
+import {
+  countWorkspaceUsersFactory,
+  getUserWorkspacesWithRoleFactory
+} from '@/modules/workspaces/repositories/workspaces'
+import { getWorkspacePlanFactory } from '@/modules/gatekeeper/repositories/billing'
 
 const getUsers = legacyGetPaginatedUsersFactory({ db })
 const countUsers = legacyGetPaginatedUsersCountFactory({ db })
@@ -116,7 +121,10 @@ const deleteUser: DeleteUser = async (...input) =>
 
           return res
         },
-        emitEvent: emit
+        emitEvent: emit,
+        getWorkspacePlan: getWorkspacePlanFactory({ db: mainDb }),
+        getUserWorkspacesWithRole: getUserWorkspacesWithRoleFactory({ db: mainDb }),
+        countWorkspaceUsers: countWorkspaceUsersFactory({ db: mainDb })
       })
 
       return deleteUser(...input)

--- a/packages/server/modules/workspaces/domain/operations.ts
+++ b/packages/server/modules/workspaces/domain/operations.ts
@@ -393,6 +393,17 @@ export type CountWorkspaceRoleWithOptionalProjectRole = (args: {
   skipUserIds?: string[]
 }) => Promise<number>
 
+export type CountWorkspaceUsers = (args: {
+  workspaceId: string
+  filter?: Partial<{
+    workspaceRole: WorkspaceRoles
+  }>
+}) => Promise<number>
+
+export type GetUserWorkspacesWithRole = (args: {
+  userId: string
+}) => Promise<Array<Workspace & { role: WorkspaceRoles }>>
+
 export type GetWorkspaceSeatCount = (args: {
   workspaceId: string
   type?: WorkspaceSeatType

--- a/packages/server/modules/workspaces/repositories/workspaces.ts
+++ b/packages/server/modules/workspaces/repositories/workspaces.ts
@@ -44,9 +44,12 @@ import type {
   UpsertWorkspace,
   UpsertWorkspaceCreationState,
   UpsertWorkspaceRole,
-  BulkUpsertWorkspaces
+  BulkUpsertWorkspaces,
+  GetUserWorkspacesWithRole,
+  CountWorkspaceUsers
 } from '@/modules/workspaces/domain/operations'
 import type { Knex } from 'knex'
+import type { WorkspaceRoles } from '@speckle/shared'
 import { isNullOrUndefined, Roles } from '@speckle/shared'
 import type {
   ServerAclRecord,
@@ -923,6 +926,38 @@ export const getPaginatedWorkspaceProjectsFactory =
       ...items,
       totalCount
     }
+  }
+
+export const countWorkspaceUsersFactory =
+  ({ db }: { db: Knex }): CountWorkspaceUsers =>
+  async (args) => {
+    const query = tables
+      .workspaces(db)
+      .innerJoin(DbWorkspaceAcl.name, DbWorkspaceAcl.col.workspaceId, Workspaces.col.id)
+      .where(Workspaces.col.id, args.workspaceId)
+
+    if (args.filter?.workspaceRole) {
+      query.where(DbWorkspaceAcl.col.role, args.filter.workspaceRole)
+    }
+
+    const [res] = await query.count()
+    const count = parseInt(res.count.toString())
+    return count
+  }
+
+export const getUserWorkspacesWithRoleFactory =
+  ({ db }: { db: Knex }): GetUserWorkspacesWithRole =>
+  async (args) => {
+    const workspaces = tables
+      .workspacesAcl(db)
+      .innerJoin(Workspaces.name, Workspaces.col.id, DbWorkspaceAcl.col.workspaceId)
+      .where(DbWorkspaceAcl.col.userId, args.userId)
+      .select<Array<Workspace & { role: WorkspaceRoles }>>([
+        Workspaces.col,
+        DbWorkspaceAcl.col.role
+      ])
+
+    return await workspaces
   }
 
 export const getAllWorkspaceChecksumFactory =


### PR DESCRIPTION
Checking workspace statuses on delete.

Avoid user leaving workspaces without admins, or with a running subscription. 
In case you are the last member, workspace gets deleted when you delete your account.

<img width="393" height="164" alt="image" src="https://github.com/user-attachments/assets/87bd5f96-0d3b-4cb1-8c57-3a27c960fb3b" />
