### PR TITLE
fix(apps): paginate api token init updates

### DIFF
--- a/packages/server/modules/auth/migrations/20251008063206_add_index_to_api_tokens.ts
+++ b/packages/server/modules/auth/migrations/20251008063206_add_index_to_api_tokens.ts
@@ -1,0 +1,23 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('api_tokens', (table) => {
+    table.index(['owner'])
+  })
+
+  await knex.schema.alterTable('personal_api_tokens', (table) => {
+    table.index(['tokenId'])
+    table.index(['userId'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('api_tokens', (table) => {
+    table.dropIndex(['owner'])
+  })
+
+  await knex.schema.alterTable('personal_api_tokens', (table) => {
+    table.dropIndex(['tokenId'])
+    table.dropIndex(['userId'])
+  })
+}

--- a/packages/server/modules/auth/services/serverApps.ts
+++ b/packages/server/modules/auth/services/serverApps.ts
@@ -39,31 +39,29 @@ export const initializeDefaultAppsFactory =
   }): InitializeDefaultApps =>
   async () => {
     allScopes = await deps.getAllScopes()
+    const defaultApps = getDefaultApps()
+    for (const app of defaultApps) {
+      const scopes =
+        app?.scopes === 'all'
+          ? allScopes.map((s) => s.name)
+          : (app.scopes as ServerScope[])
 
-    await Promise.all(
-      getDefaultApps().map(async (app) => {
-        const scopes =
-          app?.scopes === 'all'
-            ? allScopes.map((s) => s.name)
-            : (app.scopes as ServerScope[])
-
-        const existingApp = await deps.getApp({ id: app.id })
-        if (existingApp) {
-          await deps.updateDefaultApp(
-            {
-              ...app,
-              scopes
-            },
-            existingApp
-          )
-        } else {
-          await deps.registerDefaultApp({
+      const existingApp = await deps.getApp({ id: app.id })
+      if (existingApp) {
+        await deps.updateDefaultApp(
+          {
             ...app,
             scopes
-          })
-        }
-      })
-    )
+          },
+          existingApp
+        )
+      } else {
+        await deps.registerDefaultApp({
+          ...app,
+          scopes
+        })
+      }
+    }
   }
 
 export const createAppTokenFromAccessCodeFactory =


### PR DESCRIPTION
On new scope, (or removals)
tokens get updated in batches, avoiding memory issues.

This mr introduces:
- Batching logic for insert, and delete. Only one network operation every 5k tokens.
- Fix for transaction that was not getting applied
- Added indexes that help the delete queries _(and other queries in the app)_