### PR TITLE
Update loading screen copy

### DIFF
--- a/packages/frontend-2/components/presentation/Loading.vue
+++ b/packages/frontend-2/components/presentation/Loading.vue
@@ -32,7 +32,7 @@
           </svg>
         </div>
 
-        <div class="text-heading-sm mb-10">Fetching the 3D data…</div>
+        <div class="text-heading-sm mb-10">Loading presentation…</div>
 
         <div class="max-w-[220px] flex items-center gap-x-2">
           <WorkspaceAvatar :name="workspace?.name" :logo="workspace?.logo" size="lg" />


### PR DESCRIPTION
Fix: Update presentation loading screen copy

## Description & motivation

Resolves WEB-4374.

This PR updates the loading screen text for presentations from "Fetching the 3D data…" to "Loading presentation…". This change provides a more accurate and user-friendly message during the loading process of a presentation.

## Changes:

- Updated loading text in `packages/frontend-2/components/presentation/Loading.vue`.

## Screenshots:

A screenshot of the updated loading screen can be found in the Linear issue: WEB-4374.

## Validation of changes:

Visual inspection of the presentation loading screen confirms the text change.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

---
Linear Issue: [WEB-4374](https://linear.app/speckle/issue/WEB-4374/change-copy-on-loading-screen)

<a href="https://cursor.com/background-agent?bcId=bc-45a33a2c-e653-46ab-8474-372bf70cd0bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45a33a2c-e653-46ab-8474-372bf70cd0bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

