### PR TITLE
fix null object check in queryHits

### DIFF
--- a/packages/viewer/src/modules/SpeckleRenderer.ts
+++ b/packages/viewer/src/modules/SpeckleRenderer.ts
@@ -1081,9 +1081,9 @@ export default class SpeckleRenderer {
       )
       if (
         rvMaterial[0] && // If the rv exists
-        this.objectPickConfiguration.pickedObjectsFilter // If there is a pick filter
+        (this.objectPickConfiguration.pickedObjectsFilter // If there is a pick filter
           ? this.objectPickConfiguration.pickedObjectsFilter(rvMaterial) // If the pick filter passes
-          : true
+          : true)
       ) {
         rvs.push(rvMaterial[0])
         points.push(results[k].point)


### PR DESCRIPTION
### Problem
In Speckle Renderer, queryHits sometimes pushes null objects to rvs when rvMaterial[0] is null due to operator precedence in the ternary expression.

### Solution
Added explicit parentheses around the ternary to ensure rvMaterial[0] is checked before evaluating the filter. This prevents null objects from being added.