### PR TITLE
fix(fe): prevent duplicate object selection

### DIFF
--- a/packages/frontend-2/lib/viewer/composables/ui.ts
+++ b/packages/frontend-2/lib/viewer/composables/ui.ts
@@ -262,7 +262,13 @@ export function useSelectionUtilities() {
   const addToSelectionFromObjectIds = (objectIds: string[]) => {
     const originalObjects = selectedObjects.value.slice()
     setSelectionFromObjectIds(objectIds)
-    selectedObjects.value = [...originalObjects, ...selectedObjects.value]
+
+    // Filter out duplicates by checking if objects with the same ID already exist
+    const newObjects = selectedObjects.value.filter(
+      (newObj) => !originalObjects.some((existingObj) => existingObj.id === newObj.id)
+    )
+
+    selectedObjects.value = [...originalObjects, ...newObjects]
   }
 
   const removeFromSelectionObjectIds = (objectIds: string[]) => {


### PR DESCRIPTION
Originally reported by Claire in discord:
https://discord.com/channels/726756379083145269/1422565693215473811

Noticed this behavior - when you have federated models, and click on one of the models, it is added again on every click to the selection panel
