### PR TITLE
feat(policies): allow god mode admins to create dashboards

### DIFF
--- a/packages/shared/src/authz/policies/dashboard/canDelete.ts
+++ b/packages/shared/src/authz/policies/dashboard/canDelete.ts
@@ -18,9 +18,12 @@ import { hasMinimumWorkspaceRole } from '../../checks/workspaceRole.js'
 import { Roles } from '../../../core/constants.js'
 import { hasEditorSeat } from '../../checks/workspaceSeat.js'
 import { isDashboardOwner } from '../../checks/dashboards.js'
+import { checkIfAdminOverrideEnabledFragment } from '../../fragments/server.js'
 
 type PolicyLoaderKeys =
   | typeof AuthCheckContextLoaderKeys.getEnv
+  | typeof AuthCheckContextLoaderKeys.getServerRole
+  | typeof AuthCheckContextLoaderKeys.getAdminOverrideEnabled
   | typeof AuthCheckContextLoaderKeys.getDashboard
   | typeof AuthCheckContextLoaderKeys.getWorkspacePlan
   | typeof AuthCheckContextLoaderKeys.getWorkspaceRole
@@ -56,6 +59,11 @@ export const canDeleteDashboardPolicy: AuthPolicy<
       loaders
     )({ workspaceId })
     if (ensuredFeatureAccess.isErr) return err(ensuredFeatureAccess.error)
+
+    const hasAdminAccess = await checkIfAdminOverrideEnabledFragment(loaders)({
+      userId
+    })
+    if (hasAdminAccess.isOk && hasAdminAccess.value) return ok()
 
     const isWorkspaceEditorSeat = await hasEditorSeat(loaders)({
       userId: userId!,

--- a/packages/shared/src/authz/policies/dashboard/canEdit.ts
+++ b/packages/shared/src/authz/policies/dashboard/canEdit.ts
@@ -16,9 +16,12 @@ import {
 import { hasMinimumWorkspaceRole } from '../../checks/workspaceRole.js'
 import { Roles } from '../../../core/constants.js'
 import { hasEditorSeat } from '../../checks/workspaceSeat.js'
+import { checkIfAdminOverrideEnabledFragment } from '../../fragments/server.js'
 
 type PolicyLoaderKeys =
   | typeof AuthCheckContextLoaderKeys.getEnv
+  | typeof AuthCheckContextLoaderKeys.getServerRole
+  | typeof AuthCheckContextLoaderKeys.getAdminOverrideEnabled
   | typeof AuthCheckContextLoaderKeys.getDashboard
   | typeof AuthCheckContextLoaderKeys.getWorkspacePlan
   | typeof AuthCheckContextLoaderKeys.getWorkspaceRole
@@ -53,6 +56,11 @@ export const canEditDashboardPolicy: AuthPolicy<
       loaders
     )({ workspaceId })
     if (ensuredFeatureAccess.isErr) return err(ensuredFeatureAccess.error)
+
+    const hasAdminAccess = await checkIfAdminOverrideEnabledFragment(loaders)({
+      userId
+    })
+    if (hasAdminAccess.isOk && hasAdminAccess.value) return ok()
 
     const isWorkspaceMember = await hasMinimumWorkspaceRole(loaders)({
       userId: userId!,

--- a/packages/shared/src/authz/policies/dashboard/canRead.ts
+++ b/packages/shared/src/authz/policies/dashboard/canRead.ts
@@ -17,11 +17,15 @@ import {
 } from '../../fragments/dashboards.js'
 import { hasMinimumWorkspaceRole } from '../../checks/workspaceRole.js'
 import { Roles } from '../../../core/constants.js'
-import { ensureMinimumServerRoleFragment } from '../../fragments/server.js'
+import {
+  checkIfAdminOverrideEnabledFragment,
+  ensureMinimumServerRoleFragment
+} from '../../fragments/server.js'
 
 type PolicyLoaderKeys =
   | typeof AuthCheckContextLoaderKeys.getEnv
   | typeof AuthCheckContextLoaderKeys.getServerRole
+  | typeof AuthCheckContextLoaderKeys.getAdminOverrideEnabled
   | typeof AuthCheckContextLoaderKeys.getDashboard
   | typeof AuthCheckContextLoaderKeys.getWorkspaceRole
   | typeof AuthCheckContextLoaderKeys.getWorkspacePlan
@@ -62,6 +66,11 @@ export const canReadDashboardPolicy: AuthPolicy<
       loaders
     )({ workspaceId })
     if (ensuredFeatureAccess.isErr) return err(ensuredFeatureAccess.error)
+
+    const hasAdminAccess = await checkIfAdminOverrideEnabledFragment(loaders)({
+      userId
+    })
+    if (hasAdminAccess.isOk && hasAdminAccess.value) return ok()
 
     const isWorkspaceMember = await hasMinimumWorkspaceRole(loaders)({
       userId: userId!,

--- a/packages/shared/src/authz/policies/workspace/canCreateDashboards.ts
+++ b/packages/shared/src/authz/policies/workspace/canCreateDashboards.ts
@@ -15,9 +15,12 @@ import {
 import { hasMinimumWorkspaceRole } from '../../checks/workspaceRole.js'
 import { Roles } from '../../../core/constants.js'
 import { hasEditorSeat } from '../../checks/workspaceSeat.js'
+import { checkIfAdminOverrideEnabledFragment } from '../../fragments/server.js'
 
 type PolicyLoaderKeys =
   | typeof AuthCheckContextLoaderKeys.getEnv
+  | typeof AuthCheckContextLoaderKeys.getServerRole
+  | typeof AuthCheckContextLoaderKeys.getAdminOverrideEnabled
   | typeof AuthCheckContextLoaderKeys.getWorkspacePlan
   | typeof AuthCheckContextLoaderKeys.getWorkspaceRole
   | typeof AuthCheckContextLoaderKeys.getWorkspaceSeat
@@ -45,6 +48,11 @@ export const canCreateDashboardsPolicy: AuthPolicy<
       loaders
     )({ workspaceId })
     if (ensuredFeatureAccess.isErr) return err(ensuredFeatureAccess.error)
+
+    const hasAdminAccess = await checkIfAdminOverrideEnabledFragment(loaders)({
+      userId
+    })
+    if (hasAdminAccess.isOk && hasAdminAccess.value) return ok()
 
     const isWorkspaceMember = await hasMinimumWorkspaceRole(loaders)({
       userId: userId!,


### PR DESCRIPTION
use the admin override for some dashboarding permissions as requested by @jsdbroughton 