### PR TITLE
feat(multiregion): sync region on creation

### DIFF
--- a/packages/server/modules/multiregion/domain/operations.ts
+++ b/packages/server/modules/multiregion/domain/operations.ts
@@ -9,6 +9,7 @@ import type { InsertableRegionRecord } from '@/modules/multiregion/helpers/types
 import type { Optional } from '@speckle/shared'
 import type { ObjectStorage } from '@/modules/blobstorage/clients/objectStorage'
 import type { Stream } from '@/modules/core/domain/streams/types'
+import type { MultiregionJob } from '@/modules/multiregion/services/queue'
 
 export type GetRegions = () => Promise<ServerRegion[]>
 export type GetRegion = (params: { key: string }) => Promise<Optional<ServerRegion>>
@@ -69,3 +70,5 @@ export type GetProjectObjectStorage = (args: {
 export type GetRegionObjectStorage = (args: {
   regionKey: string
 }) => Promise<{ private: ObjectStorage; public: ObjectStorage }>
+
+export type ScheduleMultiregionJob = (args: MultiregionJob) => Promise<string>

--- a/packages/server/modules/multiregion/graph/resolvers/index.ts
+++ b/packages/server/modules/multiregion/graph/resolvers/index.ts
@@ -19,6 +19,7 @@ import {
 } from '@/modules/multiregion/services/management'
 import { initializeRegion as initializeBlobStorage } from '@/modules/multiregion/utils/blobStorageSelector'
 import { withOperationLogging } from '@/observability/domain/businessLogging'
+import { scheduleJob } from '@/modules/multiregion/services/queue'
 
 export default {
   ServerMultiRegionConfiguration: {
@@ -53,7 +54,8 @@ export default {
         initializeRegion: initializeRegionClients({
           initializeDb,
           initializeBlobStorage
-        })
+        }),
+        scheduleJob
       })
       return await withOperationLogging(
         async () => await createAndValidateNewRegion({ region: args.input }),

--- a/packages/server/test/hooks.ts
+++ b/packages/server/test/hooks.ts
@@ -121,7 +121,9 @@ const setupDatabases = async () => {
     }),
     getRegion: getRegionFactory({ db }),
     storeRegion: storeRegionFactory({ db }),
-    initializeRegion
+    initializeRegion,
+    // As db starts from scratch, no need to sync regions
+    scheduleJob: () => Promise.resolve('')
   })
   for (const regionKey of regionKeys) {
     await createRegion({


### PR DESCRIPTION
On adding a new region into the server, a job gets pushed that fills it with users and workspaces so we can operate on it.