### PR TITLE
Add placeholder text to name input

### DIFF
--- a/packages/frontend-2/components/presentation/SlideEditDialog.vue
+++ b/packages/frontend-2/components/presentation/SlideEditDialog.vue
@@ -12,6 +12,7 @@
           v-model="name"
           name="name"
           label="Name"
+          placeholder="Add a name..."
           color="foundation"
           :rules="[isRequired]"
         />


### PR DESCRIPTION
## Feature: Add placeholder to slide name input

## Description & motivation

This PR addresses Linear issue [WEB-4379](https://linear.app/speckle/issue/WEB-4379).
It adds a placeholder text "Add a name…" to the name input field within the slide edit dialog. This provides a clearer visual cue to users when the input is empty, improving usability.

Fixes WEB-4379

## Changes:

- Added `placeholder="Add a name..."` attribute to the `FormTextInput` component for the slide name in `SlideEditDialog.vue`.

## Screenshots:

**Before:**
The name input field was empty with no guiding text.

**After:**
The name input field now displays "Add a name…" when empty.
(Refer to the screenshot in the linked Linear issue for visual context.)

## Validation of changes:

Manually verified that the placeholder text "Add a name..." appears in the slide name input field when it is empty in the slide edit dialog.

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [ ] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

---
Linear Issue: [WEB-4379](https://linear.app/speckle/issue/WEB-4379/add-placeholder-text-to-name-input)

<a href="https://cursor.com/background-agent?bcId=bc-0e735c55-87fc-472c-bc56-66dd8849c969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e735c55-87fc-472c-bc56-66dd8849c969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

