### PR TITLE
Fix: Decrease permission required for limitedWorkspace on projects

### DIFF
--- a/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
+++ b/packages/server/modules/workspaces/graph/resolvers/workspaces.ts
@@ -2107,8 +2107,8 @@ export default FF_WORKSPACES_MODULE_ENABLED
 
           await authorizeResolver(
             context.userId,
-            parent.workspaceId,
-            Roles.Workspace.Guest,
+            parent.id,
+            Roles.Stream.Reviewer,
             context.resourceAccessRules
           )
 


### PR DESCRIPTION
Not sure if this is the right fix, please point me in the right direction 😄  Basically the limitedWorkspace should always be returned if the project is public