### PR TITLE
Show measure feature on all breakpoints

### DIFF
--- a/packages/frontend-2/components/viewer/controls/Bottom.vue
+++ b/packages/frontend-2/components/viewer/controls/Bottom.vue
@@ -121,7 +121,8 @@ const panels = shallowRef({
     tooltip: getShortcutDisplayText(shortcuts.ToggleMeasurements, {
       format: 'separate'
     }),
-    extraClasses: 'hidden md:flex'
+    // Show on all breakpoints
+    extraClasses: ''
   },
   [ActivePanel.sectionBox]: {
     id: ActivePanel.sectionBox,

--- a/packages/frontend-2/components/viewer/controls/Bottom.vue
+++ b/packages/frontend-2/components/viewer/controls/Bottom.vue
@@ -121,7 +121,6 @@ const panels = shallowRef({
     tooltip: getShortcutDisplayText(shortcuts.ToggleMeasurements, {
       format: 'separate'
     }),
-    // Show on all breakpoints
     extraClasses: ''
   },
   [ActivePanel.sectionBox]: {


### PR DESCRIPTION
Show the measure feature on all breakpoints by removing the `hidden md:flex` class from the measure button.

---
Linear Issue: [WEB-4417](https://linear.app/speckle/issue/WEB-4417/show-the-measure-feature-on-mobile)

<a href="https://cursor.com/background-agent?bcId=bc-0fcf67f2-fdc4-4fec-9a19-679162009c22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0fcf67f2-fdc4-4fec-9a19-679162009c22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

