### PR TITLE
Fix host app capitalization in viewer

### DIFF
--- a/packages/frontend-2/components/viewer/models/Card.vue
+++ b/packages/frontend-2/components/viewer/models/Card.vue
@@ -48,7 +48,7 @@
               class="shrink-0 flex items-center gap-1"
             >
               <span>
-                {{ loadedVersion.sourceApplication }}
+                {{ formatSourceApplication(loadedVersion.sourceApplication) }}
               </span>
               <span class="shrink-0">·</span>
             </div>
@@ -214,6 +214,11 @@ const versions = computed(() => [
 const loadedVersion = computed(() =>
   versions.value.find((v) => v.id === props.versionId)
 )
+
+function formatSourceApplication(app?: string | null) {
+  if (!app) return ''
+  return app.charAt(0).toUpperCase() + app.slice(1)
+}
 
 const createdAt = computed(() => loadedVersion.value?.createdAt)
 const createdAtFormatted = computed(() => {

--- a/packages/frontend-2/components/viewer/models/versions/ActiveCard.vue
+++ b/packages/frontend-2/components/viewer/models/versions/ActiveCard.vue
@@ -6,7 +6,7 @@
     />
     <div class="flex flex-col overflow-hidden text-xs select-none">
       <div class="inline-block rounded-full font-medium truncate">
-        {{ version.sourceApplication }}
+        {{ formatSourceApplication(version.sourceApplication) }}
       </div>
       <div class="truncate text-foreground opacity-80">
         {{ version.message || 'no message' }}
@@ -41,4 +41,9 @@ const createdAt = computed(() => {
     relative: formattedRelativeDate(props.version.createdAt, { capitalize: true })
   }
 })
+
+function formatSourceApplication(app?: string | null) {
+  if (!app) return ''
+  return app.charAt(0).toUpperCase() + app.slice(1)
+}
 </script>


### PR DESCRIPTION
Fix: Capitalize host app names in viewer model cards

## Description & motivation

Resolves WEB-4433.
This PR addresses an inconsistency in the web viewer's Models panel where host application names (e.g., 'revit', 'rhino') were displayed in lowercase. The change ensures that the first letter of these names is capitalized, improving UI consistency.

## Changes:

- `packages/frontend-2/components/viewer/models/Card.vue`: Introduced a `formatSourceApplication` helper function and applied it to the `loadedVersion.sourceApplication` display.
- `packages/frontend-2/components/viewer/models/versions/ActiveCard.vue`: Introduced an identical `formatSourceApplication` helper function and applied it to the `version.sourceApplication` display.

## Screenshots:

Before (as seen in WEB-4433): Host app names like 'revit' and 'rhino' are lowercase.
After: Host app names will appear as 'Revit' and 'Rhino'.

## Validation of changes:

Manually verified in the web viewer that host application names in the Models panel are now correctly capitalized (e.g., 'revit' displays as 'Revit').

## Checklist:

- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [ ] I have added appropriate tests.
- [ ] I have updated or added relevant documentation.

## References

Connects WEB-4433

---
Linear Issue: [WEB-4433](https://linear.app/speckle/issue/WEB-4433/capitalize-first-letter-of-host-app-in-viewer)

<a href="https://cursor.com/background-agent?bcId=bc-89647fca-35de-446b-83c5-5e7ffa7b8a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-89647fca-35de-446b-83c5-5e7ffa7b8a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

