### PR TITLE
fix(acc): add model button on different size and learn more

### DIFF
--- a/packages/frontend-2/components/integrations/acc/Card.vue
+++ b/packages/frontend-2/components/integrations/acc/Card.vue
@@ -41,7 +41,7 @@
         </div>
       </div>
       <div v-else>
-        <FormButton size="sm" @click="$emit('upgrade')">Upgrade</FormButton>
+        <FormButton size="sm" @click="openLearnMore">Learn more</FormButton>
       </div>
     </div>
   </div>
@@ -78,6 +78,10 @@ const statusText = () => {
     default:
       break
   }
+}
+
+const openLearnMore = () => {
+  window.open('https://docs.speckle.systems/beta/acc/overview', '_blank')
 }
 
 const handleCTA = async () => {

--- a/packages/frontend-2/components/project/page/models/Header.vue
+++ b/packages/frontend-2/components/project/page/models/Header.vue
@@ -19,24 +19,30 @@
             v-tippy="canCreateModel.cantClickCreateReason.value"
             class="grow inline-flex sm:grow-0 lg:hidden"
           >
-            <FormButton
-              :disabled="!canCreateModel.canClickCreate.value"
-              @click="handleCreateModelClick"
+            <LayoutMenu
+              v-if="showAccIntegration"
+              v-model:open="showMenu"
+              :items="menuItems"
+              :menu-position="HorizontalDirection.Left"
+              :menu-id="menuId"
+              @click.stop.prevent
+              @chosen="onActionChosen"
             >
-              New model
-            </FormButton>
-          </div>
-          <!-- I believe for now sync limits corralate with model limit since new sync creates new model, once we have limits for syncs, this should change -->
-          <div
-            v-tippy="canCreateModel.cantClickCreateReason.value"
-            class="grow inline-flex sm:grow-0 lg:hidden"
-          >
-            <FormButton
-              :disabled="!canCreateModel.canClickCreate.value"
-              @click="showNewAccSync = true"
-            >
-              New sync
-            </FormButton>
+              <FormButton color="primary" @click="showMenu = !showMenu">
+                <div class="flex items-center gap-1">
+                  Add model
+                  <ChevronDownIcon class="h-3 w-3" />
+                </div>
+              </FormButton>
+            </LayoutMenu>
+            <div v-else v-tippy="canCreateModel.cantClickCreateReason.value">
+              <FormButton
+                :disabled="!canCreateModel.canClickCreate.value"
+                @click="handleCreateModelClick"
+              >
+                New model
+              </FormButton>
+            </div>
           </div>
         </div>
       </div>
@@ -90,30 +96,31 @@
           >
             View all in 3D
           </FormButton>
-          <LayoutMenu
-            v-if="showAccIntegration"
-            v-model:open="showMenu"
-            :items="menuItems"
-            :menu-position="HorizontalDirection.Left"
-            :menu-id="menuId"
-            @click.stop.prevent
-            @chosen="onActionChosen"
-          >
-            <FormButton color="primary" @click="showMenu = !showMenu">
-              <div class="flex items-center gap-1">
-                Add model
-                <ChevronDownIcon class="h-3 w-3" />
-              </div>
-            </FormButton>
-          </LayoutMenu>
-          <div v-else v-tippy="canCreateModel.cantClickCreateReason.value">
-            <FormButton
-              :disabled="!canCreateModel.canClickCreate.value"
-              class="hidden lg:inline-flex shrink-0"
-              @click="handleCreateModelClick"
+          <div class="hidden lg:inline-flex shrink-0">
+            <LayoutMenu
+              v-if="showAccIntegration"
+              v-model:open="showMenu"
+              :items="menuItems"
+              :menu-position="HorizontalDirection.Left"
+              :menu-id="menuId"
+              @click.stop.prevent
+              @chosen="onActionChosen"
             >
-              New model
-            </FormButton>
+              <FormButton color="primary" @click="showMenu = !showMenu">
+                <div class="flex items-center gap-1">
+                  Add model
+                  <ChevronDownIcon class="h-3 w-3" />
+                </div>
+              </FormButton>
+            </LayoutMenu>
+            <div v-else v-tippy="canCreateModel.cantClickCreateReason.value">
+              <FormButton
+                :disabled="!canCreateModel.canClickCreate.value"
+                @click="handleCreateModelClick"
+              >
+                New model
+              </FormButton>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 1. Instead saying `Upgrade`, we just navigating the docs with `Learn more` button

<img width="805" height="239" alt="Screenshot 2025-10-06 at 16 09 19" src="https://github.com/user-attachments/assets/be5f8690-afb7-4dd4-8f66-3fe6a06c7498" />

## 2. Remove `New model` and `New sync` on mobile sizes.

### ACC enabled scenario 
<img width="1293" height="556" alt="Screenshot 2025-10-06 at 16 10 03" src="https://github.com/user-attachments/assets/1fede701-b397-4fe6-8a6a-692120e01345" />

<img width="751" height="493" alt="Screenshot 2025-10-06 at 16 10 13" src="https://github.com/user-attachments/assets/2b6a3c70-5226-49ae-9781-1575af0f2f4c" />

### ACC disabled scenario 
<img width="1335" height="630" alt="Screenshot 2025-10-06 at 16 11 08" src="https://github.com/user-attachments/assets/1a1c0371-9314-41fc-a3b9-66916dd27ec1" />

<img width="800" height="535" alt="Screenshot 2025-10-06 at 16 11 25" src="https://github.com/user-attachments/assets/27497a71-682b-4b58-b55b-bc6efb1a5c86" />
